### PR TITLE
feat: add 'values' field to TagObject

### DIFF
--- a/schemas/2.4.0.json
+++ b/schemas/2.4.0.json
@@ -847,6 +847,12 @@
         },
         "externalDocs": {
           "$ref": "#/definitions/externalDocs"
+        },
+        "values": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       },
       "patternProperties": {


### PR DESCRIPTION
This materializes an idea @Maciej Urbańczyk brought on https://github.com/asyncapi/spec/issues/654.
It is a RFC-0, so it can be treated as what it is. A suggestion.

This PR adds a new `values` field to  `TagObject` to declare a list of plain strings as values.

This is needed since the current Tag Object only defines a `name` that can be used as an identifier of the tag, but there is no other field for declaring values. Without this change, users are forced to compose tag names, i.e. `name:  "env:prod"` or for declaring multiple values: `name: "owner:platform,product`

However, this penalize UX (and tooling one) since no format standard will be in place. Especially hard when displaying those tags in documentation, or when filtering by any of those tags. For example, filtering by the owner tag above.

**Related issue(s):**

https://github.com/asyncapi/spec/issues/654