### PR TITLE
fix: revert use HTTPS on $schema urls to avoid mixed content

### DIFF
--- a/schemas/1.0.0.json
+++ b/schemas/1.0.0.json
@@ -1,7 +1,7 @@
 {
   "title": "AsyncAPI 1.0 schema.",
   "id": "http://asyncapi.hitchhq.com/v1/schema.json#",
-  "$schema": "https://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "required": [
     "asyncapi",
@@ -306,58 +306,58 @@
           "type": "string"
         },
         "title": {
-          "$ref": "https://json-schema.org/draft-04/schema#/properties/title"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/title"
         },
         "description": {
-          "$ref": "https://json-schema.org/draft-04/schema#/properties/description"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/description"
         },
         "default": {
-          "$ref": "https://json-schema.org/draft-04/schema#/properties/default"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/default"
         },
         "multipleOf": {
-          "$ref": "https://json-schema.org/draft-04/schema#/properties/multipleOf"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/multipleOf"
         },
         "maximum": {
-          "$ref": "https://json-schema.org/draft-04/schema#/properties/maximum"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/maximum"
         },
         "exclusiveMaximum": {
-          "$ref": "https://json-schema.org/draft-04/schema#/properties/exclusiveMaximum"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/exclusiveMaximum"
         },
         "minimum": {
-          "$ref": "https://json-schema.org/draft-04/schema#/properties/minimum"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/minimum"
         },
         "exclusiveMinimum": {
-          "$ref": "https://json-schema.org/draft-04/schema#/properties/exclusiveMinimum"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/exclusiveMinimum"
         },
         "maxLength": {
-          "$ref": "https://json-schema.org/draft-04/schema#/definitions/positiveInteger"
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
         },
         "minLength": {
-          "$ref": "https://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
         },
         "pattern": {
-          "$ref": "https://json-schema.org/draft-04/schema#/properties/pattern"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/pattern"
         },
         "maxItems": {
-          "$ref": "https://json-schema.org/draft-04/schema#/definitions/positiveInteger"
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
         },
         "minItems": {
-          "$ref": "https://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
         },
         "uniqueItems": {
-          "$ref": "https://json-schema.org/draft-04/schema#/properties/uniqueItems"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/uniqueItems"
         },
         "maxProperties": {
-          "$ref": "https://json-schema.org/draft-04/schema#/definitions/positiveInteger"
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
         },
         "minProperties": {
-          "$ref": "https://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
         },
         "required": {
-          "$ref": "https://json-schema.org/draft-04/schema#/definitions/stringArray"
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/stringArray"
         },
         "enum": {
-          "$ref": "https://json-schema.org/draft-04/schema#/properties/enum"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/enum"
         },
         "additionalProperties": {
           "anyOf": [
@@ -371,7 +371,7 @@
           "default": {}
         },
         "type": {
-          "$ref": "https://json-schema.org/draft-04/schema#/properties/type"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/type"
         },
         "items": {
           "anyOf": [
@@ -801,49 +801,49 @@
       }
     },
     "title": {
-      "$ref": "https://json-schema.org/draft-04/schema#/properties/title"
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/title"
     },
     "description": {
-      "$ref": "https://json-schema.org/draft-04/schema#/properties/description"
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/description"
     },
     "default": {
-      "$ref": "https://json-schema.org/draft-04/schema#/properties/default"
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/default"
     },
     "multipleOf": {
-      "$ref": "https://json-schema.org/draft-04/schema#/properties/multipleOf"
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/multipleOf"
     },
     "maximum": {
-      "$ref": "https://json-schema.org/draft-04/schema#/properties/maximum"
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/maximum"
     },
     "exclusiveMaximum": {
-      "$ref": "https://json-schema.org/draft-04/schema#/properties/exclusiveMaximum"
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/exclusiveMaximum"
     },
     "minimum": {
-      "$ref": "https://json-schema.org/draft-04/schema#/properties/minimum"
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/minimum"
     },
     "exclusiveMinimum": {
-      "$ref": "https://json-schema.org/draft-04/schema#/properties/exclusiveMinimum"
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/exclusiveMinimum"
     },
     "maxLength": {
-      "$ref": "https://json-schema.org/draft-04/schema#/definitions/positiveInteger"
+      "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
     },
     "minLength": {
-      "$ref": "https://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
+      "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
     },
     "pattern": {
-      "$ref": "https://json-schema.org/draft-04/schema#/properties/pattern"
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/pattern"
     },
     "maxItems": {
-      "$ref": "https://json-schema.org/draft-04/schema#/definitions/positiveInteger"
+      "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
     },
     "minItems": {
-      "$ref": "https://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
+      "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
     },
     "uniqueItems": {
-      "$ref": "https://json-schema.org/draft-04/schema#/properties/uniqueItems"
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/uniqueItems"
     },
     "enum": {
-      "$ref": "https://json-schema.org/draft-04/schema#/properties/enum"
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/enum"
     }
   }
 }

