### PR TITLE
chore: enable prereleases for 2022-04-release branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "branches": [
       "master",
       {
-        "name": "2022-01-release",
+        "name": "2022-04-release",
         "prerelease": true
       }
     ],


### PR DESCRIPTION
In order to allow CI to release pre-releases for `2022-04-release`, we need to merge this into `master` branch.

Part of https://github.com/asyncapi/spec/issues/735