### PR TITLE
chore: configure prerelease for new release

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "branches": [
       "master",
       {
-        "name": "2021-06-release",
+        "name": "2021-09-release",
         "prerelease": true
       }
     ],


### PR DESCRIPTION
unfortunately, wildcards are still not supported and we need to always configure it for release, I just forgot about it