### PR TITLE
fix: make pattern and patternProperties unicode ECMA-262 compliant

### DIFF
--- a/schemas/2.0.0-rc1.json
+++ b/schemas/2.0.0-rc1.json
@@ -10,7 +10,7 @@
   ],
   "additionalProperties": false,
   "patternProperties": {
-    "^x-[\\w\\d\\.\\-\\_]+$": {
+    "^x-[\\w\\d\\.\\x2d_]+$": {
       "$ref": "#/definitions/specificationExtension"
     }
   },
@@ -82,7 +82,7 @@
       ],
       "additionalProperties": false,
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -133,7 +133,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       }
@@ -156,7 +156,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       }
@@ -170,7 +170,7 @@
       ],
       "additionalProperties": false,
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -215,7 +215,7 @@
       "minProperties": 1,
       "additionalProperties": false,
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -318,7 +318,7 @@
       "type": "object",
       "description": "A deterministic version of a JSON Schema object.",
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -508,7 +508,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       }
@@ -517,7 +517,7 @@
       "type": "object",
       "additionalProperties": false,
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -555,7 +555,7 @@
     "parameter": {
       "additionalProperties": false,
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -580,7 +580,7 @@
       "type": "object",
       "additionalProperties": false,
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -650,7 +650,7 @@
               ],
               "additionalProperties": false,
               "patternProperties": {
-                "^x-[\\w\\d\\.\\-\\_]+$": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
                   "$ref": "#/definitions/specificationExtension"
                 }
               },
@@ -672,7 +672,7 @@
       "type": "object",
       "additionalProperties": false,
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -782,7 +782,7 @@
       ],
       "additionalProperties": false,
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -821,7 +821,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       }
@@ -839,7 +839,7 @@
       "type": "object",
       "additionalProperties": false,
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -875,7 +875,7 @@
       "type": "object",
       "additionalProperties": false,
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -982,7 +982,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -1013,7 +1013,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -1036,7 +1036,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -1059,7 +1059,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -1082,7 +1082,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -1127,7 +1127,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -1160,7 +1160,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -1196,7 +1196,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -1270,7 +1270,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       }
@@ -1295,7 +1295,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -1329,7 +1329,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },

--- a/schemas/2.0.0-rc2.json
+++ b/schemas/2.0.0-rc2.json
@@ -9,7 +9,7 @@
   ],
   "additionalProperties": false,
   "patternProperties": {
-    "^x-[\\w\\d\\.\\-\\_]+$": {
+    "^x-[\\w\\d\\.\\x2d_]+$": {
       "$ref": "#/definitions/specificationExtension"
     }
   },
@@ -80,7 +80,7 @@
       ],
       "additionalProperties": false,
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -131,7 +131,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       }
@@ -154,7 +154,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       }
@@ -168,7 +168,7 @@
       ],
       "additionalProperties": false,
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -212,7 +212,7 @@
       "minProperties": 1,
       "additionalProperties": false,
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -360,7 +360,7 @@
         {
           "type": "object",
           "patternProperties": {
-            "^x-[\\w\\d\\.\\-\\_]+$": {
+            "^x-[\\w\\d\\.\\x2d_]+$": {
               "$ref": "#/definitions/specificationExtension"
             }
           },
@@ -458,7 +458,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       }
@@ -467,7 +467,7 @@
       "type": "object",
       "additionalProperties": false,
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -504,7 +504,7 @@
     "parameter": {
       "additionalProperties": false,
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -519,7 +519,7 @@
         "location": {
           "type": "string",
           "description": "A runtime expression that specifies the location of the parameter value",
-          "pattern": "^\\$message\\.(header|payload)\\#(\\/(([^\\/~])|(~[01]))*)*"
+          "pattern": "^\\$message\\.(header|payload)#(\\/(([^\\/~])|(~[01]))*)*"
         },
         "$ref": {
           "$ref": "#/definitions/ReferenceObject"
@@ -530,7 +530,7 @@
       "type": "object",
       "additionalProperties": false,
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -620,7 +620,7 @@
               "type": "object",
               "additionalProperties": false,
               "patternProperties": {
-                "^x-[\\w\\d\\.\\-\\_]+$": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
                   "$ref": "#/definitions/specificationExtension"
                 }
               },
@@ -748,7 +748,7 @@
       ],
       "additionalProperties": false,
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -760,7 +760,7 @@
         "location": {
           "type": "string",
           "description": "A runtime expression that specifies the location of the correlation ID",
-          "pattern": "^\\$message\\.(header|payload)\\#(\\/(([^\\/~])|(~[01]))*)*"
+          "pattern": "^\\$message\\.(header|payload)#(\\/(([^\\/~])|(~[01]))*)*"
         }
       }
     },