--- a/schemas/1.1.0.json
+++ b/schemas/1.1.0.json
@@ -1,7 +1,7 @@
 {
   "title": "AsyncAPI 1.1.0 schema.",
   "id": "http://asyncapi.hitchhq.com/v1/schema.json#",
-  "$schema": "https://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "required": [
     "asyncapi",
@@ -308,58 +308,58 @@
           "type": "string"
         },
         "title": {
-          "$ref": "https://json-schema.org/draft-04/schema#/properties/title"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/title"
         },
         "description": {
-          "$ref": "https://json-schema.org/draft-04/schema#/properties/description"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/description"
         },
         "default": {
-          "$ref": "https://json-schema.org/draft-04/schema#/properties/default"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/default"
         },
         "multipleOf": {
-          "$ref": "https://json-schema.org/draft-04/schema#/properties/multipleOf"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/multipleOf"
         },
         "maximum": {
-          "$ref": "https://json-schema.org/draft-04/schema#/properties/maximum"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/maximum"
         },
         "exclusiveMaximum": {
-          "$ref": "https://json-schema.org/draft-04/schema#/properties/exclusiveMaximum"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/exclusiveMaximum"
         },
         "minimum": {
-          "$ref": "https://json-schema.org/draft-04/schema#/properties/minimum"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/minimum"
         },
         "exclusiveMinimum": {
-          "$ref": "https://json-schema.org/draft-04/schema#/properties/exclusiveMinimum"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/exclusiveMinimum"
         },
         "maxLength": {
-          "$ref": "https://json-schema.org/draft-04/schema#/definitions/positiveInteger"
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
         },
         "minLength": {
-          "$ref": "https://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
         },
         "pattern": {
-          "$ref": "https://json-schema.org/draft-04/schema#/properties/pattern"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/pattern"
         },
         "maxItems": {
-          "$ref": "https://json-schema.org/draft-04/schema#/definitions/positiveInteger"
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
         },
         "minItems": {
-          "$ref": "https://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
         },
         "uniqueItems": {
-          "$ref": "https://json-schema.org/draft-04/schema#/properties/uniqueItems"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/uniqueItems"
         },
         "maxProperties": {
-          "$ref": "https://json-schema.org/draft-04/schema#/definitions/positiveInteger"
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
         },
         "minProperties": {
-          "$ref": "https://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
         },
         "required": {
-          "$ref": "https://json-schema.org/draft-04/schema#/definitions/stringArray"
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/stringArray"
         },
         "enum": {
-          "$ref": "https://json-schema.org/draft-04/schema#/properties/enum"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/enum"
         },
         "additionalProperties": {
           "anyOf": [
@@ -373,7 +373,7 @@
           "default": {}
         },
         "type": {
-          "$ref": "https://json-schema.org/draft-04/schema#/properties/type"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/type"
         },
         "items": {
           "anyOf": [
@@ -873,49 +873,49 @@
       }
     },
     "title": {
-      "$ref": "https://json-schema.org/draft-04/schema#/properties/title"
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/title"
     },
     "description": {
-      "$ref": "https://json-schema.org/draft-04/schema#/properties/description"
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/description"
     },
     "default": {
-      "$ref": "https://json-schema.org/draft-04/schema#/properties/default"
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/default"
     },
     "multipleOf": {
-      "$ref": "https://json-schema.org/draft-04/schema#/properties/multipleOf"
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/multipleOf"
     },
     "maximum": {
-      "$ref": "https://json-schema.org/draft-04/schema#/properties/maximum"
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/maximum"
     },
     "exclusiveMaximum": {
-      "$ref": "https://json-schema.org/draft-04/schema#/properties/exclusiveMaximum"
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/exclusiveMaximum"
     },
     "minimum": {
-      "$ref": "https://json-schema.org/draft-04/schema#/properties/minimum"
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/minimum"
     },
     "exclusiveMinimum": {
-      "$ref": "https://json-schema.org/draft-04/schema#/properties/exclusiveMinimum"
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/exclusiveMinimum"
     },
     "maxLength": {
-      "$ref": "https://json-schema.org/draft-04/schema#/definitions/positiveInteger"
+      "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
     },
     "minLength": {
-      "$ref": "https://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
+      "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
     },
     "pattern": {
-      "$ref": "https://json-schema.org/draft-04/schema#/properties/pattern"
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/pattern"
     },
     "maxItems": {
-      "$ref": "https://json-schema.org/draft-04/schema#/definitions/positiveInteger"
+      "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
     },
     "minItems": {
-      "$ref": "https://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
+      "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
     },
     "uniqueItems": {
-      "$ref": "https://json-schema.org/draft-04/schema#/properties/uniqueItems"
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/uniqueItems"
     },
     "enum": {
-      "$ref": "https://json-schema.org/draft-04/schema#/properties/enum"
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/enum"
     }
   }
 }

