### PR TITLE
chore: repo rename from asyncapi-node to spec-json-schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![](https://travis-ci.org/asyncapi/asyncapi-node.svg?branch=master)
+![npm](https://img.shields.io/npm/v/@asyncapi/specs?style=for-the-badge) ![npm](https://img.shields.io/npm/dt/@asyncapi/specs?style=for-the-badge)
 
 # AsyncAPI
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/asyncapi/asyncapi-node.git"
+    "url": "git+https://github.com/asyncapi/spec-json-schemas.git"
   },
   "author": {
     "name": "Fran Mendez",
@@ -31,9 +31,9 @@
   ],
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/asyncapi/asyncapi-node/issues"
+    "url": "https://github.com/asyncapi/spec-json-schemas/issues"
   },
-  "homepage": "https://github.com/asyncapi/asyncapi-node#readme",
+  "homepage": "https://github.com/asyncapi/spec-json-schemas#readme",
   "devDependencies": {
     "mocha": "^8.2.1",
     "nyc": "^15.1.0",


### PR DESCRIPTION
fixes https://github.com/asyncapi/spec-json-schemas/issues/45