@@ -787,7 +787,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       }
@@ -796,7 +796,7 @@
       "type": "object",
       "additionalProperties": false,
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -829,7 +829,7 @@
       "type": "object",
       "additionalProperties": false,
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -946,7 +946,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -977,7 +977,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -1000,7 +1000,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -1023,7 +1023,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -1046,7 +1046,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -1097,7 +1097,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -1130,7 +1130,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -1166,7 +1166,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -1271,7 +1271,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       }
@@ -1296,7 +1296,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -1330,7 +1330,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },

--- a/schemas/2.0.0.json
+++ b/schemas/2.0.0.json
@@ -9,7 +9,7 @@
   ],
   "additionalProperties": false,
   "patternProperties": {
-    "^x-[\\w\\d\\.\\-\\_]+$": {
+    "^x-[\\w\\d\\.\\x2d_]+$": {
       "$ref": "#/definitions/specificationExtension"
     }
   },
@@ -80,7 +80,7 @@
       ],
       "additionalProperties": false,
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -131,7 +131,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       }
@@ -154,7 +154,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       }
@@ -168,7 +168,7 @@
       ],
       "additionalProperties": false,
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -211,7 +211,7 @@
       "description": "An object representing a Server Variable for server URL template substitution.",
       "additionalProperties": false,
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -253,7 +253,7 @@
       "description": "An object to hold a set of reusable objects for different aspects of the AsyncAPI Specification.",
       "additionalProperties": false,
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -363,7 +363,7 @@
         },
         {
           "patternProperties": {
-            "^x-[\\w\\d\\.\\-\\_]+$": {
+            "^x-[\\w\\d\\.\\x2d_]+$": {
               "$ref": "#/definitions/specificationExtension"
             }
           },
@@ -469,7 +469,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       }
@@ -478,7 +478,7 @@
       "type": "object",
       "additionalProperties": false,
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -514,7 +514,7 @@
     "parameter": {
       "additionalProperties": false,
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -529,7 +529,7 @@
         "location": {
           "type": "string",
           "description": "A runtime expression that specifies the location of the parameter value",
-          "pattern": "^\\$message\\.(header|payload)\\#(\\/(([^\\/~])|(~[01]))*)*"
+          "pattern": "^\\$message\\.(header|payload)#(\\/(([^\\/~])|(~[01]))*)*"
         },
         "$ref": {
           "$ref": "#/definitions/ReferenceObject"
@@ -540,7 +540,7 @@
       "type": "object",
       "additionalProperties": false,
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -630,7 +630,7 @@
               "type": "object",
               "additionalProperties": false,
               "patternProperties": {
-                "^x-[\\w\\d\\.\\-\\_]+$": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
                   "$ref": "#/definitions/specificationExtension"
                 }
               },
@@ -776,7 +776,7 @@
       ],
       "additionalProperties": false,
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -788,7 +788,7 @@
         "location": {
           "type": "string",
           "description": "A runtime expression that specifies the location of the correlation ID",
-          "pattern": "^\\$message\\.(header|payload)\\#(\\/(([^\\/~])|(~[01]))*)*"
+          "pattern": "^\\$message\\.(header|payload)#(\\/(([^\\/~])|(~[01]))*)*"
         }
       }
     },
