### PR TITLE
fix: force object type for message trait's headers

### DIFF
--- a/schemas/2.2.0.json
+++ b/schemas/2.2.0.json
@@ -891,12 +891,16 @@
           "type": "string"
         },
         "headers": {
-          "oneOf": [
-            {
-              "$ref": "#/definitions/Reference"
-            },
+          "allOf": [
             {
               "$ref": "#/definitions/schema"
+            },
+            {
+              "properties": {
+                "type": {
+                  "const": "object"
+                }
+              }
             }
           ]
         },


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Force object type for message trait's headers in `2.2.0` version.

**Related issue(s)**
Fixes https://github.com/asyncapi/spec-json-schemas/issues/82