### PR TITLE
feat: add Go package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,11 @@
+module github.com/asyncapi/spec-json-schemas
+
+go 1.17
+
+require github.com/stretchr/testify v1.7.0
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,11 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/spec-json-schemas.go
+++ b/spec-json-schemas.go
@@ -1,0 +1,41 @@
+package spec_json_schemas
+
+import (
+	"embed"
+	"fmt"
+	"strings"
+)
+
+//go:embed schemas
+var fs embed.FS
+var specs = make(map[string][]byte)
+
+// Get retrieves the Schema for a given version. Nil if not found.
+func Get(version string) ([]byte, error) {
+	if specs[version] == nil {
+		schemas, err := fs.ReadDir("schemas")
+		if err != nil {
+			return nil, err
+		}
+
+		if len(schemas) == len(specs) {
+			// No more files to load
+			return nil, nil
+		}
+
+		for _, f := range schemas {
+			if f.IsDir() {
+				continue
+			}
+
+			raw, err := fs.ReadFile(fmt.Sprintf("schemas/%s", f.Name()))
+			if err != nil {
+				return nil, err
+			}
+
+			specs[strings.TrimSuffix(f.Name(), ".json")] = raw
+		}
+	}
+
+	return specs[version], nil
+}

--- a/spec-json-schemas_test.go
+++ b/spec-json-schemas_test.go
@@ -1,0 +1,47 @@
+package spec_json_schemas
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"os"
+	"testing"
+)
+
+func TestGet(t *testing.T) {
+	tests := []struct {
+		name string
+		versions []string
+		expectedErr error
+		notFound bool
+	}{
+		{
+			name: "All schemas should be available",
+			versions: []string{"1.0.0", "1.1.0", "1.2.0", "2.0.0-rc1", "2.0.0-rc2", "2.1.0", "2.2.0"},
+		},
+		{
+			name: "Missing schema should return nil",
+			versions: []string{"99.99.99-rc99-not-found"},
+			notFound: true,
+		},
+	}
+		for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			for _, v := range test.versions {
+				s, err := Get(v)
+				if test.expectedErr == nil && !test.notFound {
+					assert.NoError(t, err, "No error is expected")
+					expectedContent, err := os.ReadFile(fmt.Sprintf("schemas/%s.json", v))
+					require.NoError(t, err)
+					require.NotNil(t, expectedContent)
+					assert.Equal(t, expectedContent, s)
+				} else if test.notFound {
+					assert.NoError(t, err)
+					assert.Nil(t, s)
+				} else {
+					assert.EqualError(t, err, test.expectedErr.Error())
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Description**

Closes https://github.com/asyncapi/spec-json-schemas/issues/118

As side note, this is gonna be used by the https://github.com/asyncapi/parser-go to support all spec versions :)
PR will be created on https://github.com/asyncapi/parser-go right after merging this. You can see the change [here](https://github.com/asyncapi/parser-go/compare/master...smoya:feat/2.2.0?expand=1)