@@ -815,7 +815,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       }
@@ -824,7 +824,7 @@
       "type": "object",
       "additionalProperties": false,
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -857,7 +857,7 @@
       "type": "object",
       "additionalProperties": false,
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -974,7 +974,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -1005,7 +1005,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -1028,7 +1028,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -1051,7 +1051,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -1074,7 +1074,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -1125,7 +1125,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -1158,7 +1158,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -1194,7 +1194,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -1298,7 +1298,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       }
@@ -1323,7 +1323,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -1357,7 +1357,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },

--- a/schemas/2.1.0.json
+++ b/schemas/2.1.0.json
@@ -9,7 +9,7 @@
   ],
   "additionalProperties": false,
   "patternProperties": {
-    "^x-[\\w\\d\\.\\-\\_]+$": {
+    "^x-[\\w\\d\\.\\x2d_]+$": {
       "$ref": "#/definitions/specificationExtension"
     }
   },
@@ -80,7 +80,7 @@
       ],
       "additionalProperties": false,
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -131,7 +131,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       }
@@ -154,7 +154,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       }
@@ -168,7 +168,7 @@
       ],
       "additionalProperties": false,
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -211,7 +211,7 @@
       "description": "An object representing a Server Variable for server URL template substitution.",
       "additionalProperties": false,
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -253,7 +253,7 @@
       "description": "An object to hold a set of reusable objects for different aspects of the AsyncAPI Specification.",
       "additionalProperties": false,
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -363,7 +363,7 @@
         },
         {
           "patternProperties": {
-            "^x-[\\w\\d\\.\\-\\_]+$": {
+            "^x-[\\w\\d\\.\\x2d_]+$": {
               "$ref": "#/definitions/specificationExtension"
             }
           },
@@ -469,7 +469,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       }
@@ -478,7 +478,7 @@
       "type": "object",
       "additionalProperties": false,
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -514,7 +514,7 @@
     "parameter": {
       "additionalProperties": false,
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -529,7 +529,7 @@
         "location": {
           "type": "string",
           "description": "A runtime expression that specifies the location of the parameter value",
-          "pattern": "^\\$message\\.(header|payload)\\#(\\/(([^\\/~])|(~[01]))*)*"
+          "pattern": "^\\$message\\.(header|payload)#(\\/(([^\\/~])|(~[01]))*)*"
         },
         "$ref": {
           "$ref": "#/definitions/ReferenceObject"
@@ -540,7 +540,7 @@
       "type": "object",
       "additionalProperties": false,
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -630,7 +630,7 @@
               "type": "object",
               "additionalProperties": false,
               "patternProperties": {
-                "^x-[\\w\\d\\.\\-\\_]+$": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
                   "$ref": "#/definitions/specificationExtension"
                 }
               },
@@ -789,7 +789,7 @@
       ],
       "additionalProperties": false,
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -801,7 +801,7 @@
         "location": {
           "type": "string",
           "description": "A runtime expression that specifies the location of the correlation ID",
-          "pattern": "^\\$message\\.(header|payload)\\#(\\/(([^\\/~])|(~[01]))*)*"
+          "pattern": "^\\$message\\.(header|payload)#(\\/(([^\\/~])|(~[01]))*)*"
         }
       }
     },
@@ -828,7 +828,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       }
@@ -837,7 +837,7 @@
       "type": "object",
       "additionalProperties": false,
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -870,7 +870,7 @@
       "type": "object",
       "additionalProperties": false,
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -1009,7 +1009,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -1040,7 +1040,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -1063,7 +1063,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -1086,7 +1086,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -1109,7 +1109,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -1160,7 +1160,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -1193,7 +1193,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -1229,7 +1229,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -1265,7 +1265,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -1289,7 +1289,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -1312,7 +1312,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -1416,7 +1416,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       }
@@ -1441,7 +1441,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -1475,7 +1475,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },

