### PR TITLE
chore: add next major spec prerelease

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,10 @@
       {
         "name": "2022-04-release",
         "prerelease": true
+      },
+      {
+        "name": "next-major-spec",
+        "prerelease": true
       }
     ],
     "plugins": [


### PR DESCRIPTION
**Description**
This PR adds the [agreed-upon branch for next major spec version](https://github.com/asyncapi/spec/issues/734#issuecomment-1077455953) going forward.

**Related issue(s)**
Related to https://github.com/asyncapi/spec/issues/691