--- a/schemas/1.2.0.json
+++ b/schemas/1.2.0.json
@@ -1,7 +1,7 @@
 {
   "title": "AsyncAPI 1.2.0 schema.",
   "id": "http://asyncapi.hitchhq.com/v1/schema.json#",
-  "$schema": "https://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "required": [
     "asyncapi",
@@ -345,58 +345,58 @@
           "type": "string"
         },
         "title": {
-          "$ref": "https://json-schema.org/draft-04/schema#/properties/title"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/title"
         },
         "description": {
-          "$ref": "https://json-schema.org/draft-04/schema#/properties/description"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/description"
         },
         "default": {
-          "$ref": "https://json-schema.org/draft-04/schema#/properties/default"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/default"
         },
         "multipleOf": {
-          "$ref": "https://json-schema.org/draft-04/schema#/properties/multipleOf"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/multipleOf"
         },
         "maximum": {
-          "$ref": "https://json-schema.org/draft-04/schema#/properties/maximum"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/maximum"
         },
         "exclusiveMaximum": {
-          "$ref": "https://json-schema.org/draft-04/schema#/properties/exclusiveMaximum"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/exclusiveMaximum"
         },
         "minimum": {
-          "$ref": "https://json-schema.org/draft-04/schema#/properties/minimum"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/minimum"
         },
         "exclusiveMinimum": {
-          "$ref": "https://json-schema.org/draft-04/schema#/properties/exclusiveMinimum"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/exclusiveMinimum"
         },
         "maxLength": {
-          "$ref": "https://json-schema.org/draft-04/schema#/definitions/positiveInteger"
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
         },
         "minLength": {
-          "$ref": "https://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
         },
         "pattern": {
-          "$ref": "https://json-schema.org/draft-04/schema#/properties/pattern"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/pattern"
         },
         "maxItems": {
-          "$ref": "https://json-schema.org/draft-04/schema#/definitions/positiveInteger"
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
         },
         "minItems": {
-          "$ref": "https://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
         },
         "uniqueItems": {
-          "$ref": "https://json-schema.org/draft-04/schema#/properties/uniqueItems"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/uniqueItems"
         },
         "maxProperties": {
-          "$ref": "https://json-schema.org/draft-04/schema#/definitions/positiveInteger"
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
         },
         "minProperties": {
-          "$ref": "https://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
         },
         "required": {
-          "$ref": "https://json-schema.org/draft-04/schema#/definitions/stringArray"
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/stringArray"
         },
         "enum": {
-          "$ref": "https://json-schema.org/draft-04/schema#/properties/enum"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/enum"
         },
         "additionalProperties": {
           "anyOf": [
@@ -410,7 +410,7 @@
           "default": {}
         },
         "type": {
-          "$ref": "https://json-schema.org/draft-04/schema#/properties/type"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/type"
         },
         "items": {
           "anyOf": [
@@ -1036,49 +1036,49 @@
       }
     },
     "title": {
-      "$ref": "https://json-schema.org/draft-04/schema#/properties/title"
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/title"
     },
     "description": {
-      "$ref": "https://json-schema.org/draft-04/schema#/properties/description"
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/description"
     },
     "default": {
-      "$ref": "https://json-schema.org/draft-04/schema#/properties/default"
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/default"
     },
     "multipleOf": {
-      "$ref": "https://json-schema.org/draft-04/schema#/properties/multipleOf"
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/multipleOf"
     },
     "maximum": {
-      "$ref": "https://json-schema.org/draft-04/schema#/properties/maximum"
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/maximum"
     },
     "exclusiveMaximum": {
-      "$ref": "https://json-schema.org/draft-04/schema#/properties/exclusiveMaximum"
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/exclusiveMaximum"
     },
     "minimum": {
-      "$ref": "https://json-schema.org/draft-04/schema#/properties/minimum"
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/minimum"
     },
     "exclusiveMinimum": {
-      "$ref": "https://json-schema.org/draft-04/schema#/properties/exclusiveMinimum"
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/exclusiveMinimum"
     },
     "maxLength": {
-      "$ref": "https://json-schema.org/draft-04/schema#/definitions/positiveInteger"
+      "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
     },
     "minLength": {
-      "$ref": "https://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
+      "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
     },
     "pattern": {
-      "$ref": "https://json-schema.org/draft-04/schema#/properties/pattern"
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/pattern"
     },
     "maxItems": {
-      "$ref": "https://json-schema.org/draft-04/schema#/definitions/positiveInteger"
+      "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
     },
     "minItems": {
-      "$ref": "https://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
+      "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
     },
     "uniqueItems": {
-      "$ref": "https://json-schema.org/draft-04/schema#/properties/uniqueItems"
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/uniqueItems"
     },
     "enum": {
-      "$ref": "https://json-schema.org/draft-04/schema#/properties/enum"
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/enum"
     }
   }
 }