--- a/schemas/2.2.0.json
+++ b/schemas/2.2.0.json
@@ -9,7 +9,7 @@
   ],
   "additionalProperties": false,
   "patternProperties": {
-    "^x-[\\w\\d\\.\\-\\_]+$": {
+    "^x-[\\w\\d\\.\\x2d_]+$": {
       "$ref": "#/definitions/specificationExtension"
     }
   },
@@ -80,7 +80,7 @@
       ],
       "additionalProperties": false,
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -131,7 +131,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       }
@@ -154,7 +154,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       }
@@ -168,7 +168,7 @@
       ],
       "additionalProperties": false,
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -211,7 +211,7 @@
       "description": "An object representing a Server Variable for server URL template substitution.",
       "additionalProperties": false,
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -253,7 +253,7 @@
       "description": "An object to hold a set of reusable objects for different aspects of the AsyncAPI Specification.",
       "additionalProperties": false,
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -363,7 +363,7 @@
         },
         {
           "patternProperties": {
-            "^x-[\\w\\d\\.\\-\\_]+$": {
+            "^x-[\\w\\d\\.\\x2d_]+$": {
               "$ref": "#/definitions/specificationExtension"
             }
           },
@@ -469,7 +469,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       }
@@ -478,7 +478,7 @@
       "type": "object",
       "additionalProperties": false,
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -522,7 +522,7 @@
     "parameter": {
       "additionalProperties": false,
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -537,7 +537,7 @@
         "location": {
           "type": "string",
           "description": "A runtime expression that specifies the location of the parameter value",
-          "pattern": "^\\$message\\.(header|payload)\\#(\\/(([^\\/~])|(~[01]))*)*"
+          "pattern": "^\\$message\\.(header|payload)#(\\/(([^\\/~])|(~[01]))*)*"
         },
         "$ref": {
           "$ref": "#/definitions/ReferenceObject"
@@ -548,7 +548,7 @@
       "type": "object",
       "additionalProperties": false,
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -638,7 +638,7 @@
               "type": "object",
               "additionalProperties": false,
               "patternProperties": {
-                "^x-[\\w\\d\\.\\-\\_]+$": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
                   "$ref": "#/definitions/specificationExtension"
                 }
               },
@@ -798,7 +798,7 @@
       ],
       "additionalProperties": false,
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -810,7 +810,7 @@
         "location": {
           "type": "string",
           "description": "A runtime expression that specifies the location of the correlation ID",
-          "pattern": "^\\$message\\.(header|payload)\\#(\\/(([^\\/~])|(~[01]))*)*"
+          "pattern": "^\\$message\\.(header|payload)#(\\/(([^\\/~])|(~[01]))*)*"
         }
       }
     },
@@ -837,7 +837,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       }
@@ -846,7 +846,7 @@
       "type": "object",
       "additionalProperties": false,
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -879,7 +879,7 @@
       "type": "object",
       "additionalProperties": false,
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -999,7 +999,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -1030,7 +1030,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -1053,7 +1053,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -1076,7 +1076,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -1099,7 +1099,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -1150,7 +1150,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -1183,7 +1183,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -1219,7 +1219,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -1255,7 +1255,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -1279,7 +1279,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -1302,7 +1302,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -1406,7 +1406,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       }
@@ -1431,7 +1431,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -1465,7 +1465,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },

