### PR TITLE
feat: make channels optional

### DIFF
--- a/schemas/2.3.0.json
+++ b/schemas/2.3.0.json
@@ -4,8 +4,7 @@
   "type": "object",
   "required": [
     "asyncapi",
-    "info",
-    "channels"
+    "info"
   ],
   "additionalProperties": false,
   "patternProperties": {


### PR DESCRIPTION
**Description**

Part of https://github.com/asyncapi/spec/issues/661.

This PR removes `channels` from the required fields on the root of the document, meaning `channels` is not required to be present anymore.

**Related issue(s)**
https://github.com/asyncapi/spec/issues/661