### PR TITLE
feat!: release for version 3.0.0 of the spec

### DIFF
--- a/.github/workflows/automerge-for-humans-add-ready-to-merge-or-do-not-merge-label.yml
+++ b/.github/workflows/automerge-for-humans-add-ready-to-merge-or-do-not-merge-label.yml
@@ -50,7 +50,7 @@ jobs:
               repo: pull.head.repo.name,
               basehead: `${pull.base.label}...${pull.head.label}`,
             });
-            if (comparison.behind_by !== 0) {
+            if (comparison.behind_by !== 0 && pull.mergeable_state === 'behind') {
               console.log(`This branch is behind the target by ${comparison.behind_by} commits`)
               console.log('adding out-of-date comment...');
               github.rest.issues.createComment({

--- a/.github/workflows/automerge-orphans.yml
+++ b/.github/workflows/automerge-orphans.yml
@@ -57,7 +57,7 @@ jobs:
         name: Send info about orphan to slack
         uses: rtCamp/action-slack-notify@v2
         env:
-          SLACK_WEBHOOK: ${{secrets.SLACK_GITHUB_NEWISSUEPR}}
+          SLACK_WEBHOOK: ${{secrets.SLACK_CI_FAIL_NOTIFY}}
           SLACK_TITLE: 🚨 Not merged PR that should be automerged 🚨
           SLACK_MESSAGE: ${{steps.issuemarkdown.outputs.text}}
           MSG_MINIMAL: true

--- a/.github/workflows/link-check-cron.yml
+++ b/.github/workflows/link-check-cron.yml
@@ -29,8 +29,8 @@ jobs:
     - name: Report workflow run status to Slack
       uses: 8398a7/action-slack@v3
       with:
-          status: ${{ job.status }}
-          fields: repo,message,action,eventName,ref,workflow
+        status: ${{ job.status }}
+        fields: repo,action,workflow
       env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_DOCS_CHANNEL }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_CI_FAIL_NOTIFY }}
       if: failure() # Only, on failure, send a message on the Slack Docs Channel (if there are broken links)

--- a/.github/workflows/link-check-pr.yml
+++ b/.github/workflows/link-check-pr.yml
@@ -6,12 +6,15 @@ name: Check Markdown links
 on: 
   pull_request_target:
     types: [synchronize, ready_for_review, opened, reopened]
+    paths:
+      - '**.md'
 
 jobs:
   External-link-validation-on-PR:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - name: Checkout repo
+      uses: actions/checkout@v3
     - name: Check links
       uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:

--- a/package.json
+++ b/package.json
@@ -48,6 +48,10 @@
       {
         "name": "2022-04-release",
         "prerelease": true
+      },
+      {
+        "name": "next-major-spec",
+        "prerelease": true
       }
     ],
     "plugins": [


### PR DESCRIPTION
This PR is created upfront to reflect on a daily basis what things are included in the release.

Also, the reason to create this PR a long time before the release is to enable automation (bot keeps upstream branches always up to date with master, see this [action](https://github.com/asyncapi/spec/blob/master/.github/workflows/autoupdate.yml)) that we have in place to regularly update the release branch with whatever is changed in the master branch. So nobody has to do it manually.