--- a/schemas/2.3.0.json
+++ b/schemas/2.3.0.json
@@ -9,7 +9,7 @@
   ],
   "additionalProperties": false,
   "patternProperties": {
-    "^x-[\\w\\d\\.\\-\\_]+$": {
+    "^x-[\\w\\d\\.\\x2d_]+$": {
       "$ref": "#/definitions/specificationExtension"
     }
   },
@@ -80,7 +80,7 @@
       ],
       "additionalProperties": false,
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -131,7 +131,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       }
@@ -154,7 +154,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       }
@@ -168,7 +168,7 @@
       ],
       "additionalProperties": false,
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -211,7 +211,7 @@
       "description": "An object representing a Server Variable for server URL template substitution.",
       "additionalProperties": false,
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -253,7 +253,7 @@
       "description": "An object to hold a set of reusable objects for different aspects of the AsyncAPI Specification.",
       "additionalProperties": false,
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -363,7 +363,7 @@
         },
         {
           "patternProperties": {
-            "^x-[\\w\\d\\.\\-\\_]+$": {
+            "^x-[\\w\\d\\.\\x2d_]+$": {
               "$ref": "#/definitions/specificationExtension"
             }
           },
@@ -469,7 +469,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       }
@@ -478,7 +478,7 @@
       "type": "object",
       "additionalProperties": false,
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -522,7 +522,7 @@
     "parameter": {
       "additionalProperties": false,
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -537,7 +537,7 @@
         "location": {
           "type": "string",
           "description": "A runtime expression that specifies the location of the parameter value",
-          "pattern": "^\\$message\\.(header|payload)\\#(\\/(([^\\/~])|(~[01]))*)*"
+          "pattern": "^\\$message\\.(header|payload)#(\\/(([^\\/~])|(~[01]))*)*"
         },
         "$ref": {
           "$ref": "#/definitions/ReferenceObject"
@@ -548,7 +548,7 @@
       "type": "object",
       "additionalProperties": false,
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -638,7 +638,7 @@
               "type": "object",
               "additionalProperties": false,
               "patternProperties": {
-                "^x-[\\w\\d\\.\\-\\_]+$": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
                   "$ref": "#/definitions/specificationExtension"
                 }
               },
@@ -799,7 +799,7 @@
       ],
       "additionalProperties": false,
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -811,7 +811,7 @@
         "location": {
           "type": "string",
           "description": "A runtime expression that specifies the location of the correlation ID",
-          "pattern": "^\\$message\\.(header|payload)\\#(\\/(([^\\/~])|(~[01]))*)*"
+          "pattern": "^\\$message\\.(header|payload)#(\\/(([^\\/~])|(~[01]))*)*"
         }
       }
     },
@@ -838,7 +838,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       }
@@ -847,7 +847,7 @@
       "type": "object",
       "additionalProperties": false,
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -880,7 +880,7 @@
       "type": "object",
       "additionalProperties": false,
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -1000,7 +1000,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -1031,7 +1031,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -1054,7 +1054,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -1077,7 +1077,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -1100,7 +1100,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -1151,7 +1151,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -1184,7 +1184,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -1220,7 +1220,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -1256,7 +1256,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -1280,7 +1280,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -1303,7 +1303,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -1407,7 +1407,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       }
@@ -1432,7 +1432,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },
@@ -1466,7 +1466,7 @@
         }
       },
       "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
           "$ref": "#/definitions/specificationExtension"
         }
       },


### PR DESCRIPTION
**Description**

This PR makes the regular expressions found in `pattern` and `patternProperties` fields unicode compliant (according to ECMA-262). It only changes the `2.3.0.json` schema but if you consider this should be applied to the rest, I can expand it.

It means now the regular expressions are compatible with `u` flag, flag that some JSON Schema parsers use when parsing a JSON Schema document. For example the one from Hyperjump](https://github.com/hyperjump-io/json-schema-validator). See implementation [here](https://github.com/hyperjump-io/json-schema-validator/blob/521818176d71d82344450a40a405fff2029e6bcc/lib/keywords/patternProperties.js) and [here}(https://github.com/hyperjump-io/json-schema-validator/blob/521818176d71d82344450a40a405fff2029e6bcc/lib/keywords/pattern.js). This is being used by the online tool https://json-schema.hyperjump.io.


This is not introducing a BC since the regular expressions didn't change their meaning. You can see each version with each regex explanation on the following links:

- patternProperties: 
  - [old](https://regex101.com/r/xhn0Bf/2)
  - [new](https://regex101.com/r/nEJXSz/1)
- pattern
  - [old](https://regex101.com/r/Ny2oXU/1)
  - [new](https://regex101.com/r/q7cgyA/1)


**Related issue(s)**
Based on https://github.com/asyncapi/spec-json-schemas/pull/128 but fixing the proposed for the `patternProperties` with a proper unicode character.

cc @jonaslagoni @fmvilas 