### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,9 @@
+# This file provides an overview of code owners in this repository.
+
+# Each line is a file pattern followed by one or more owners.
+# The last matching pattern has the most precedence.
+# For more details, read the following article on GitHub: https://help.github.com/articles/about-codeowners/.
+
+# The default owners are automatically added as reviewers when you open a pull request unless different owners are specified in the file.
+
+* @fmvilas @derberg @github-actions[bot]


### PR DESCRIPTION
@fmvilas I wasn't sure here so I took an approach that JSON Schema is very closely aligned with `spec` then it should have exactly the same owners as `spec` repo.

We can rethink once we make a final decision about https://github.com/asyncapi/spec-json-schemas/issues/130

Thoughts?