--- a/schemas/2.0.0-rc1.json
+++ b/schemas/2.0.0-rc1.json
@@ -1,6 +1,6 @@
 {
   "title": "AsyncAPI 2.0.0-rc1 schema.",
-  "$schema": "https://json-schema.org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "required": [
     "asyncapi",
@@ -330,58 +330,58 @@
           "type": "string"
         },
         "title": {
-          "$ref": "https://json-schema.org/draft-04/schema#/properties/title"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/title"
         },
         "description": {
-          "$ref": "https://json-schema.org/draft-04/schema#/properties/description"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/description"
         },
         "default": {
-          "$ref": "https://json-schema.org/draft-04/schema#/properties/default"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/default"
         },
         "multipleOf": {
-          "$ref": "https://json-schema.org/draft-04/schema#/properties/multipleOf"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/multipleOf"
         },
         "maximum": {
-          "$ref": "https://json-schema.org/draft-04/schema#/properties/maximum"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/maximum"
         },
         "exclusiveMaximum": {
-          "$ref": "https://json-schema.org/draft-04/schema#/properties/exclusiveMaximum"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/exclusiveMaximum"
         },
         "minimum": {
-          "$ref": "https://json-schema.org/draft-04/schema#/properties/minimum"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/minimum"
         },
         "exclusiveMinimum": {
-          "$ref": "https://json-schema.org/draft-04/schema#/properties/exclusiveMinimum"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/exclusiveMinimum"
         },
         "maxLength": {
-          "$ref": "https://json-schema.org/draft-04/schema#/definitions/positiveInteger"
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
         },
         "minLength": {
-          "$ref": "https://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
         },
         "pattern": {
-          "$ref": "https://json-schema.org/draft-04/schema#/properties/pattern"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/pattern"
         },
         "maxItems": {
-          "$ref": "https://json-schema.org/draft-04/schema#/definitions/positiveInteger"
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
         },
         "minItems": {
-          "$ref": "https://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
         },
         "uniqueItems": {
-          "$ref": "https://json-schema.org/draft-04/schema#/properties/uniqueItems"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/uniqueItems"
         },
         "maxProperties": {
-          "$ref": "https://json-schema.org/draft-04/schema#/definitions/positiveInteger"
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
         },
         "minProperties": {
-          "$ref": "https://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
         },
         "required": {
-          "$ref": "https://json-schema.org/draft-04/schema#/definitions/stringArray"
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/stringArray"
         },
         "enum": {
-          "$ref": "https://json-schema.org/draft-04/schema#/properties/enum"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/enum"
         },
       	"deprecated": {
           "type": "boolean",
@@ -399,7 +399,7 @@
           "default": {}
         },
         "type": {
-          "$ref": "https://json-schema.org/draft-04/schema#/properties/type"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/type"
         },
         "items": {
           "anyOf": [

--- a/schemas/2.0.0-rc2.json
+++ b/schemas/2.0.0-rc2.json
@@ -1,6 +1,6 @@
 {
   "title": "AsyncAPI 2.0.0-rc2 schema.",
-  "$schema": "https://json-schema.org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "required": [
     "asyncapi",
@@ -355,7 +355,7 @@
     "schema": {
       "allOf": [
         {
-          "$ref": "https://json-schema.org/draft-07/schema#"
+          "$ref": "http://json-schema.org/draft-07/schema#"
         },
         {
           "type": "object",

--- a/schemas/2.0.0.json
+++ b/schemas/2.0.0.json
@@ -1,6 +1,6 @@
 {
   "title": "AsyncAPI 2.0.0 schema.",
-  "$schema": "https://json-schema.org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "required": [
     "asyncapi",
@@ -359,7 +359,7 @@
     "schema": {
       "allOf": [
         {
-          "$ref": "https://json-schema.org/draft-07/schema#"
+          "$ref": "http://json-schema.org/draft-07/schema#"
         },
         {
           "patternProperties": {

--- a/schemas/2.1.0.json
+++ b/schemas/2.1.0.json
@@ -1,6 +1,6 @@
 {
   "title": "AsyncAPI 2.1.0 schema.",
-  "$schema": "https://json-schema.org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "required": [
     "asyncapi",
@@ -359,7 +359,7 @@
     "schema": {
       "allOf": [
         {
-          "$ref": "https://json-schema.org/draft-07/schema#"
+          "$ref": "http://json-schema.org/draft-07/schema#"
         },
         {
           "patternProperties": {

--- a/schemas/2.2.0.json
+++ b/schemas/2.2.0.json
@@ -1,6 +1,6 @@
 {
   "title": "AsyncAPI 2.2.0 schema.",
-  "$schema": "https://json-schema.org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "required": [
     "asyncapi",
@@ -359,7 +359,7 @@
     "schema": {
       "allOf": [
         {
-          "$ref": "https://json-schema.org/draft-07/schema#"
+          "$ref": "http://json-schema.org/draft-07/schema#"
         },
         {
           "patternProperties": {


### PR DESCRIPTION
Reverts asyncapi/spec-json-schemas#115

Tools like ajv (schema validator) are not compatible with https. See https://github.com/ajv-validator/ajv/issues/1104.

Also from a point of view of JSON Schema, this note about Schema ID's is very important:
> Even though schemas are identified by URIs, those identifiers are not necessarily network-addressable. They are just identifiers. Generally, implementations don’t make HTTP requests (https://) or read from the file system (file://) to fetch schemas. Instead, they provide a way to load schemas into an internal schema database. When a schema is referenced by it’s URI identifier, the schema is retrieved from the internal schema database.

Meaning it **should not** matter what protocol the URI has because It should not be treated as network address. However, it seems the [Monaco yaml plugin](https://github.com/remcohaszing/monaco-yaml) used in [Studio](https://github.com/asyncapi/studio) fills a request to the schema when the schema is not loaded from start (when it is not provided from the studio).

@magicmatatjahu is working on the fix.