### PR TITLE
fix: add v2 suffix to Go module

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,5 @@
-.travis.yml
+.github
 test
+go.mod
+go.sum
+*.go

--- a/README.md
+++ b/README.md
@@ -6,11 +6,19 @@ This package provides all the versions of the AsyncAPI schema.
 
 ## Installation
 
+### NodeJS
 ```bash
 npm install @asyncapi/specs
 ```
 
+### Go
+```bash
+go get github.com/asyncapi/spec-json-schemas/v2
+```
+
 ## Usage
+
+### NodeJS
 
 Grab a specific AsyncAPI version:
 
@@ -36,4 +44,22 @@ console.log(versions);
 const asyncapi = versions['1.1.0'];
 
 // Do something with the schema.
+```
+
+### Go
+
+Grab a specific AsyncAPI version:
+
+```go
+import "github.com/asyncapi/spec_json_schemas/v2"
+
+func Do() {
+    schema, err := spec_json_schemas.Get("1.1.0")
+    if err != nil {
+        panic(err)
+    }
+
+    // Do something with the schema
+}
+
 ```

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/asyncapi/spec-json-schemas
+module github.com/asyncapi/spec-json-schemas/v2
 
 go 1.17
 


### PR DESCRIPTION
**Description**

This change will make the Go module compatible with Go semantic versioning.
As the tag it is >= v2, Go requires `v2` suffix in module name. See https://golang.org/ref/mod#major-version-suffixes

I also took this opportunity to add few lines in the `README.md` explaining how to install and use the Go package.

**Related issue(s)**
The issue is that users won't be able to import the module ever due to the following error:
> invalid version: module contains a go.mod file, so major version must be compatible: should be v0 or v1, not v2