### PR TITLE
feat: let channels be identified by ID. Address is now moved into a new field

### DIFF
--- a/definitions/3.0.0/channelItem.json
+++ b/definitions/3.0.0/channelItem.json
@@ -1,5 +1,8 @@
 {
   "type": "object",
+  "required": [
+    "address"
+  ],
   "additionalProperties": false,
   "patternProperties": {
     "^x-[\\w\\d\\.\\x2d_]+$": {
@@ -9,6 +12,11 @@
   "properties": {
     "$ref": {
       "$ref": "http://asyncapi.com/definitions/3.0.0/ReferenceObject.json"
+    },
+    "address": {
+      "type": "string",
+      "format": "uri-template",
+      "minLength": 1
     },
     "parameters": {
       "type": "object",

--- a/definitions/3.0.0/channels.json
+++ b/definitions/3.0.0/channels.json
@@ -1,10 +1,5 @@
 {
   "type": "object",
-  "propertyNames": {
-    "type": "string",
-    "format": "uri-template",
-    "minLength": 1
-  },
   "additionalProperties": {
     "$ref": "http://asyncapi.com/definitions/3.0.0/channelItem.json"
   },


### PR DESCRIPTION
This PR allows channels to be identified by an ID rather than by their address. Instead, the address has now been moved into a new field called `address`.

This is a breaking change so it should be considered as a candidate for `v3.0.0`.

**Related issue(s):**

See https://github.com/asyncapi/spec/issues/663 for knowing about the reason behind this RFC.

CC @char0n @magicmatatjahu @derberg 