### PR TITLE
feat: add 2.4 schemas

### DIFF
--- a/.github/workflows/add-good-first-issue-labels.yml
+++ b/.github/workflows/add-good-first-issue-labels.yml
@@ -21,7 +21,7 @@ jobs:
           github-token: ${{ secrets.GH_TOKEN }}
           script: |
             const areas = ['javascript', 'typescript', 'java' , 'go', 'docs', 'ci-cd', 'design'];
-            const values = context.payload.comment.body.split(" ");
+            const values = context.payload.comment.body.trim().split(" ");
             switch(values[1]){
               case 'ts':
                 values[1] = 'typescript';

--- a/definitions/2.3.0/components.json
+++ b/definitions/2.3.0/components.json
@@ -12,7 +12,7 @@
       "$ref": "http://asyncapi.com/definitions/2.3.0/schemas.json"
     },
     "servers": {
-      "$ref": "http://asyncapi.com/definitions/2.3.0//servers.json"
+      "$ref": "http://asyncapi.com/definitions/2.3.0/servers.json"
     },
     "channels": {
       "$ref": "http://asyncapi.com/definitions/2.3.0/channels.json"

--- a/definitions/2.3.0/components.json
+++ b/definitions/2.3.0/components.json
@@ -11,6 +11,12 @@
     "schemas": {
       "$ref": "http://asyncapi.com/definitions/2.3.0/schemas.json"
     },
+    "servers": {
+      "$ref": "http://asyncapi.com/definitions/2.3.0//servers.json"
+    },
+    "channels": {
+      "$ref": "http://asyncapi.com/definitions/2.3.0/channels.json"
+    },
     "messages": {
       "$ref": "http://asyncapi.com/definitions/2.3.0/messages.json"
     },

--- a/definitions/2.4.0/APIKeyHTTPSecurityScheme.json
+++ b/definitions/2.4.0/APIKeyHTTPSecurityScheme.json
@@ -1,0 +1,38 @@
+{
+  "type": "object",
+  "required": [
+    "type",
+    "name",
+    "in"
+  ],
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": [
+        "httpApiKey"
+      ]
+    },
+    "name": {
+      "type": "string"
+    },
+    "in": {
+      "type": "string",
+      "enum": [
+        "header",
+        "query",
+        "cookie"
+      ]
+    },
+    "description": {
+      "type": "string"
+    }
+  },
+  "patternProperties": {
+    "^x-[\\w\\d\\.\\x2d_]+$": {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+    }
+  },
+  "additionalProperties": false,
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/definitions/2.4.0/APIKeyHTTPSecurityScheme.json"
+}

--- a/definitions/2.4.0/BearerHTTPSecurityScheme.json
+++ b/definitions/2.4.0/BearerHTTPSecurityScheme.json
@@ -1,0 +1,35 @@
+{
+  "type": "object",
+  "required": [
+    "type",
+    "scheme"
+  ],
+  "properties": {
+    "scheme": {
+      "type": "string",
+      "enum": [
+        "bearer"
+      ]
+    },
+    "bearerFormat": {
+      "type": "string"
+    },
+    "type": {
+      "type": "string",
+      "enum": [
+        "http"
+      ]
+    },
+    "description": {
+      "type": "string"
+    }
+  },
+  "patternProperties": {
+    "^x-[\\w\\d\\.\\x2d_]+$": {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+    }
+  },
+  "additionalProperties": false,
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/definitions/2.4.0/BearerHTTPSecurityScheme.json"
+}

--- a/definitions/2.4.0/HTTPSecurityScheme.json
+++ b/definitions/2.4.0/HTTPSecurityScheme.json
@@ -1,0 +1,15 @@
+{
+  "oneOf": [
+    {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/NonBearerHTTPSecurityScheme.json"
+    },
+    {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/BearerHTTPSecurityScheme.json"
+    },
+    {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/APIKeyHTTPSecurityScheme.json"
+    }
+  ],
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/definitions/2.4.0/HTTPSecurityScheme.json"
+}

--- a/definitions/2.4.0/NonBearerHTTPSecurityScheme.json
+++ b/definitions/2.4.0/NonBearerHTTPSecurityScheme.json
@@ -1,0 +1,40 @@
+{
+  "not": {
+    "type": "object",
+    "properties": {
+      "scheme": {
+        "type": "string",
+        "enum": [
+          "bearer"
+        ]
+      }
+    }
+  },
+  "type": "object",
+  "required": [
+    "scheme",
+    "type"
+  ],
+  "properties": {
+    "scheme": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "type": {
+      "type": "string",
+      "enum": [
+        "http"
+      ]
+    }
+  },
+  "patternProperties": {
+    "^x-[\\w\\d\\.\\x2d_]+$": {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+    }
+  },
+  "additionalProperties": false,
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/definitions/2.4.0/NonBearerHTTPSecurityScheme.json"
+}

--- a/definitions/2.4.0/Reference.json
+++ b/definitions/2.4.0/Reference.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "required": [
+    "$ref"
+  ],
+  "properties": {
+    "$ref": {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/ReferenceObject.json"
+    }
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/definitions/2.4.0/Reference.json"
+}

--- a/definitions/2.4.0/ReferenceObject.json
+++ b/definitions/2.4.0/ReferenceObject.json
@@ -1,0 +1,6 @@
+{
+  "type": "string",
+  "format": "uri-reference",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/definitions/2.4.0/ReferenceObject.json"
+}

--- a/definitions/2.4.0/SaslGssapiSecurityScheme.json
+++ b/definitions/2.4.0/SaslGssapiSecurityScheme.json
@@ -1,0 +1,25 @@
+{
+  "type": "object",
+  "required": [
+    "type"
+  ],
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": [
+        "gssapi"
+      ]
+    },
+    "description": {
+      "type": "string"
+    }
+  },
+  "patternProperties": {
+    "^x-[\\w\\d\\.\\x2d_]+$": {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+    }
+  },
+  "additionalProperties": false,
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/definitions/2.4.0/SaslGssapiSecurityScheme.json"
+}

--- a/definitions/2.4.0/SaslPlainSecurityScheme.json
+++ b/definitions/2.4.0/SaslPlainSecurityScheme.json
@@ -1,0 +1,25 @@
+{
+  "type": "object",
+  "required": [
+    "type"
+  ],
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": [
+        "plain"
+      ]
+    },
+    "description": {
+      "type": "string"
+    }
+  },
+  "patternProperties": {
+    "^x-[\\w\\d\\.\\x2d_]+$": {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+    }
+  },
+  "additionalProperties": false,
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/definitions/2.4.0/SaslPlainSecurityScheme.json"
+}

--- a/definitions/2.4.0/SaslScramSecurityScheme.json
+++ b/definitions/2.4.0/SaslScramSecurityScheme.json
@@ -1,0 +1,26 @@
+{
+  "type": "object",
+  "required": [
+    "type"
+  ],
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": [
+        "scramSha256",
+        "scramSha512"
+      ]
+    },
+    "description": {
+      "type": "string"
+    }
+  },
+  "patternProperties": {
+    "^x-[\\w\\d\\.\\x2d_]+$": {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+    }
+  },
+  "additionalProperties": false,
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/definitions/2.4.0/SaslScramSecurityScheme.json"
+}

--- a/definitions/2.4.0/SaslSecurityScheme.json
+++ b/definitions/2.4.0/SaslSecurityScheme.json
@@ -1,0 +1,15 @@
+{
+  "oneOf": [
+    {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/SaslPlainSecurityScheme.json"
+    },
+    {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/SaslScramSecurityScheme.json"
+    },
+    {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/SaslGssapiSecurityScheme.json"
+    }
+  ],
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/definitions/2.4.0/SaslSecurityScheme.json"
+}

--- a/definitions/2.4.0/SecurityRequirement.json
+++ b/definitions/2.4.0/SecurityRequirement.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "additionalProperties": {
+    "type": "array",
+    "items": {
+      "type": "string"
+    },
+    "uniqueItems": true
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/definitions/2.4.0/SecurityRequirement.json"
+}

--- a/definitions/2.4.0/SecurityScheme.json
+++ b/definitions/2.4.0/SecurityScheme.json
@@ -1,0 +1,33 @@
+{
+  "oneOf": [
+    {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/userPassword.json"
+    },
+    {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/apiKey.json"
+    },
+    {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/X509.json"
+    },
+    {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/symmetricEncryption.json"
+    },
+    {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/asymmetricEncryption.json"
+    },
+    {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/HTTPSecurityScheme.json"
+    },
+    {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/oauth2Flows.json"
+    },
+    {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/openIdConnect.json"
+    },
+    {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/SaslSecurityScheme.json"
+    }
+  ],
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/definitions/2.4.0/SecurityScheme.json"
+}

--- a/definitions/2.4.0/X509.json
+++ b/definitions/2.4.0/X509.json
@@ -1,0 +1,25 @@
+{
+  "type": "object",
+  "required": [
+    "type"
+  ],
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": [
+        "X509"
+      ]
+    },
+    "description": {
+      "type": "string"
+    }
+  },
+  "patternProperties": {
+    "^x-[\\w\\d\\.\\x2d_]+$": {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+    }
+  },
+  "additionalProperties": false,
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/definitions/2.4.0/X509.json"
+}

--- a/definitions/2.4.0/apiKey.json
+++ b/definitions/2.4.0/apiKey.json
@@ -1,0 +1,33 @@
+{
+  "type": "object",
+  "required": [
+    "type",
+    "in"
+  ],
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": [
+        "apiKey"
+      ]
+    },
+    "in": {
+      "type": "string",
+      "enum": [
+        "user",
+        "password"
+      ]
+    },
+    "description": {
+      "type": "string"
+    }
+  },
+  "patternProperties": {
+    "^x-[\\w\\d\\.\\x2d_]+$": {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+    }
+  },
+  "additionalProperties": false,
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/definitions/2.4.0/apiKey.json"
+}

--- a/definitions/2.4.0/asymmetricEncryption.json
+++ b/definitions/2.4.0/asymmetricEncryption.json
@@ -1,0 +1,25 @@
+{
+  "type": "object",
+  "required": [
+    "type"
+  ],
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": [
+        "asymmetricEncryption"
+      ]
+    },
+    "description": {
+      "type": "string"
+    }
+  },
+  "patternProperties": {
+    "^x-[\\w\\d\\.\\x2d_]+$": {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+    }
+  },
+  "additionalProperties": false,
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/definitions/2.4.0/asymmetricEncryption.json"
+}

--- a/definitions/2.4.0/asyncapi.json
+++ b/definitions/2.4.0/asyncapi.json
@@ -1,5 +1,5 @@
 {
-  "title": "AsyncAPI 2.3.0 schema.",
+  "title": "AsyncAPI 2.4.0 schema.",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "http://asyncapi.com/definitions/2.4.0/asyncapi.json",
   "type": "object",
@@ -18,7 +18,7 @@
     "asyncapi": {
       "type": "string",
       "enum": [
-        "2.3.0"
+        "2.4.0"
       ],
       "description": "The AsyncAPI specification version of this document."
     },

--- a/definitions/2.4.0/asyncapi.json
+++ b/definitions/2.4.0/asyncapi.json
@@ -1,0 +1,56 @@
+{
+  "title": "AsyncAPI 2.3.0 schema.",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/definitions/2.4.0/asyncapi.json",
+  "type": "object",
+  "required": [
+    "asyncapi",
+    "info",
+    "channels"
+  ],
+  "additionalProperties": false,
+  "patternProperties": {
+    "^x-[\\w\\d\\.\\x2d_]+$": {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+    }
+  },
+  "properties": {
+    "asyncapi": {
+      "type": "string",
+      "enum": [
+        "2.3.0"
+      ],
+      "description": "The AsyncAPI specification version of this document."
+    },
+    "id": {
+      "type": "string",
+      "description": "A unique id representing the application.",
+      "format": "uri"
+    },
+    "info": {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/info.json"
+    },
+    "servers": {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/servers.json"
+    },
+    "defaultContentType": {
+      "type": "string"
+    },
+    "channels": {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/channels.json"
+    },
+    "components": {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/components.json"
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "$ref": "http://asyncapi.com/definitions/2.4.0/tag.json"
+      },
+      "uniqueItems": true
+    },
+    "externalDocs": {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/externalDocs.json"
+    }
+  }
+}

--- a/definitions/2.4.0/bindingsObject.json
+++ b/definitions/2.4.0/bindingsObject.json
@@ -1,0 +1,24 @@
+{
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "http": {},
+    "ws": {},
+    "amqp": {},
+    "amqp1": {},
+    "mqtt": {},
+    "mqtt5": {},
+    "kafka": {},
+    "anypointmq": {},
+    "nats": {},
+    "jms": {},
+    "sns": {},
+    "sqs": {},
+    "stomp": {},
+    "redis": {},
+    "ibmmq": {},
+    "solace": {}
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/definitions/2.4.0/bindingsObject.json"
+}

--- a/definitions/2.4.0/channelItem.json
+++ b/definitions/2.4.0/channelItem.json
@@ -1,0 +1,47 @@
+{
+  "type": "object",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^x-[\\w\\d\\.\\x2d_]+$": {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+    }
+  },
+  "properties": {
+    "$ref": {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/ReferenceObject.json"
+    },
+    "parameters": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "http://asyncapi.com/definitions/2.4.0/parameter.json"
+      }
+    },
+    "description": {
+      "type": "string",
+      "description": "A description of the channel."
+    },
+    "servers": {
+      "type": "array",
+      "description": "The names of the servers on which this channel is available. If absent or empty then this channel must be available on all servers.",
+      "items": {
+        "type": "string"
+      },
+      "uniqueItems": true
+    },
+    "publish": {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/operation.json"
+    },
+    "subscribe": {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/operation.json"
+    },
+    "deprecated": {
+      "type": "boolean",
+      "default": false
+    },
+    "bindings": {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/bindingsObject.json"
+    }
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/definitions/2.4.0/channelItem.json"
+}

--- a/definitions/2.4.0/channels.json
+++ b/definitions/2.4.0/channels.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "propertyNames": {
+    "type": "string",
+    "format": "uri-template",
+    "minLength": 1
+  },
+  "additionalProperties": {
+    "$ref": "http://asyncapi.com/definitions/2.4.0/channelItem.json"
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/definitions/2.4.0/channels.json"
+}

--- a/definitions/2.4.0/components.json
+++ b/definitions/2.4.0/components.json
@@ -1,0 +1,89 @@
+{
+  "type": "object",
+  "description": "An object to hold a set of reusable objects for different aspects of the AsyncAPI Specification.",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^x-[\\w\\d\\.\\x2d_]+$": {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+    }
+  },
+  "properties": {
+    "schemas": {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/schemas.json"
+    },
+    "messages": {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/messages.json"
+    },
+    "securitySchemes": {
+      "type": "object",
+      "patternProperties": {
+        "^[\\w\\d\\.\\-_]+$": {
+          "oneOf": [
+            {
+              "$ref": "http://asyncapi.com/definitions/2.4.0/Reference.json"
+            },
+            {
+              "$ref": "http://asyncapi.com/definitions/2.4.0/SecurityScheme.json"
+            }
+          ]
+        }
+      }
+    },
+    "parameters": {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/parameters.json"
+    },
+    "correlationIds": {
+      "type": "object",
+      "patternProperties": {
+        "^[\\w\\d\\.\\-_]+$": {
+          "oneOf": [
+            {
+              "$ref": "http://asyncapi.com/definitions/2.4.0/Reference.json"
+            },
+            {
+              "$ref": "http://asyncapi.com/definitions/2.4.0/correlationId.json"
+            }
+          ]
+        }
+      }
+    },
+    "operationTraits": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "http://asyncapi.com/definitions/2.4.0/operationTrait.json"
+      }
+    },
+    "messageTraits": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "http://asyncapi.com/definitions/2.4.0/messageTrait.json"
+      }
+    },
+    "serverBindings": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "http://asyncapi.com/definitions/2.4.0/bindingsObject.json"
+      }
+    },
+    "channelBindings": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "http://asyncapi.com/definitions/2.4.0/bindingsObject.json"
+      }
+    },
+    "operationBindings": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "http://asyncapi.com/definitions/2.4.0/bindingsObject.json"
+      }
+    },
+    "messageBindings": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "http://asyncapi.com/definitions/2.4.0/bindingsObject.json"
+      }
+    }
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/definitions/2.4.0/components.json"
+}

--- a/definitions/2.4.0/components.json
+++ b/definitions/2.4.0/components.json
@@ -11,6 +11,15 @@
     "schemas": {
       "$ref": "http://asyncapi.com/definitions/2.4.0/schemas.json"
     },
+    "servers": {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/servers.json"
+    },
+    "channels": {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/channels.json"
+    },
+    "serverVariables": {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/serverVariables.json"
+    },
     "messages": {
       "$ref": "http://asyncapi.com/definitions/2.4.0/messages.json"
     },

--- a/definitions/2.4.0/contact.json
+++ b/definitions/2.4.0/contact.json
@@ -1,0 +1,28 @@
+{
+  "type": "object",
+  "description": "Contact information for the owners of the API.",
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "The identifying name of the contact person/organization."
+    },
+    "url": {
+      "type": "string",
+      "description": "The URL pointing to the contact information.",
+      "format": "uri"
+    },
+    "email": {
+      "type": "string",
+      "description": "The email address of the contact person/organization.",
+      "format": "email"
+    }
+  },
+  "patternProperties": {
+    "^x-[\\w\\d\\.\\x2d_]+$": {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+    }
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/definitions/2.4.0/contact.json"
+}

--- a/definitions/2.4.0/correlationId.json
+++ b/definitions/2.4.0/correlationId.json
@@ -1,0 +1,25 @@
+{
+  "type": "object",
+  "required": [
+    "location"
+  ],
+  "additionalProperties": false,
+  "patternProperties": {
+    "^x-[\\w\\d\\.\\x2d_]+$": {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+    }
+  },
+  "properties": {
+    "description": {
+      "type": "string",
+      "description": "A optional description of the correlation ID. GitHub Flavored Markdown is allowed."
+    },
+    "location": {
+      "type": "string",
+      "description": "A runtime expression that specifies the location of the correlation ID",
+      "pattern": "^\\$message\\.(header|payload)#(\\/(([^\\/~])|(~[01]))*)*"
+    }
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/definitions/2.4.0/correlationId.json"
+}

--- a/definitions/2.4.0/external.json
+++ b/definitions/2.4.0/external.json
@@ -1,0 +1,5 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://asyncapi.com/definitions/2.4.0/http://something.example.com/schemas/external.json",
+    "type": "string"
+  }

--- a/definitions/2.4.0/externalDocs.json
+++ b/definitions/2.4.0/externalDocs.json
@@ -1,0 +1,24 @@
+{
+  "type": "object",
+  "additionalProperties": false,
+  "description": "information about external documentation",
+  "required": [
+    "url"
+  ],
+  "properties": {
+    "description": {
+      "type": "string"
+    },
+    "url": {
+      "type": "string",
+      "format": "uri"
+    }
+  },
+  "patternProperties": {
+    "^x-[\\w\\d\\.\\x2d_]+$": {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+    }
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/definitions/2.4.0/externalDocs.json"
+}

--- a/definitions/2.4.0/info.json
+++ b/definitions/2.4.0/info.json
@@ -1,0 +1,41 @@
+{
+  "type": "object",
+  "description": "General information about the API.",
+  "required": [
+    "version",
+    "title"
+  ],
+  "additionalProperties": false,
+  "patternProperties": {
+    "^x-[\\w\\d\\.\\x2d_]+$": {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+    }
+  },
+  "properties": {
+    "title": {
+      "type": "string",
+      "description": "A unique and precise title of the API."
+    },
+    "version": {
+      "type": "string",
+      "description": "A semantic version number of the API."
+    },
+    "description": {
+      "type": "string",
+      "description": "A longer description of the API. Should be different from the title. CommonMark is allowed."
+    },
+    "termsOfService": {
+      "type": "string",
+      "description": "A URL to the Terms of Service for the API. MUST be in the format of a URL.",
+      "format": "uri"
+    },
+    "contact": {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/contact.json"
+    },
+    "license": {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/license.json"
+    }
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/definitions/2.4.0/info.json"
+}

--- a/definitions/2.4.0/license.json
+++ b/definitions/2.4.0/license.json
@@ -1,0 +1,25 @@
+{
+  "type": "object",
+  "required": [
+    "name"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "The name of the license type. It's encouraged to use an OSI compatible license."
+    },
+    "url": {
+      "type": "string",
+      "description": "The URL pointing to the license.",
+      "format": "uri"
+    }
+  },
+  "patternProperties": {
+    "^x-[\\w\\d\\.\\x2d_]+$": {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+    }
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/definitions/2.4.0/license.json"
+}

--- a/definitions/2.4.0/message.json
+++ b/definitions/2.4.0/message.json
@@ -49,6 +49,9 @@
                 }
               ]
             },
+            "messageId": {
+              "type": "string"
+            },
             "payload": {},
             "correlationId": {
               "oneOf": [

--- a/definitions/2.4.0/message.json
+++ b/definitions/2.4.0/message.json
@@ -1,0 +1,168 @@
+{
+  "oneOf": [
+    {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/Reference.json"
+    },
+    {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "oneOf"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "oneOf": {
+              "type": "array",
+              "items": {
+                "$ref": "http://asyncapi.com/definitions/2.4.0/message.json"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "patternProperties": {
+            "^x-[\\w\\d\\.\\x2d_]+$": {
+              "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+            }
+          },
+          "properties": {
+            "schemaFormat": {
+              "type": "string"
+            },
+            "contentType": {
+              "type": "string"
+            },
+            "headers": {
+              "allOf": [
+                {
+                  "$ref": "http://asyncapi.com/definitions/2.4.0/schema.json"
+                },
+                {
+                  "properties": {
+                    "type": {
+                      "const": "object"
+                    }
+                  }
+                }
+              ]
+            },
+            "payload": {},
+            "correlationId": {
+              "oneOf": [
+                {
+                  "$ref": "http://asyncapi.com/definitions/2.4.0/Reference.json"
+                },
+                {
+                  "$ref": "http://asyncapi.com/definitions/2.4.0/correlationId.json"
+                }
+              ]
+            },
+            "tags": {
+              "type": "array",
+              "items": {
+                "$ref": "http://asyncapi.com/definitions/2.4.0/tag.json"
+              },
+              "uniqueItems": true
+            },
+            "summary": {
+              "type": "string",
+              "description": "A brief summary of the message."
+            },
+            "name": {
+              "type": "string",
+              "description": "Name of the message."
+            },
+            "title": {
+              "type": "string",
+              "description": "A human-friendly title for the message."
+            },
+            "description": {
+              "type": "string",
+              "description": "A longer description of the message. CommonMark is allowed."
+            },
+            "externalDocs": {
+              "$ref": "http://asyncapi.com/definitions/2.4.0/externalDocs.json"
+            },
+            "deprecated": {
+              "type": "boolean",
+              "default": false
+            },
+            "examples": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "anyOf": [
+                  {
+                    "required": [
+                      "payload"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "headers"
+                    ]
+                  }
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "Machine readable name of the message example."
+                  },
+                  "summary": {
+                    "type": "string",
+                    "description": "A brief summary of the message example."
+                  },
+                  "headers": {
+                    "type": "object"
+                  },
+                  "payload": {}
+                }
+              }
+            },
+            "bindings": {
+              "$ref": "http://asyncapi.com/definitions/2.4.0/bindingsObject.json"
+            },
+            "traits": {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/Reference.json"
+                  },
+                  {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/messageTrait.json"
+                  },
+                  {
+                    "type": "array",
+                    "items": [
+                      {
+                        "oneOf": [
+                          {
+                            "$ref": "http://asyncapi.com/definitions/2.4.0/Reference.json"
+                          },
+                          {
+                            "$ref": "http://asyncapi.com/definitions/2.4.0/messageTrait.json"
+                          }
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "additionalItems": true
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/definitions/2.4.0/message.json"
+}

--- a/definitions/2.4.0/messageTrait.json
+++ b/definitions/2.4.0/messageTrait.json
@@ -1,0 +1,82 @@
+{
+  "type": "object",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^x-[\\w\\d\\.\\x2d_]+$": {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+    }
+  },
+  "properties": {
+    "schemaFormat": {
+      "type": "string"
+    },
+    "contentType": {
+      "type": "string"
+    },
+    "headers": {
+      "allOf": [
+        {
+          "$ref": "http://asyncapi.com/definitions/2.4.0/schema.json"
+        },
+        {
+          "properties": {
+            "type": {
+              "const": "object"
+            }
+          }
+        }
+      ]
+    },
+    "correlationId": {
+      "oneOf": [
+        {
+          "$ref": "http://asyncapi.com/definitions/2.4.0/Reference.json"
+        },
+        {
+          "$ref": "http://asyncapi.com/definitions/2.4.0/correlationId.json"
+        }
+      ]
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "$ref": "http://asyncapi.com/definitions/2.4.0/tag.json"
+      },
+      "uniqueItems": true
+    },
+    "summary": {
+      "type": "string",
+      "description": "A brief summary of the message."
+    },
+    "name": {
+      "type": "string",
+      "description": "Name of the message."
+    },
+    "title": {
+      "type": "string",
+      "description": "A human-friendly title for the message."
+    },
+    "description": {
+      "type": "string",
+      "description": "A longer description of the message. CommonMark is allowed."
+    },
+    "externalDocs": {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/externalDocs.json"
+    },
+    "deprecated": {
+      "type": "boolean",
+      "default": false
+    },
+    "examples": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "bindings": {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/bindingsObject.json"
+    }
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/definitions/2.4.0/messageTrait.json"
+}

--- a/definitions/2.4.0/messageTrait.json
+++ b/definitions/2.4.0/messageTrait.json
@@ -27,6 +27,9 @@
         }
       ]
     },
+    "messageId": {
+      "type": "string"
+    },
     "correlationId": {
       "oneOf": [
         {

--- a/definitions/2.4.0/messages.json
+++ b/definitions/2.4.0/messages.json
@@ -1,0 +1,9 @@
+{
+  "type": "object",
+  "additionalProperties": {
+    "$ref": "http://asyncapi.com/definitions/2.4.0/message.json"
+  },
+  "description": "JSON objects describing the messages being consumed and produced by the API.",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/definitions/2.4.0/messages.json"
+}

--- a/definitions/2.4.0/oauth2Flow.json
+++ b/definitions/2.4.0/oauth2Flow.json
@@ -1,0 +1,28 @@
+{
+  "type": "object",
+  "properties": {
+    "authorizationUrl": {
+      "type": "string",
+      "format": "uri"
+    },
+    "tokenUrl": {
+      "type": "string",
+      "format": "uri"
+    },
+    "refreshUrl": {
+      "type": "string",
+      "format": "uri"
+    },
+    "scopes": {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/oauth2Scopes.json"
+    }
+  },
+  "patternProperties": {
+    "^x-[\\w\\d\\.\\x2d_]+$": {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+    }
+  },
+  "additionalProperties": false,
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/definitions/2.4.0/oauth2Flow.json"
+}

--- a/definitions/2.4.0/oauth2Flows.json
+++ b/definitions/2.4.0/oauth2Flows.json
@@ -1,0 +1,105 @@
+{
+  "type": "object",
+  "required": [
+    "type",
+    "flows"
+  ],
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": [
+        "oauth2"
+      ]
+    },
+    "description": {
+      "type": "string"
+    },
+    "flows": {
+      "type": "object",
+      "properties": {
+        "implicit": {
+          "allOf": [
+            {
+              "$ref": "http://asyncapi.com/definitions/2.4.0/oauth2Flow.json"
+            },
+            {
+              "required": [
+                "authorizationUrl",
+                "scopes"
+              ]
+            },
+            {
+              "not": {
+                "required": [
+                  "tokenUrl"
+                ]
+              }
+            }
+          ]
+        },
+        "password": {
+          "allOf": [
+            {
+              "$ref": "http://asyncapi.com/definitions/2.4.0/oauth2Flow.json"
+            },
+            {
+              "required": [
+                "tokenUrl",
+                "scopes"
+              ]
+            },
+            {
+              "not": {
+                "required": [
+                  "authorizationUrl"
+                ]
+              }
+            }
+          ]
+        },
+        "clientCredentials": {
+          "allOf": [
+            {
+              "$ref": "http://asyncapi.com/definitions/2.4.0/oauth2Flow.json"
+            },
+            {
+              "required": [
+                "tokenUrl",
+                "scopes"
+              ]
+            },
+            {
+              "not": {
+                "required": [
+                  "authorizationUrl"
+                ]
+              }
+            }
+          ]
+        },
+        "authorizationCode": {
+          "allOf": [
+            {
+              "$ref": "http://asyncapi.com/definitions/2.4.0/oauth2Flow.json"
+            },
+            {
+              "required": [
+                "authorizationUrl",
+                "tokenUrl",
+                "scopes"
+              ]
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "patternProperties": {
+    "^x-[\\w\\d\\.\\x2d_]+$": {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+    }
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/definitions/2.4.0/oauth2Flows.json"
+}

--- a/definitions/2.4.0/oauth2Scopes.json
+++ b/definitions/2.4.0/oauth2Scopes.json
@@ -1,0 +1,8 @@
+{
+  "type": "object",
+  "additionalProperties": {
+    "type": "string"
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/definitions/2.4.0/oauth2Scopes.json"
+}

--- a/definitions/2.4.0/openIdConnect.json
+++ b/definitions/2.4.0/openIdConnect.json
@@ -1,0 +1,30 @@
+{
+  "type": "object",
+  "required": [
+    "type",
+    "openIdConnectUrl"
+  ],
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": [
+        "openIdConnect"
+      ]
+    },
+    "description": {
+      "type": "string"
+    },
+    "openIdConnectUrl": {
+      "type": "string",
+      "format": "uri"
+    }
+  },
+  "patternProperties": {
+    "^x-[\\w\\d\\.\\x2d_]+$": {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+    }
+  },
+  "additionalProperties": false,
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/definitions/2.4.0/openIdConnect.json"
+}

--- a/definitions/2.4.0/operation.json
+++ b/definitions/2.4.0/operation.json
@@ -45,6 +45,12 @@
     "description": {
       "type": "string"
     },
+    "security": {
+      "type": "array",
+      "items": {
+        "$ref": "http://asyncapi.com/definitions/2.4.0/SecurityRequirement.json"
+      }
+    },
     "tags": {
       "type": "array",
       "items": {

--- a/definitions/2.4.0/operation.json
+++ b/definitions/2.4.0/operation.json
@@ -1,0 +1,70 @@
+{
+  "type": "object",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^x-[\\w\\d\\.\\x2d_]+$": {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+    }
+  },
+  "properties": {
+    "traits": {
+      "type": "array",
+      "items": {
+        "oneOf": [
+          {
+            "$ref": "http://asyncapi.com/definitions/2.4.0/Reference.json"
+          },
+          {
+            "$ref": "http://asyncapi.com/definitions/2.4.0/operationTrait.json"
+          },
+          {
+            "type": "array",
+            "items": [
+              {
+                "oneOf": [
+                  {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/Reference.json"
+                  },
+                  {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/operationTrait.json"
+                  }
+                ]
+              },
+              {
+                "type": "object",
+                "additionalItems": true
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "summary": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "$ref": "http://asyncapi.com/definitions/2.4.0/tag.json"
+      },
+      "uniqueItems": true
+    },
+    "externalDocs": {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/externalDocs.json"
+    },
+    "operationId": {
+      "type": "string"
+    },
+    "bindings": {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/bindingsObject.json"
+    },
+    "message": {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/message.json"
+    }
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/definitions/2.4.0/operation.json"
+}

--- a/definitions/2.4.0/operationTrait.json
+++ b/definitions/2.4.0/operationTrait.json
@@ -26,6 +26,12 @@
     "operationId": {
       "type": "string"
     },
+    "security": {
+      "type": "array",
+      "items": {
+        "$ref": "http://asyncapi.com/definitions/2.4.0/SecurityRequirement.json"
+      }
+    },
     "bindings": {
       "$ref": "http://asyncapi.com/definitions/2.4.0/bindingsObject.json"
     }

--- a/definitions/2.4.0/operationTrait.json
+++ b/definitions/2.4.0/operationTrait.json
@@ -1,0 +1,35 @@
+{
+  "type": "object",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^x-[\\w\\d\\.\\x2d_]+$": {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+    }
+  },
+  "properties": {
+    "summary": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "$ref": "http://asyncapi.com/definitions/2.4.0/tag.json"
+      },
+      "uniqueItems": true
+    },
+    "externalDocs": {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/externalDocs.json"
+    },
+    "operationId": {
+      "type": "string"
+    },
+    "bindings": {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/bindingsObject.json"
+    }
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/definitions/2.4.0/operationTrait.json"
+}

--- a/definitions/2.4.0/parameter.json
+++ b/definitions/2.4.0/parameter.json
@@ -1,0 +1,27 @@
+{
+  "additionalProperties": false,
+  "patternProperties": {
+    "^x-[\\w\\d\\.\\x2d_]+$": {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+    }
+  },
+  "properties": {
+    "description": {
+      "type": "string",
+      "description": "A brief description of the parameter. This could contain examples of use. GitHub Flavored Markdown is allowed."
+    },
+    "schema": {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/schema.json"
+    },
+    "location": {
+      "type": "string",
+      "description": "A runtime expression that specifies the location of the parameter value",
+      "pattern": "^\\$message\\.(header|payload)#(\\/(([^\\/~])|(~[01]))*)*"
+    },
+    "$ref": {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/ReferenceObject.json"
+    }
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/definitions/2.4.0/parameter.json"
+}

--- a/definitions/2.4.0/parameters.json
+++ b/definitions/2.4.0/parameters.json
@@ -1,0 +1,9 @@
+{
+  "type": "object",
+  "additionalProperties": {
+    "$ref": "http://asyncapi.com/definitions/2.4.0/parameter.json"
+  },
+  "description": "JSON objects describing re-usable channel parameters.",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/definitions/2.4.0/parameters.json"
+}

--- a/definitions/2.4.0/schema.json
+++ b/definitions/2.4.0/schema.json
@@ -1,0 +1,98 @@
+{
+  "allOf": [
+    {
+      "$ref": "http://json-schema.org/draft-07/schema#"
+    },
+    {
+      "patternProperties": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
+          "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+        }
+      },
+      "properties": {
+        "additionalProperties": {
+          "anyOf": [
+            {
+              "$ref": "http://asyncapi.com/definitions/2.4.0/schema.json"
+            },
+            {
+              "type": "boolean"
+            }
+          ],
+          "default": {}
+        },
+        "items": {
+          "anyOf": [
+            {
+              "$ref": "http://asyncapi.com/definitions/2.4.0/schema.json"
+            },
+            {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "$ref": "http://asyncapi.com/definitions/2.4.0/schema.json"
+              }
+            }
+          ],
+          "default": {}
+        },
+        "allOf": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "http://asyncapi.com/definitions/2.4.0/schema.json"
+          }
+        },
+        "oneOf": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "http://asyncapi.com/definitions/2.4.0/schema.json"
+          }
+        },
+        "anyOf": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "http://asyncapi.com/definitions/2.4.0/schema.json"
+          }
+        },
+        "not": {
+          "$ref": "http://asyncapi.com/definitions/2.4.0/schema.json"
+        },
+        "properties": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "http://asyncapi.com/definitions/2.4.0/schema.json"
+          },
+          "default": {}
+        },
+        "patternProperties": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "http://asyncapi.com/definitions/2.4.0/schema.json"
+          },
+          "default": {}
+        },
+        "propertyNames": {
+          "$ref": "http://asyncapi.com/definitions/2.4.0/schema.json"
+        },
+        "contains": {
+          "$ref": "http://asyncapi.com/definitions/2.4.0/schema.json"
+        },
+        "discriminator": {
+          "type": "string"
+        },
+        "externalDocs": {
+          "$ref": "http://asyncapi.com/definitions/2.4.0/externalDocs.json"
+        },
+        "deprecated": {
+          "type": "boolean",
+          "default": false
+        }
+      }
+    }
+  ],
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/definitions/2.4.0/schema.json"
+}

--- a/definitions/2.4.0/schemas.json
+++ b/definitions/2.4.0/schemas.json
@@ -1,0 +1,9 @@
+{
+  "type": "object",
+  "additionalProperties": {
+    "$ref": "http://asyncapi.com/definitions/2.4.0/schema.json"
+  },
+  "description": "JSON objects describing schemas the API uses.",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/definitions/2.4.0/schemas.json"
+}

--- a/definitions/2.4.0/server.json
+++ b/definitions/2.4.0/server.json
@@ -1,0 +1,43 @@
+{
+  "type": "object",
+  "description": "An object representing a Server.",
+  "required": [
+    "url",
+    "protocol"
+  ],
+  "additionalProperties": false,
+  "patternProperties": {
+    "^x-[\\w\\d\\.\\x2d_]+$": {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+    }
+  },
+  "properties": {
+    "url": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "protocol": {
+      "type": "string",
+      "description": "The transfer protocol."
+    },
+    "protocolVersion": {
+      "type": "string"
+    },
+    "variables": {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/serverVariables.json"
+    },
+    "security": {
+      "type": "array",
+      "items": {
+        "$ref": "http://asyncapi.com/definitions/2.4.0/SecurityRequirement.json"
+      }
+    },
+    "bindings": {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/bindingsObject.json"
+    }
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/definitions/2.4.0/server.json"
+}

--- a/definitions/2.4.0/serverVariable.json
+++ b/definitions/2.4.0/serverVariable.json
@@ -1,0 +1,33 @@
+{
+  "type": "object",
+  "description": "An object representing a Server Variable for server URL template substitution.",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^x-[\\w\\d\\.\\x2d_]+$": {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+    }
+  },
+  "properties": {
+    "enum": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "uniqueItems": true
+    },
+    "default": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "examples": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/definitions/2.4.0/serverVariable.json"
+}

--- a/definitions/2.4.0/serverVariables.json
+++ b/definitions/2.4.0/serverVariables.json
@@ -1,0 +1,8 @@
+{
+  "type": "object",
+  "additionalProperties": {
+    "$ref": "http://asyncapi.com/definitions/2.4.0/serverVariable.json"
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/definitions/2.4.0/serverVariables.json"
+}

--- a/definitions/2.4.0/servers.json
+++ b/definitions/2.4.0/servers.json
@@ -1,0 +1,16 @@
+{
+  "description": "An object representing multiple servers.",
+  "type": "object",
+  "additionalProperties": {
+    "oneOf": [
+      {
+        "$ref": "http://asyncapi.com/definitions/2.4.0/Reference.json"
+      },
+      {
+        "$ref": "http://asyncapi.com/definitions/2.4.0/server.json"
+      }
+    ]
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/definitions/2.4.0/servers.json"
+}

--- a/definitions/2.4.0/specificationExtension.json
+++ b/definitions/2.4.0/specificationExtension.json
@@ -1,0 +1,7 @@
+{
+  "description": "Any property starting with x- is valid.",
+  "additionalProperties": true,
+  "additionalItems": true,
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+}

--- a/definitions/2.4.0/symmetricEncryption.json
+++ b/definitions/2.4.0/symmetricEncryption.json
@@ -1,0 +1,25 @@
+{
+  "type": "object",
+  "required": [
+    "type"
+  ],
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": [
+        "symmetricEncryption"
+      ]
+    },
+    "description": {
+      "type": "string"
+    }
+  },
+  "patternProperties": {
+    "^x-[\\w\\d\\.\\x2d_]+$": {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+    }
+  },
+  "additionalProperties": false,
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/definitions/2.4.0/symmetricEncryption.json"
+}

--- a/definitions/2.4.0/tag.json
+++ b/definitions/2.4.0/tag.json
@@ -1,0 +1,25 @@
+{
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "name"
+  ],
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "externalDocs": {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/externalDocs.json"
+    }
+  },
+  "patternProperties": {
+    "^x-[\\w\\d\\.\\x2d_]+$": {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+    }
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/definitions/2.4.0/tag.json"
+}

--- a/definitions/2.4.0/userPassword.json
+++ b/definitions/2.4.0/userPassword.json
@@ -1,0 +1,25 @@
+{
+  "type": "object",
+  "required": [
+    "type"
+  ],
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": [
+        "userPassword"
+      ]
+    },
+    "description": {
+      "type": "string"
+    }
+  },
+  "patternProperties": {
+    "^x-[\\w\\d\\.\\x2d_]+$": {
+      "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+    }
+  },
+  "additionalProperties": false,
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/definitions/2.4.0/userPassword.json"
+}

--- a/index.js
+++ b/index.js
@@ -7,5 +7,6 @@ module.exports = {
   '2.0.0': require('./schemas/2.0.0.json'),
   '2.1.0': require('./schemas/2.1.0.json'),
   '2.2.0': require('./schemas/2.2.0.json'),
-  '2.3.0': require('./schemas/2.3.0.json')
+  '2.3.0': require('./schemas/2.3.0.json'),
+  '2.4.0': require('./schemas/2.4.0.json'),
 };

--- a/schemas/2.3.0.json
+++ b/schemas/2.3.0.json
@@ -1159,6 +1159,12 @@
                 "schemas": {
                     "$ref": "http://asyncapi.com/definitions/2.3.0/schemas.json"
                 },
+                "servers": {
+                    "$ref": "http://asyncapi.com/definitions/2.3.0/servers.json"
+                },
+                "channels": {
+                    "$ref": "http://asyncapi.com/definitions/2.3.0/channels.json"
+                },
                 "messages": {
                     "$ref": "http://asyncapi.com/definitions/2.3.0/messages.json"
                 },

--- a/schemas/2.4.0.json
+++ b/schemas/2.4.0.json
@@ -1,0 +1,1523 @@
+{
+  "title": "AsyncAPI 2.4.0 schema.",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": [
+    "asyncapi",
+    "info",
+    "channels"
+  ],
+  "additionalProperties": false,
+  "patternProperties": {
+    "^x-[\\w\\d\\.\\x2d_]+$": {
+      "$ref": "#/definitions/specificationExtension"
+    }
+  },
+  "properties": {
+    "asyncapi": {
+      "type": "string",
+      "enum": [
+        "2.4.0"
+      ],
+      "description": "The AsyncAPI specification version of this document."
+    },
+    "id": {
+      "type": "string",
+      "description": "A unique id representing the application.",
+      "format": "uri"
+    },
+    "info": {
+      "$ref": "#/definitions/info"
+    },
+    "servers": {
+      "$ref": "#/definitions/servers"
+    },
+    "defaultContentType": {
+      "type": "string"
+    },
+    "channels": {
+      "$ref": "#/definitions/channels"
+    },
+    "components": {
+      "$ref": "#/definitions/components"
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/tag"
+      },
+      "uniqueItems": true
+    },
+    "externalDocs": {
+      "$ref": "#/definitions/externalDocs"
+    }
+  },
+  "definitions": {
+    "Reference": {
+      "type": "object",
+      "required": [
+        "$ref"
+      ],
+      "properties": {
+        "$ref": {
+          "$ref": "#/definitions/ReferenceObject"
+        }
+      }
+    },
+    "ReferenceObject": {
+      "type": "string",
+      "format": "uri-reference"
+    },
+    "info": {
+      "type": "object",
+      "description": "General information about the API.",
+      "required": [
+        "version",
+        "title"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
+          "$ref": "#/definitions/specificationExtension"
+        }
+      },
+      "properties": {
+        "title": {
+          "type": "string",
+          "description": "A unique and precise title of the API."
+        },
+        "version": {
+          "type": "string",
+          "description": "A semantic version number of the API."
+        },
+        "description": {
+          "type": "string",
+          "description": "A longer description of the API. Should be different from the title. CommonMark is allowed."
+        },
+        "termsOfService": {
+          "type": "string",
+          "description": "A URL to the Terms of Service for the API. MUST be in the format of a URL.",
+          "format": "uri"
+        },
+        "contact": {
+          "$ref": "#/definitions/contact"
+        },
+        "license": {
+          "$ref": "#/definitions/license"
+        }
+      }
+    },
+    "contact": {
+      "type": "object",
+      "description": "Contact information for the owners of the API.",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The identifying name of the contact person/organization."
+        },
+        "url": {
+          "type": "string",
+          "description": "The URL pointing to the contact information.",
+          "format": "uri"
+        },
+        "email": {
+          "type": "string",
+          "description": "The email address of the contact person/organization.",
+          "format": "email"
+        }
+      },
+      "patternProperties": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
+          "$ref": "#/definitions/specificationExtension"
+        }
+      }
+    },
+    "license": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the license type. It's encouraged to use an OSI compatible license."
+        },
+        "url": {
+          "type": "string",
+          "description": "The URL pointing to the license.",
+          "format": "uri"
+        }
+      },
+      "patternProperties": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
+          "$ref": "#/definitions/specificationExtension"
+        }
+      }
+    },
+    "server": {
+      "type": "object",
+      "description": "An object representing a Server.",
+      "anyOf" : [
+        { "required" : ["url", "protocol"] },
+        { "required" : ["$ref"] }
+      ],    
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
+          "$ref": "#/definitions/specificationExtension"
+        }
+      },
+      "properties": {
+        "$ref": {
+          "$ref": "#/definitions/ReferenceObject"
+        },
+        "url": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "protocol": {
+          "type": "string",
+          "description": "The transfer protocol."
+        },
+        "protocolVersion": {
+          "type": "string"
+        },
+        "variables": {
+          "$ref": "#/definitions/serverVariables"
+        },
+        "security": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SecurityRequirement"
+          }
+        },
+        "bindings": {
+          "$ref": "#/definitions/bindingsObject"
+        }
+      }
+    },
+    "servers": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/server"
+      }
+    },
+    "serverVariables": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/serverVariable"
+      }
+    },
+    "serverVariable": {
+      "type": "object",
+      "description": "An object representing a Server Variable for server URL template substitution.",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
+          "$ref": "#/definitions/specificationExtension"
+        }
+      },
+      "properties": {
+        "enum": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true
+        },
+        "default": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "examples": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "channels": {
+      "type": "object",
+      "propertyNames": {
+        "type": "string",
+        "format": "uri-template",
+        "minLength": 1
+      },
+      "additionalProperties": {
+        "$ref": "#/definitions/channelItem"
+      }
+    },
+    "components": {
+      "type": "object",
+      "description": "An object to hold a set of reusable objects for different aspects of the AsyncAPI Specification.",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
+          "$ref": "#/definitions/specificationExtension"
+        }
+      },
+      "properties": {
+        "schemas": {
+          "$ref": "#/definitions/schemas"
+        },
+        "servers": {
+          "$ref": "#/definitions/servers"
+        },
+        "serverVariables": {
+          "$ref": "#/definitions/serverVariables"
+        },
+        "channels": {
+          "$ref": "#/definitions/channels"
+        },
+        "messages": {
+          "$ref": "#/definitions/messages"
+        },
+        "securitySchemes": {
+          "type": "object",
+          "patternProperties": {
+            "^[\\w\\d\\.\\-_]+$": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/Reference"
+                },
+                {
+                  "$ref": "#/definitions/SecurityScheme"
+                }
+              ]
+            }
+          }
+        },
+        "parameters": {
+          "$ref": "#/definitions/parameters"
+        },
+        "correlationIds": {
+          "type": "object",
+          "patternProperties": {
+            "^[\\w\\d\\.\\-_]+$": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/Reference"
+                },
+                {
+                  "$ref": "#/definitions/correlationId"
+                }
+              ]
+            }
+          }
+        },
+        "operationTraits": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/operationTrait"
+          }
+        },
+        "messageTraits": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/messageTrait"
+          }
+        },
+        "serverBindings": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/bindingsObject"
+          }
+        },
+        "channelBindings": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/bindingsObject"
+          }
+        },
+        "operationBindings": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/bindingsObject"
+          }
+        },
+        "messageBindings": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/bindingsObject"
+          }
+        }
+      }
+    },
+    "schemas": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/schema"
+      },
+      "description": "JSON objects describing schemas the API uses."
+    },
+    "messages": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/message"
+      },
+      "description": "JSON objects describing the messages being consumed and produced by the API."
+    },
+    "parameters": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/parameter"
+      },
+      "description": "JSON objects describing re-usable channel parameters."
+    },
+    "schema": {
+      "allOf": [
+        {
+          "$ref": "http://json-schema.org/draft-07/schema#"
+        },
+        {
+          "patternProperties": {
+            "^x-[\\w\\d\\.\\x2d_]+$": {
+              "$ref": "#/definitions/specificationExtension"
+            }
+          },
+          "properties": {
+            "additionalProperties": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/schema"
+                },
+                {
+                  "type": "boolean"
+                }
+              ],
+              "default": {}
+            },
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/schema"
+                },
+                {
+                  "type": "array",
+                  "minItems": 1,
+                  "items": {
+                    "$ref": "#/definitions/schema"
+                  }
+                }
+              ],
+              "default": {}
+            },
+            "allOf": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "$ref": "#/definitions/schema"
+              }
+            },
+            "oneOf": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "$ref": "#/definitions/schema"
+              }
+            },
+            "anyOf": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "$ref": "#/definitions/schema"
+              }
+            },
+            "not": {
+              "$ref": "#/definitions/schema"
+            },
+            "properties": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/schema"
+              },
+              "default": {}
+            },
+            "patternProperties": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/schema"
+              },
+              "default": {}
+            },
+            "propertyNames": {
+              "$ref": "#/definitions/schema"
+            },
+            "contains": {
+              "$ref": "#/definitions/schema"
+            },
+            "discriminator": {
+              "type": "string"
+            },
+            "externalDocs": {
+              "$ref": "#/definitions/externalDocs"
+            },
+            "deprecated": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        }
+      ]
+    },
+    "externalDocs": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "information about external documentation",
+      "required": [
+        "url"
+      ],
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      },
+      "patternProperties": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
+          "$ref": "#/definitions/specificationExtension"
+        }
+      }
+    },
+    "channelItem": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
+          "$ref": "#/definitions/specificationExtension"
+        }
+      },
+      "properties": {
+        "$ref": {
+          "$ref": "#/definitions/ReferenceObject"
+        },
+        "parameters": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/parameter"
+          }
+        },
+        "description": {
+          "type": "string",
+          "description": "A description of the channel."
+        },
+        "servers": {
+          "type": "array",
+          "description": "The names of the servers on which this channel is available. If absent or empty then this channel must be available on all servers.",
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true
+        },
+        "publish": {
+          "$ref": "#/definitions/operation"
+        },
+        "subscribe": {
+          "$ref": "#/definitions/operation"
+        },
+        "deprecated": {
+          "type": "boolean",
+          "default": false
+        },
+        "bindings": {
+          "$ref": "#/definitions/bindingsObject"
+        }
+      }
+    },
+    "parameter": {
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
+          "$ref": "#/definitions/specificationExtension"
+        }
+      },
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "A brief description of the parameter. This could contain examples of use. GitHub Flavored Markdown is allowed."
+        },
+        "schema": {
+          "$ref": "#/definitions/schema"
+        },
+        "location": {
+          "type": "string",
+          "description": "A runtime expression that specifies the location of the parameter value",
+          "pattern": "^\\$message\\.(header|payload)#(\\/(([^\\/~])|(~[01]))*)*"
+        },
+        "$ref": {
+          "$ref": "#/definitions/ReferenceObject"
+        }
+      }
+    },
+    "operation": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
+          "$ref": "#/definitions/specificationExtension"
+        }
+      },
+      "properties": {
+        "traits": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Reference"
+              },
+              {
+                "$ref": "#/definitions/operationTrait"
+              },
+              {
+                "type": "array",
+                "items": [
+                  {
+                    "oneOf": [
+                      {
+                        "$ref": "#/definitions/Reference"
+                      },
+                      {
+                        "$ref": "#/definitions/operationTrait"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "object",
+                    "additionalItems": true
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/tag"
+          },
+          "uniqueItems": true
+        },
+        "externalDocs": {
+          "$ref": "#/definitions/externalDocs"
+        },
+        "operationId": {
+          "type": "string"
+        },
+        "security": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SecurityRequirement"
+          }
+        },
+        "bindings": {
+          "$ref": "#/definitions/bindingsObject"
+        },
+        "message": {
+          "$ref": "#/definitions/message"
+        }
+      }
+    },
+    "message": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/Reference"
+        },
+        {
+          "oneOf": [
+            {
+              "type": "object",
+              "required": [
+                "oneOf"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "oneOf": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/message"
+                  }
+                }
+              }
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                  "$ref": "#/definitions/specificationExtension"
+                }
+              },
+              "properties": {
+                "schemaFormat": {
+                  "type": "string"
+                },
+                "contentType": {
+                  "type": "string"
+                },
+                "headers": {
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/schema"
+                    },
+                    {
+                      "properties": {
+                        "type": {
+                          "const": "object"
+                        }
+                      }
+                    }
+                  ]
+                },
+                "messageId": {
+                  "type": "string"
+                },
+                "payload": {},
+                "correlationId": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/definitions/Reference"
+                    },
+                    {
+                      "$ref": "#/definitions/correlationId"
+                    }
+                  ]
+                },
+                "tags": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/tag"
+                  },
+                  "uniqueItems": true
+                },
+                "summary": {
+                  "type": "string",
+                  "description": "A brief summary of the message."
+                },
+                "name": {
+                  "type": "string",
+                  "description": "Name of the message."
+                },
+                "title": {
+                  "type": "string",
+                  "description": "A human-friendly title for the message."
+                },
+                "description": {
+                  "type": "string",
+                  "description": "A longer description of the message. CommonMark is allowed."
+                },
+                "externalDocs": {
+                  "$ref": "#/definitions/externalDocs"
+                },
+                "deprecated": {
+                  "type": "boolean",
+                  "default": false
+                },
+                "examples": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "anyOf": [
+                      {"required": ["payload"] },
+                      {"required": ["headers"] }
+                    ],
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "description": "Machine readable name of the message example."
+                      },
+                      "summary": {
+                        "type": "string",
+                        "description": "A brief summary of the message example."
+                      },
+                      "headers": {
+                        "type": "object"
+                      },
+                      "payload": {}
+                    }
+                  }
+                },
+                "bindings": {
+                  "$ref": "#/definitions/bindingsObject"
+                },
+                "traits": {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "$ref": "#/definitions/Reference"
+                      },
+                      {
+                        "$ref": "#/definitions/messageTrait"
+                      },
+                      {
+                        "type": "array",
+                        "items": [
+                          {
+                            "oneOf": [
+                              {
+                                "$ref": "#/definitions/Reference"
+                              },
+                              {
+                                "$ref": "#/definitions/messageTrait"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "object",
+                            "additionalItems": true
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "bindingsObject": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "http": {},
+        "ws": {},
+        "amqp": {},
+        "amqp1": {},
+        "mqtt": {},
+        "mqtt5": {},
+        "kafka": {},
+        "anypointmq": {},
+        "nats": {},
+        "jms": {},
+        "sns": {},
+        "sqs": {},
+        "stomp": {},
+        "redis": {},
+        "ibmmq": {},
+        "solace": {}
+      }
+    },
+    "correlationId": {
+      "type": "object",
+      "required": [
+        "location"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
+          "$ref": "#/definitions/specificationExtension"
+        }
+      },
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "A optional description of the correlation ID. GitHub Flavored Markdown is allowed."
+        },
+        "location": {
+          "type": "string",
+          "description": "A runtime expression that specifies the location of the correlation ID",
+          "pattern": "^\\$message\\.(header|payload)#(\\/(([^\\/~])|(~[01]))*)*"
+        }
+      }
+    },
+    "specificationExtension": {
+      "description": "Any property starting with x- is valid.",
+      "additionalProperties": true,
+      "additionalItems": true
+    },
+    "tag": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "externalDocs": {
+          "$ref": "#/definitions/externalDocs"
+        }
+      },
+      "patternProperties": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
+          "$ref": "#/definitions/specificationExtension"
+        }
+      }
+    },
+    "operationTrait": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
+          "$ref": "#/definitions/specificationExtension"
+        }
+      },
+      "properties": {
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "security": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SecurityRequirement"
+          }
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/tag"
+          },
+          "uniqueItems": true
+        },
+        "externalDocs": {
+          "$ref": "#/definitions/externalDocs"
+        },
+        "operationId": {
+          "type": "string"
+        },
+        "bindings": {
+          "$ref": "#/definitions/bindingsObject"
+        }
+      }
+    },
+    "messageTrait": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
+          "$ref": "#/definitions/specificationExtension"
+        }
+      },
+      "properties": {
+        "schemaFormat": {
+          "type": "string"
+        },
+        "contentType": {
+          "type": "string"
+        },
+        "headers": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/schema"
+            },
+            {
+              "properties": {
+                "type": {
+                  "const": "object"
+                }
+              }
+            }
+          ]
+        },
+        "messageId": {
+          "type": "string"
+        },
+        "correlationId": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Reference"
+            },
+            {
+              "$ref": "#/definitions/correlationId"
+            }
+          ]
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/tag"
+          },
+          "uniqueItems": true
+        },
+        "summary": {
+          "type": "string",
+          "description": "A brief summary of the message."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the message."
+        },
+        "title": {
+          "type": "string",
+          "description": "A human-friendly title for the message."
+        },
+        "description": {
+          "type": "string",
+          "description": "A longer description of the message. CommonMark is allowed."
+        },
+        "externalDocs": {
+          "$ref": "#/definitions/externalDocs"
+        },
+        "deprecated": {
+          "type": "boolean",
+          "default": false
+        },
+        "examples": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "bindings": {
+          "$ref": "#/definitions/bindingsObject"
+        }
+      }
+    },
+    "SecurityScheme": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/userPassword"
+        },
+        {
+          "$ref": "#/definitions/apiKey"
+        },
+        {
+          "$ref": "#/definitions/X509"
+        },
+        {
+          "$ref": "#/definitions/symmetricEncryption"
+        },
+        {
+          "$ref": "#/definitions/asymmetricEncryption"
+        },
+        {
+          "$ref": "#/definitions/HTTPSecurityScheme"
+        },
+        {
+          "$ref": "#/definitions/oauth2Flows"
+        },
+        {
+          "$ref": "#/definitions/openIdConnect"
+        },
+        {
+          "$ref": "#/definitions/SaslSecurityScheme"
+        }
+      ]
+    },
+    "userPassword": {
+      "type": "object",
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "userPassword"
+          ]
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
+          "$ref": "#/definitions/specificationExtension"
+        }
+      },
+      "additionalProperties": false
+    },
+    "apiKey": {
+      "type": "object",
+      "required": [
+        "type",
+        "in"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "apiKey"
+          ]
+        },
+        "in": {
+          "type": "string",
+          "enum": [
+            "user",
+            "password"
+          ]
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
+          "$ref": "#/definitions/specificationExtension"
+        }
+      },
+      "additionalProperties": false
+    },
+    "X509": {
+      "type": "object",
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "X509"
+          ]
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
+          "$ref": "#/definitions/specificationExtension"
+        }
+      },
+      "additionalProperties": false
+    },
+    "symmetricEncryption": {
+      "type": "object",
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "symmetricEncryption"
+          ]
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
+          "$ref": "#/definitions/specificationExtension"
+        }
+      },
+      "additionalProperties": false
+    },
+    "asymmetricEncryption": {
+      "type": "object",
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "asymmetricEncryption"
+          ]
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
+          "$ref": "#/definitions/specificationExtension"
+        }
+      },
+      "additionalProperties": false
+    },
+    "HTTPSecurityScheme": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/NonBearerHTTPSecurityScheme"
+        },
+        {
+          "$ref": "#/definitions/BearerHTTPSecurityScheme"
+        },
+        {
+          "$ref": "#/definitions/APIKeyHTTPSecurityScheme"
+        }
+      ]
+    },
+    "NonBearerHTTPSecurityScheme": {
+      "not": {
+        "type": "object",
+        "properties": {
+          "scheme": {
+            "type": "string",
+            "enum": [
+              "bearer"
+            ]
+          }
+        }
+      },
+      "type": "object",
+      "required": [
+        "scheme",
+        "type"
+      ],
+      "properties": {
+        "scheme": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "http"
+          ]
+        }
+      },
+      "patternProperties": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
+          "$ref": "#/definitions/specificationExtension"
+        }
+      },
+      "additionalProperties": false
+    },
+    "BearerHTTPSecurityScheme": {
+      "type": "object",
+      "required": [
+        "type",
+        "scheme"
+      ],
+      "properties": {
+        "scheme": {
+          "type": "string",
+          "enum": [
+            "bearer"
+          ]
+        },
+        "bearerFormat": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "http"
+          ]
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
+          "$ref": "#/definitions/specificationExtension"
+        }
+      },
+      "additionalProperties": false
+    },
+    "APIKeyHTTPSecurityScheme": {
+      "type": "object",
+      "required": [
+        "type",
+        "name",
+        "in"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "httpApiKey"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "in": {
+          "type": "string",
+          "enum": [
+            "header",
+            "query",
+            "cookie"
+          ]
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
+          "$ref": "#/definitions/specificationExtension"
+        }
+      },
+      "additionalProperties": false
+    },
+    "SaslSecurityScheme": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/SaslPlainSecurityScheme"
+        },
+        {
+          "$ref": "#/definitions/SaslScramSecurityScheme"
+        },
+        {
+          "$ref": "#/definitions/SaslGssapiSecurityScheme"
+        }
+      ]
+    },
+    "SaslPlainSecurityScheme": {
+      "type": "object",
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "plain"
+          ]
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
+          "$ref": "#/definitions/specificationExtension"
+        }
+      },
+      "additionalProperties": false
+    },
+    "SaslScramSecurityScheme": {
+      "type": "object",
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "scramSha256",
+            "scramSha512"
+          ]
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
+          "$ref": "#/definitions/specificationExtension"
+        }
+      },
+      "additionalProperties": false
+    },
+    "SaslGssapiSecurityScheme": {
+      "type": "object",
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "gssapi"
+          ]
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
+          "$ref": "#/definitions/specificationExtension"
+        }
+      },
+      "additionalProperties": false
+    },
+    "oauth2Flows": {
+      "type": "object",
+      "required": [
+        "type",
+        "flows"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "oauth2"
+          ]
+        },
+        "description": {
+          "type": "string"
+        },
+        "flows": {
+          "type": "object",
+          "properties": {
+            "implicit": {
+              "allOf": [
+                {
+                  "$ref": "#/definitions/oauth2Flow"
+                },
+                {
+                  "required": [
+                    "authorizationUrl",
+                    "scopes"
+                  ]
+                },
+                {
+                  "not": {
+                    "required": [
+                      "tokenUrl"
+                    ]
+                  }
+                }
+              ]
+            },
+            "password": {
+              "allOf": [
+                {
+                  "$ref": "#/definitions/oauth2Flow"
+                },
+                {
+                  "required": [
+                    "tokenUrl",
+                    "scopes"
+                  ]
+                },
+                {
+                  "not": {
+                    "required": [
+                      "authorizationUrl"
+                    ]
+                  }
+                }
+              ]
+            },
+            "clientCredentials": {
+              "allOf": [
+                {
+                  "$ref": "#/definitions/oauth2Flow"
+                },
+                {
+                  "required": [
+                    "tokenUrl",
+                    "scopes"
+                  ]
+                },
+                {
+                  "not": {
+                    "required": [
+                      "authorizationUrl"
+                    ]
+                  }
+                }
+              ]
+            },
+            "authorizationCode": {
+              "allOf": [
+                {
+                  "$ref": "#/definitions/oauth2Flow"
+                },
+                {
+                  "required": [
+                    "authorizationUrl",
+                    "tokenUrl",
+                    "scopes"
+                  ]
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "patternProperties": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
+          "$ref": "#/definitions/specificationExtension"
+        }
+      }
+    },
+    "oauth2Flow": {
+      "type": "object",
+      "properties": {
+        "authorizationUrl": {
+          "type": "string",
+          "format": "uri"
+        },
+        "tokenUrl": {
+          "type": "string",
+          "format": "uri"
+        },
+        "refreshUrl": {
+          "type": "string",
+          "format": "uri"
+        },
+        "scopes": {
+          "$ref": "#/definitions/oauth2Scopes"
+        }
+      },
+      "patternProperties": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
+          "$ref": "#/definitions/specificationExtension"
+        }
+      },
+      "additionalProperties": false
+    },
+    "oauth2Scopes": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "openIdConnect": {
+      "type": "object",
+      "required": [
+        "type",
+        "openIdConnectUrl"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "openIdConnect"
+          ]
+        },
+        "description": {
+          "type": "string"
+        },
+        "openIdConnectUrl": {
+          "type": "string",
+          "format": "uri"
+        }
+      },
+      "patternProperties": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
+          "$ref": "#/definitions/specificationExtension"
+        }
+      },
+      "additionalProperties": false
+    },
+    "SecurityRequirement": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "uniqueItems": true
+      }
+    }
+  }
+}

--- a/schemas/2.4.0.json
+++ b/schemas/2.4.0.json
@@ -1,7 +1,7 @@
 {
     "$id": "http://asyncapi.com/definitions/2.4.0/asyncapi.json",
     "$schema": "http://json-schema.org/draft-07/schema",
-    "title": "AsyncAPI 2.3.0 schema.",
+    "title": "AsyncAPI 2.4.0 schema.",
     "type": "object",
     "required": [
         "asyncapi",
@@ -18,7 +18,7 @@
         "asyncapi": {
             "type": "string",
             "enum": [
-                "2.3.0"
+                "2.4.0"
             ],
             "description": "The AsyncAPI specification version of this document."
         },

--- a/schemas/2.4.0.json
+++ b/schemas/2.4.0.json
@@ -1,1523 +1,1827 @@
 {
-  "title": "AsyncAPI 2.4.0 schema.",
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "type": "object",
-  "required": [
-    "asyncapi",
-    "info",
-    "channels"
-  ],
-  "additionalProperties": false,
-  "patternProperties": {
-    "^x-[\\w\\d\\.\\x2d_]+$": {
-      "$ref": "#/definitions/specificationExtension"
-    }
-  },
-  "properties": {
-    "asyncapi": {
-      "type": "string",
-      "enum": [
-        "2.4.0"
-      ],
-      "description": "The AsyncAPI specification version of this document."
-    },
-    "id": {
-      "type": "string",
-      "description": "A unique id representing the application.",
-      "format": "uri"
-    },
-    "info": {
-      "$ref": "#/definitions/info"
-    },
-    "servers": {
-      "$ref": "#/definitions/servers"
-    },
-    "defaultContentType": {
-      "type": "string"
-    },
-    "channels": {
-      "$ref": "#/definitions/channels"
-    },
-    "components": {
-      "$ref": "#/definitions/components"
-    },
-    "tags": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/tag"
-      },
-      "uniqueItems": true
-    },
-    "externalDocs": {
-      "$ref": "#/definitions/externalDocs"
-    }
-  },
-  "definitions": {
-    "Reference": {
-      "type": "object",
-      "required": [
-        "$ref"
-      ],
-      "properties": {
-        "$ref": {
-          "$ref": "#/definitions/ReferenceObject"
-        }
-      }
-    },
-    "ReferenceObject": {
-      "type": "string",
-      "format": "uri-reference"
-    },
-    "info": {
-      "type": "object",
-      "description": "General information about the API.",
-      "required": [
-        "version",
-        "title"
-      ],
-      "additionalProperties": false,
-      "patternProperties": {
+    "$id": "http://asyncapi.com/definitions/2.4.0/asyncapi.json",
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "title": "AsyncAPI 2.3.0 schema.",
+    "type": "object",
+    "required": [
+        "asyncapi",
+        "info",
+        "channels"
+    ],
+    "additionalProperties": false,
+    "patternProperties": {
         "^x-[\\w\\d\\.\\x2d_]+$": {
-          "$ref": "#/definitions/specificationExtension"
+            "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
         }
-      },
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "A unique and precise title of the API."
-        },
-        "version": {
-          "type": "string",
-          "description": "A semantic version number of the API."
-        },
-        "description": {
-          "type": "string",
-          "description": "A longer description of the API. Should be different from the title. CommonMark is allowed."
-        },
-        "termsOfService": {
-          "type": "string",
-          "description": "A URL to the Terms of Service for the API. MUST be in the format of a URL.",
-          "format": "uri"
-        },
-        "contact": {
-          "$ref": "#/definitions/contact"
-        },
-        "license": {
-          "$ref": "#/definitions/license"
-        }
-      }
     },
-    "contact": {
-      "type": "object",
-      "description": "Contact information for the owners of the API.",
-      "additionalProperties": false,
-      "properties": {
-        "name": {
-          "type": "string",
-          "description": "The identifying name of the contact person/organization."
-        },
-        "url": {
-          "type": "string",
-          "description": "The URL pointing to the contact information.",
-          "format": "uri"
-        },
-        "email": {
-          "type": "string",
-          "description": "The email address of the contact person/organization.",
-          "format": "email"
-        }
-      },
-      "patternProperties": {
-        "^x-[\\w\\d\\.\\x2d_]+$": {
-          "$ref": "#/definitions/specificationExtension"
-        }
-      }
-    },
-    "license": {
-      "type": "object",
-      "required": [
-        "name"
-      ],
-      "additionalProperties": false,
-      "properties": {
-        "name": {
-          "type": "string",
-          "description": "The name of the license type. It's encouraged to use an OSI compatible license."
-        },
-        "url": {
-          "type": "string",
-          "description": "The URL pointing to the license.",
-          "format": "uri"
-        }
-      },
-      "patternProperties": {
-        "^x-[\\w\\d\\.\\x2d_]+$": {
-          "$ref": "#/definitions/specificationExtension"
-        }
-      }
-    },
-    "server": {
-      "type": "object",
-      "description": "An object representing a Server.",
-      "anyOf" : [
-        { "required" : ["url", "protocol"] },
-        { "required" : ["$ref"] }
-      ],    
-      "additionalProperties": false,
-      "patternProperties": {
-        "^x-[\\w\\d\\.\\x2d_]+$": {
-          "$ref": "#/definitions/specificationExtension"
-        }
-      },
-      "properties": {
-        "$ref": {
-          "$ref": "#/definitions/ReferenceObject"
-        },
-        "url": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        },
-        "protocol": {
-          "type": "string",
-          "description": "The transfer protocol."
-        },
-        "protocolVersion": {
-          "type": "string"
-        },
-        "variables": {
-          "$ref": "#/definitions/serverVariables"
-        },
-        "security": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/SecurityRequirement"
-          }
-        },
-        "bindings": {
-          "$ref": "#/definitions/bindingsObject"
-        }
-      }
-    },
-    "servers": {
-      "type": "object",
-      "additionalProperties": {
-        "$ref": "#/definitions/server"
-      }
-    },
-    "serverVariables": {
-      "type": "object",
-      "additionalProperties": {
-        "$ref": "#/definitions/serverVariable"
-      }
-    },
-    "serverVariable": {
-      "type": "object",
-      "description": "An object representing a Server Variable for server URL template substitution.",
-      "additionalProperties": false,
-      "patternProperties": {
-        "^x-[\\w\\d\\.\\x2d_]+$": {
-          "$ref": "#/definitions/specificationExtension"
-        }
-      },
-      "properties": {
-        "enum": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "uniqueItems": true
-        },
-        "default": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        },
-        "examples": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "channels": {
-      "type": "object",
-      "propertyNames": {
-        "type": "string",
-        "format": "uri-template",
-        "minLength": 1
-      },
-      "additionalProperties": {
-        "$ref": "#/definitions/channelItem"
-      }
-    },
-    "components": {
-      "type": "object",
-      "description": "An object to hold a set of reusable objects for different aspects of the AsyncAPI Specification.",
-      "additionalProperties": false,
-      "patternProperties": {
-        "^x-[\\w\\d\\.\\x2d_]+$": {
-          "$ref": "#/definitions/specificationExtension"
-        }
-      },
-      "properties": {
-        "schemas": {
-          "$ref": "#/definitions/schemas"
-        },
-        "servers": {
-          "$ref": "#/definitions/servers"
-        },
-        "serverVariables": {
-          "$ref": "#/definitions/serverVariables"
-        },
-        "channels": {
-          "$ref": "#/definitions/channels"
-        },
-        "messages": {
-          "$ref": "#/definitions/messages"
-        },
-        "securitySchemes": {
-          "type": "object",
-          "patternProperties": {
-            "^[\\w\\d\\.\\-_]+$": {
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/Reference"
-                },
-                {
-                  "$ref": "#/definitions/SecurityScheme"
-                }
-              ]
-            }
-          }
-        },
-        "parameters": {
-          "$ref": "#/definitions/parameters"
-        },
-        "correlationIds": {
-          "type": "object",
-          "patternProperties": {
-            "^[\\w\\d\\.\\-_]+$": {
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/Reference"
-                },
-                {
-                  "$ref": "#/definitions/correlationId"
-                }
-              ]
-            }
-          }
-        },
-        "operationTraits": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/operationTrait"
-          }
-        },
-        "messageTraits": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/messageTrait"
-          }
-        },
-        "serverBindings": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/bindingsObject"
-          }
-        },
-        "channelBindings": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/bindingsObject"
-          }
-        },
-        "operationBindings": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/bindingsObject"
-          }
-        },
-        "messageBindings": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/bindingsObject"
-          }
-        }
-      }
-    },
-    "schemas": {
-      "type": "object",
-      "additionalProperties": {
-        "$ref": "#/definitions/schema"
-      },
-      "description": "JSON objects describing schemas the API uses."
-    },
-    "messages": {
-      "type": "object",
-      "additionalProperties": {
-        "$ref": "#/definitions/message"
-      },
-      "description": "JSON objects describing the messages being consumed and produced by the API."
-    },
-    "parameters": {
-      "type": "object",
-      "additionalProperties": {
-        "$ref": "#/definitions/parameter"
-      },
-      "description": "JSON objects describing re-usable channel parameters."
-    },
-    "schema": {
-      "allOf": [
-        {
-          "$ref": "http://json-schema.org/draft-07/schema#"
-        },
-        {
-          "patternProperties": {
-            "^x-[\\w\\d\\.\\x2d_]+$": {
-              "$ref": "#/definitions/specificationExtension"
-            }
-          },
-          "properties": {
-            "additionalProperties": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/schema"
-                },
-                {
-                  "type": "boolean"
-                }
-              ],
-              "default": {}
-            },
-            "items": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/schema"
-                },
-                {
-                  "type": "array",
-                  "minItems": 1,
-                  "items": {
-                    "$ref": "#/definitions/schema"
-                  }
-                }
-              ],
-              "default": {}
-            },
-            "allOf": {
-              "type": "array",
-              "minItems": 1,
-              "items": {
-                "$ref": "#/definitions/schema"
-              }
-            },
-            "oneOf": {
-              "type": "array",
-              "minItems": 1,
-              "items": {
-                "$ref": "#/definitions/schema"
-              }
-            },
-            "anyOf": {
-              "type": "array",
-              "minItems": 1,
-              "items": {
-                "$ref": "#/definitions/schema"
-              }
-            },
-            "not": {
-              "$ref": "#/definitions/schema"
-            },
-            "properties": {
-              "type": "object",
-              "additionalProperties": {
-                "$ref": "#/definitions/schema"
-              },
-              "default": {}
-            },
-            "patternProperties": {
-              "type": "object",
-              "additionalProperties": {
-                "$ref": "#/definitions/schema"
-              },
-              "default": {}
-            },
-            "propertyNames": {
-              "$ref": "#/definitions/schema"
-            },
-            "contains": {
-              "$ref": "#/definitions/schema"
-            },
-            "discriminator": {
-              "type": "string"
-            },
-            "externalDocs": {
-              "$ref": "#/definitions/externalDocs"
-            },
-            "deprecated": {
-              "type": "boolean",
-              "default": false
-            }
-          }
-        }
-      ]
-    },
-    "externalDocs": {
-      "type": "object",
-      "additionalProperties": false,
-      "description": "information about external documentation",
-      "required": [
-        "url"
-      ],
-      "properties": {
-        "description": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        }
-      },
-      "patternProperties": {
-        "^x-[\\w\\d\\.\\x2d_]+$": {
-          "$ref": "#/definitions/specificationExtension"
-        }
-      }
-    },
-    "channelItem": {
-      "type": "object",
-      "additionalProperties": false,
-      "patternProperties": {
-        "^x-[\\w\\d\\.\\x2d_]+$": {
-          "$ref": "#/definitions/specificationExtension"
-        }
-      },
-      "properties": {
-        "$ref": {
-          "$ref": "#/definitions/ReferenceObject"
-        },
-        "parameters": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/parameter"
-          }
-        },
-        "description": {
-          "type": "string",
-          "description": "A description of the channel."
-        },
-        "servers": {
-          "type": "array",
-          "description": "The names of the servers on which this channel is available. If absent or empty then this channel must be available on all servers.",
-          "items": {
-            "type": "string"
-          },
-          "uniqueItems": true
-        },
-        "publish": {
-          "$ref": "#/definitions/operation"
-        },
-        "subscribe": {
-          "$ref": "#/definitions/operation"
-        },
-        "deprecated": {
-          "type": "boolean",
-          "default": false
-        },
-        "bindings": {
-          "$ref": "#/definitions/bindingsObject"
-        }
-      }
-    },
-    "parameter": {
-      "additionalProperties": false,
-      "patternProperties": {
-        "^x-[\\w\\d\\.\\x2d_]+$": {
-          "$ref": "#/definitions/specificationExtension"
-        }
-      },
-      "properties": {
-        "description": {
-          "type": "string",
-          "description": "A brief description of the parameter. This could contain examples of use. GitHub Flavored Markdown is allowed."
-        },
-        "schema": {
-          "$ref": "#/definitions/schema"
-        },
-        "location": {
-          "type": "string",
-          "description": "A runtime expression that specifies the location of the parameter value",
-          "pattern": "^\\$message\\.(header|payload)#(\\/(([^\\/~])|(~[01]))*)*"
-        },
-        "$ref": {
-          "$ref": "#/definitions/ReferenceObject"
-        }
-      }
-    },
-    "operation": {
-      "type": "object",
-      "additionalProperties": false,
-      "patternProperties": {
-        "^x-[\\w\\d\\.\\x2d_]+$": {
-          "$ref": "#/definitions/specificationExtension"
-        }
-      },
-      "properties": {
-        "traits": {
-          "type": "array",
-          "items": {
-            "oneOf": [
-              {
-                "$ref": "#/definitions/Reference"
-              },
-              {
-                "$ref": "#/definitions/operationTrait"
-              },
-              {
-                "type": "array",
-                "items": [
-                  {
-                    "oneOf": [
-                      {
-                        "$ref": "#/definitions/Reference"
-                      },
-                      {
-                        "$ref": "#/definitions/operationTrait"
-                      }
-                    ]
-                  },
-                  {
-                    "type": "object",
-                    "additionalItems": true
-                  }
-                ]
-              }
-            ]
-          }
-        },
-        "summary": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        },
-        "tags": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/tag"
-          },
-          "uniqueItems": true
-        },
-        "externalDocs": {
-          "$ref": "#/definitions/externalDocs"
-        },
-        "operationId": {
-          "type": "string"
-        },
-        "security": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/SecurityRequirement"
-          }
-        },
-        "bindings": {
-          "$ref": "#/definitions/bindingsObject"
-        },
-        "message": {
-          "$ref": "#/definitions/message"
-        }
-      }
-    },
-    "message": {
-      "oneOf": [
-        {
-          "$ref": "#/definitions/Reference"
-        },
-        {
-          "oneOf": [
-            {
-              "type": "object",
-              "required": [
-                "oneOf"
-              ],
-              "additionalProperties": false,
-              "properties": {
-                "oneOf": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/message"
-                  }
-                }
-              }
-            },
-            {
-              "type": "object",
-              "additionalProperties": false,
-              "patternProperties": {
-                "^x-[\\w\\d\\.\\x2d_]+$": {
-                  "$ref": "#/definitions/specificationExtension"
-                }
-              },
-              "properties": {
-                "schemaFormat": {
-                  "type": "string"
-                },
-                "contentType": {
-                  "type": "string"
-                },
-                "headers": {
-                  "allOf": [
-                    {
-                      "$ref": "#/definitions/schema"
-                    },
-                    {
-                      "properties": {
-                        "type": {
-                          "const": "object"
-                        }
-                      }
-                    }
-                  ]
-                },
-                "messageId": {
-                  "type": "string"
-                },
-                "payload": {},
-                "correlationId": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/definitions/Reference"
-                    },
-                    {
-                      "$ref": "#/definitions/correlationId"
-                    }
-                  ]
-                },
-                "tags": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/tag"
-                  },
-                  "uniqueItems": true
-                },
-                "summary": {
-                  "type": "string",
-                  "description": "A brief summary of the message."
-                },
-                "name": {
-                  "type": "string",
-                  "description": "Name of the message."
-                },
-                "title": {
-                  "type": "string",
-                  "description": "A human-friendly title for the message."
-                },
-                "description": {
-                  "type": "string",
-                  "description": "A longer description of the message. CommonMark is allowed."
-                },
-                "externalDocs": {
-                  "$ref": "#/definitions/externalDocs"
-                },
-                "deprecated": {
-                  "type": "boolean",
-                  "default": false
-                },
-                "examples": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "additionalProperties": false,
-                    "anyOf": [
-                      {"required": ["payload"] },
-                      {"required": ["headers"] }
-                    ],
-                    "properties": {
-                      "name": {
-                        "type": "string",
-                        "description": "Machine readable name of the message example."
-                      },
-                      "summary": {
-                        "type": "string",
-                        "description": "A brief summary of the message example."
-                      },
-                      "headers": {
-                        "type": "object"
-                      },
-                      "payload": {}
-                    }
-                  }
-                },
-                "bindings": {
-                  "$ref": "#/definitions/bindingsObject"
-                },
-                "traits": {
-                  "type": "array",
-                  "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/definitions/Reference"
-                      },
-                      {
-                        "$ref": "#/definitions/messageTrait"
-                      },
-                      {
-                        "type": "array",
-                        "items": [
-                          {
-                            "oneOf": [
-                              {
-                                "$ref": "#/definitions/Reference"
-                              },
-                              {
-                                "$ref": "#/definitions/messageTrait"
-                              }
-                            ]
-                          },
-                          {
-                            "type": "object",
-                            "additionalItems": true
-                          }
-                        ]
-                      }
-                    ]
-                  }
-                }
-              }
-            }
-          ]
-        }
-      ]
-    },
-    "bindingsObject": {
-      "type": "object",
-      "additionalProperties": true,
-      "properties": {
-        "http": {},
-        "ws": {},
-        "amqp": {},
-        "amqp1": {},
-        "mqtt": {},
-        "mqtt5": {},
-        "kafka": {},
-        "anypointmq": {},
-        "nats": {},
-        "jms": {},
-        "sns": {},
-        "sqs": {},
-        "stomp": {},
-        "redis": {},
-        "ibmmq": {},
-        "solace": {}
-      }
-    },
-    "correlationId": {
-      "type": "object",
-      "required": [
-        "location"
-      ],
-      "additionalProperties": false,
-      "patternProperties": {
-        "^x-[\\w\\d\\.\\x2d_]+$": {
-          "$ref": "#/definitions/specificationExtension"
-        }
-      },
-      "properties": {
-        "description": {
-          "type": "string",
-          "description": "A optional description of the correlation ID. GitHub Flavored Markdown is allowed."
-        },
-        "location": {
-          "type": "string",
-          "description": "A runtime expression that specifies the location of the correlation ID",
-          "pattern": "^\\$message\\.(header|payload)#(\\/(([^\\/~])|(~[01]))*)*"
-        }
-      }
-    },
-    "specificationExtension": {
-      "description": "Any property starting with x- is valid.",
-      "additionalProperties": true,
-      "additionalItems": true
-    },
-    "tag": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        },
-        "externalDocs": {
-          "$ref": "#/definitions/externalDocs"
-        }
-      },
-      "patternProperties": {
-        "^x-[\\w\\d\\.\\x2d_]+$": {
-          "$ref": "#/definitions/specificationExtension"
-        }
-      }
-    },
-    "operationTrait": {
-      "type": "object",
-      "additionalProperties": false,
-      "patternProperties": {
-        "^x-[\\w\\d\\.\\x2d_]+$": {
-          "$ref": "#/definitions/specificationExtension"
-        }
-      },
-      "properties": {
-        "summary": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        },
-        "security": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/SecurityRequirement"
-          }
-        },
-        "tags": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/tag"
-          },
-          "uniqueItems": true
-        },
-        "externalDocs": {
-          "$ref": "#/definitions/externalDocs"
-        },
-        "operationId": {
-          "type": "string"
-        },
-        "bindings": {
-          "$ref": "#/definitions/bindingsObject"
-        }
-      }
-    },
-    "messageTrait": {
-      "type": "object",
-      "additionalProperties": false,
-      "patternProperties": {
-        "^x-[\\w\\d\\.\\x2d_]+$": {
-          "$ref": "#/definitions/specificationExtension"
-        }
-      },
-      "properties": {
-        "schemaFormat": {
-          "type": "string"
-        },
-        "contentType": {
-          "type": "string"
-        },
-        "headers": {
-          "allOf": [
-            {
-              "$ref": "#/definitions/schema"
-            },
-            {
-              "properties": {
-                "type": {
-                  "const": "object"
-                }
-              }
-            }
-          ]
-        },
-        "messageId": {
-          "type": "string"
-        },
-        "correlationId": {
-          "oneOf": [
-            {
-              "$ref": "#/definitions/Reference"
-            },
-            {
-              "$ref": "#/definitions/correlationId"
-            }
-          ]
-        },
-        "tags": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/tag"
-          },
-          "uniqueItems": true
-        },
-        "summary": {
-          "type": "string",
-          "description": "A brief summary of the message."
-        },
-        "name": {
-          "type": "string",
-          "description": "Name of the message."
-        },
-        "title": {
-          "type": "string",
-          "description": "A human-friendly title for the message."
-        },
-        "description": {
-          "type": "string",
-          "description": "A longer description of the message. CommonMark is allowed."
-        },
-        "externalDocs": {
-          "$ref": "#/definitions/externalDocs"
-        },
-        "deprecated": {
-          "type": "boolean",
-          "default": false
-        },
-        "examples": {
-          "type": "array",
-          "items": {
-            "type": "object"
-          }
-        },
-        "bindings": {
-          "$ref": "#/definitions/bindingsObject"
-        }
-      }
-    },
-    "SecurityScheme": {
-      "oneOf": [
-        {
-          "$ref": "#/definitions/userPassword"
-        },
-        {
-          "$ref": "#/definitions/apiKey"
-        },
-        {
-          "$ref": "#/definitions/X509"
-        },
-        {
-          "$ref": "#/definitions/symmetricEncryption"
-        },
-        {
-          "$ref": "#/definitions/asymmetricEncryption"
-        },
-        {
-          "$ref": "#/definitions/HTTPSecurityScheme"
-        },
-        {
-          "$ref": "#/definitions/oauth2Flows"
-        },
-        {
-          "$ref": "#/definitions/openIdConnect"
-        },
-        {
-          "$ref": "#/definitions/SaslSecurityScheme"
-        }
-      ]
-    },
-    "userPassword": {
-      "type": "object",
-      "required": [
-        "type"
-      ],
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": [
-            "userPassword"
-          ]
-        },
-        "description": {
-          "type": "string"
-        }
-      },
-      "patternProperties": {
-        "^x-[\\w\\d\\.\\x2d_]+$": {
-          "$ref": "#/definitions/specificationExtension"
-        }
-      },
-      "additionalProperties": false
-    },
-    "apiKey": {
-      "type": "object",
-      "required": [
-        "type",
-        "in"
-      ],
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": [
-            "apiKey"
-          ]
-        },
-        "in": {
-          "type": "string",
-          "enum": [
-            "user",
-            "password"
-          ]
-        },
-        "description": {
-          "type": "string"
-        }
-      },
-      "patternProperties": {
-        "^x-[\\w\\d\\.\\x2d_]+$": {
-          "$ref": "#/definitions/specificationExtension"
-        }
-      },
-      "additionalProperties": false
-    },
-    "X509": {
-      "type": "object",
-      "required": [
-        "type"
-      ],
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": [
-            "X509"
-          ]
-        },
-        "description": {
-          "type": "string"
-        }
-      },
-      "patternProperties": {
-        "^x-[\\w\\d\\.\\x2d_]+$": {
-          "$ref": "#/definitions/specificationExtension"
-        }
-      },
-      "additionalProperties": false
-    },
-    "symmetricEncryption": {
-      "type": "object",
-      "required": [
-        "type"
-      ],
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": [
-            "symmetricEncryption"
-          ]
-        },
-        "description": {
-          "type": "string"
-        }
-      },
-      "patternProperties": {
-        "^x-[\\w\\d\\.\\x2d_]+$": {
-          "$ref": "#/definitions/specificationExtension"
-        }
-      },
-      "additionalProperties": false
-    },
-    "asymmetricEncryption": {
-      "type": "object",
-      "required": [
-        "type"
-      ],
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": [
-            "asymmetricEncryption"
-          ]
-        },
-        "description": {
-          "type": "string"
-        }
-      },
-      "patternProperties": {
-        "^x-[\\w\\d\\.\\x2d_]+$": {
-          "$ref": "#/definitions/specificationExtension"
-        }
-      },
-      "additionalProperties": false
-    },
-    "HTTPSecurityScheme": {
-      "oneOf": [
-        {
-          "$ref": "#/definitions/NonBearerHTTPSecurityScheme"
-        },
-        {
-          "$ref": "#/definitions/BearerHTTPSecurityScheme"
-        },
-        {
-          "$ref": "#/definitions/APIKeyHTTPSecurityScheme"
-        }
-      ]
-    },
-    "NonBearerHTTPSecurityScheme": {
-      "not": {
-        "type": "object",
-        "properties": {
-          "scheme": {
+    "properties": {
+        "asyncapi": {
             "type": "string",
             "enum": [
-              "bearer"
-            ]
-          }
-        }
-      },
-      "type": "object",
-      "required": [
-        "scheme",
-        "type"
-      ],
-      "properties": {
-        "scheme": {
-          "type": "string"
+                "2.3.0"
+            ],
+            "description": "The AsyncAPI specification version of this document."
         },
-        "description": {
-          "type": "string"
+        "id": {
+            "type": "string",
+            "description": "A unique id representing the application.",
+            "format": "uri"
         },
-        "type": {
-          "type": "string",
-          "enum": [
-            "http"
-          ]
-        }
-      },
-      "patternProperties": {
-        "^x-[\\w\\d\\.\\x2d_]+$": {
-          "$ref": "#/definitions/specificationExtension"
-        }
-      },
-      "additionalProperties": false
-    },
-    "BearerHTTPSecurityScheme": {
-      "type": "object",
-      "required": [
-        "type",
-        "scheme"
-      ],
-      "properties": {
-        "scheme": {
-          "type": "string",
-          "enum": [
-            "bearer"
-          ]
+        "info": {
+            "$ref": "http://asyncapi.com/definitions/2.4.0/info.json"
         },
-        "bearerFormat": {
-          "type": "string"
+        "servers": {
+            "$ref": "http://asyncapi.com/definitions/2.4.0/servers.json"
         },
-        "type": {
-          "type": "string",
-          "enum": [
-            "http"
-          ]
+        "defaultContentType": {
+            "type": "string"
         },
-        "description": {
-          "type": "string"
-        }
-      },
-      "patternProperties": {
-        "^x-[\\w\\d\\.\\x2d_]+$": {
-          "$ref": "#/definitions/specificationExtension"
-        }
-      },
-      "additionalProperties": false
-    },
-    "APIKeyHTTPSecurityScheme": {
-      "type": "object",
-      "required": [
-        "type",
-        "name",
-        "in"
-      ],
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": [
-            "httpApiKey"
-          ]
+        "channels": {
+            "$ref": "http://asyncapi.com/definitions/2.4.0/channels.json"
         },
-        "name": {
-          "type": "string"
+        "components": {
+            "$ref": "http://asyncapi.com/definitions/2.4.0/components.json"
         },
-        "in": {
-          "type": "string",
-          "enum": [
-            "header",
-            "query",
-            "cookie"
-          ]
-        },
-        "description": {
-          "type": "string"
-        }
-      },
-      "patternProperties": {
-        "^x-[\\w\\d\\.\\x2d_]+$": {
-          "$ref": "#/definitions/specificationExtension"
-        }
-      },
-      "additionalProperties": false
-    },
-    "SaslSecurityScheme": {
-      "oneOf": [
-        {
-          "$ref": "#/definitions/SaslPlainSecurityScheme"
-        },
-        {
-          "$ref": "#/definitions/SaslScramSecurityScheme"
-        },
-        {
-          "$ref": "#/definitions/SaslGssapiSecurityScheme"
-        }
-      ]
-    },
-    "SaslPlainSecurityScheme": {
-      "type": "object",
-      "required": [
-        "type"
-      ],
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": [
-            "plain"
-          ]
-        },
-        "description": {
-          "type": "string"
-        }
-      },
-      "patternProperties": {
-        "^x-[\\w\\d\\.\\x2d_]+$": {
-          "$ref": "#/definitions/specificationExtension"
-        }
-      },
-      "additionalProperties": false
-    },
-    "SaslScramSecurityScheme": {
-      "type": "object",
-      "required": [
-        "type"
-      ],
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": [
-            "scramSha256",
-            "scramSha512"
-          ]
-        },
-        "description": {
-          "type": "string"
-        }
-      },
-      "patternProperties": {
-        "^x-[\\w\\d\\.\\x2d_]+$": {
-          "$ref": "#/definitions/specificationExtension"
-        }
-      },
-      "additionalProperties": false
-    },
-    "SaslGssapiSecurityScheme": {
-      "type": "object",
-      "required": [
-        "type"
-      ],
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": [
-            "gssapi"
-          ]
-        },
-        "description": {
-          "type": "string"
-        }
-      },
-      "patternProperties": {
-        "^x-[\\w\\d\\.\\x2d_]+$": {
-          "$ref": "#/definitions/specificationExtension"
-        }
-      },
-      "additionalProperties": false
-    },
-    "oauth2Flows": {
-      "type": "object",
-      "required": [
-        "type",
-        "flows"
-      ],
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": [
-            "oauth2"
-          ]
-        },
-        "description": {
-          "type": "string"
-        },
-        "flows": {
-          "type": "object",
-          "properties": {
-            "implicit": {
-              "allOf": [
-                {
-                  "$ref": "#/definitions/oauth2Flow"
-                },
-                {
-                  "required": [
-                    "authorizationUrl",
-                    "scopes"
-                  ]
-                },
-                {
-                  "not": {
-                    "required": [
-                      "tokenUrl"
-                    ]
-                  }
-                }
-              ]
+        "tags": {
+            "type": "array",
+            "items": {
+                "$ref": "http://asyncapi.com/definitions/2.4.0/tag.json"
             },
-            "password": {
-              "allOf": [
-                {
-                  "$ref": "#/definitions/oauth2Flow"
-                },
-                {
-                  "required": [
-                    "tokenUrl",
-                    "scopes"
-                  ]
-                },
-                {
-                  "not": {
-                    "required": [
-                      "authorizationUrl"
-                    ]
-                  }
+            "uniqueItems": true
+        },
+        "externalDocs": {
+            "$ref": "http://asyncapi.com/definitions/2.4.0/externalDocs.json"
+        }
+    },
+    "definitions": {
+        "http://asyncapi.com/definitions/2.4.0/specificationExtension.json": {
+            "$id": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json",
+            "description": "Any property starting with x- is valid.",
+            "additionalProperties": true,
+            "additionalItems": true
+        },
+        "http://asyncapi.com/definitions/2.4.0/info.json": {
+            "$id": "http://asyncapi.com/definitions/2.4.0/info.json",
+            "type": "object",
+            "description": "General information about the API.",
+            "required": [
+                "version",
+                "title"
+            ],
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
                 }
-              ]
             },
-            "clientCredentials": {
-              "allOf": [
-                {
-                  "$ref": "#/definitions/oauth2Flow"
+            "properties": {
+                "title": {
+                    "type": "string",
+                    "description": "A unique and precise title of the API."
                 },
-                {
-                  "required": [
-                    "tokenUrl",
-                    "scopes"
-                  ]
+                "version": {
+                    "type": "string",
+                    "description": "A semantic version number of the API."
                 },
-                {
-                  "not": {
-                    "required": [
-                      "authorizationUrl"
-                    ]
-                  }
+                "description": {
+                    "type": "string",
+                    "description": "A longer description of the API. Should be different from the title. CommonMark is allowed."
+                },
+                "termsOfService": {
+                    "type": "string",
+                    "description": "A URL to the Terms of Service for the API. MUST be in the format of a URL.",
+                    "format": "uri"
+                },
+                "contact": {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/contact.json"
+                },
+                "license": {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/license.json"
                 }
-              ]
-            },
-            "authorizationCode": {
-              "allOf": [
-                {
-                  "$ref": "#/definitions/oauth2Flow"
-                },
-                {
-                  "required": [
-                    "authorizationUrl",
-                    "tokenUrl",
-                    "scopes"
-                  ]
-                }
-              ]
             }
-          },
-          "additionalProperties": false
+        },
+        "http://asyncapi.com/definitions/2.4.0/contact.json": {
+            "$id": "http://asyncapi.com/definitions/2.4.0/contact.json",
+            "type": "object",
+            "description": "Contact information for the owners of the API.",
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "The identifying name of the contact person/organization."
+                },
+                "url": {
+                    "type": "string",
+                    "description": "The URL pointing to the contact information.",
+                    "format": "uri"
+                },
+                "email": {
+                    "type": "string",
+                    "description": "The email address of the contact person/organization.",
+                    "format": "email"
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+                }
+            }
+        },
+        "http://asyncapi.com/definitions/2.4.0/license.json": {
+            "$id": "http://asyncapi.com/definitions/2.4.0/license.json",
+            "type": "object",
+            "required": [
+                "name"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "The name of the license type. It's encouraged to use an OSI compatible license."
+                },
+                "url": {
+                    "type": "string",
+                    "description": "The URL pointing to the license.",
+                    "format": "uri"
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+                }
+            }
+        },
+        "http://asyncapi.com/definitions/2.4.0/servers.json": {
+            "$id": "http://asyncapi.com/definitions/2.4.0/servers.json",
+            "description": "An object representing multiple servers.",
+            "type": "object",
+            "additionalProperties": {
+                "oneOf": [
+                    {
+                        "$ref": "http://asyncapi.com/definitions/2.4.0/Reference.json"
+                    },
+                    {
+                        "$ref": "http://asyncapi.com/definitions/2.4.0/server.json"
+                    }
+                ]
+            }
+        },
+        "http://asyncapi.com/definitions/2.4.0/Reference.json": {
+            "$id": "http://asyncapi.com/definitions/2.4.0/Reference.json",
+            "type": "object",
+            "required": [
+                "$ref"
+            ],
+            "properties": {
+                "$ref": {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/ReferenceObject.json"
+                }
+            }
+        },
+        "http://asyncapi.com/definitions/2.4.0/ReferenceObject.json": {
+            "$id": "http://asyncapi.com/definitions/2.4.0/ReferenceObject.json",
+            "type": "string",
+            "format": "uri-reference"
+        },
+        "http://asyncapi.com/definitions/2.4.0/server.json": {
+            "$id": "http://asyncapi.com/definitions/2.4.0/server.json",
+            "type": "object",
+            "description": "An object representing a Server.",
+            "required": [
+                "url",
+                "protocol"
+            ],
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "url": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "protocol": {
+                    "type": "string",
+                    "description": "The transfer protocol."
+                },
+                "protocolVersion": {
+                    "type": "string"
+                },
+                "variables": {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/serverVariables.json"
+                },
+                "security": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "http://asyncapi.com/definitions/2.4.0/SecurityRequirement.json"
+                    }
+                },
+                "bindings": {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/bindingsObject.json"
+                }
+            }
+        },
+        "http://asyncapi.com/definitions/2.4.0/serverVariables.json": {
+            "$id": "http://asyncapi.com/definitions/2.4.0/serverVariables.json",
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "http://asyncapi.com/definitions/2.4.0/serverVariable.json"
+            }
+        },
+        "http://asyncapi.com/definitions/2.4.0/serverVariable.json": {
+            "$id": "http://asyncapi.com/definitions/2.4.0/serverVariable.json",
+            "type": "object",
+            "description": "An object representing a Server Variable for server URL template substitution.",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "enum": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "uniqueItems": true
+                },
+                "default": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "examples": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "http://asyncapi.com/definitions/2.4.0/SecurityRequirement.json": {
+            "$id": "http://asyncapi.com/definitions/2.4.0/SecurityRequirement.json",
+            "type": "object",
+            "additionalProperties": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                },
+                "uniqueItems": true
+            }
+        },
+        "http://asyncapi.com/definitions/2.4.0/bindingsObject.json": {
+            "$id": "http://asyncapi.com/definitions/2.4.0/bindingsObject.json",
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+                "http": {},
+                "ws": {},
+                "amqp": {},
+                "amqp1": {},
+                "mqtt": {},
+                "mqtt5": {},
+                "kafka": {},
+                "anypointmq": {},
+                "nats": {},
+                "jms": {},
+                "sns": {},
+                "sqs": {},
+                "stomp": {},
+                "redis": {},
+                "ibmmq": {},
+                "solace": {}
+            }
+        },
+        "http://asyncapi.com/definitions/2.4.0/channels.json": {
+            "$id": "http://asyncapi.com/definitions/2.4.0/channels.json",
+            "type": "object",
+            "propertyNames": {
+                "type": "string",
+                "format": "uri-template",
+                "minLength": 1
+            },
+            "additionalProperties": {
+                "$ref": "http://asyncapi.com/definitions/2.4.0/channelItem.json"
+            }
+        },
+        "http://asyncapi.com/definitions/2.4.0/channelItem.json": {
+            "$id": "http://asyncapi.com/definitions/2.4.0/channelItem.json",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "$ref": {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/ReferenceObject.json"
+                },
+                "parameters": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "http://asyncapi.com/definitions/2.4.0/parameter.json"
+                    }
+                },
+                "description": {
+                    "type": "string",
+                    "description": "A description of the channel."
+                },
+                "servers": {
+                    "type": "array",
+                    "description": "The names of the servers on which this channel is available. If absent or empty then this channel must be available on all servers.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "uniqueItems": true
+                },
+                "publish": {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/operation.json"
+                },
+                "subscribe": {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/operation.json"
+                },
+                "deprecated": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "bindings": {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/bindingsObject.json"
+                }
+            }
+        },
+        "http://asyncapi.com/definitions/2.4.0/parameter.json": {
+            "$id": "http://asyncapi.com/definitions/2.4.0/parameter.json",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "description": {
+                    "type": "string",
+                    "description": "A brief description of the parameter. This could contain examples of use. GitHub Flavored Markdown is allowed."
+                },
+                "schema": {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/schema.json"
+                },
+                "location": {
+                    "type": "string",
+                    "description": "A runtime expression that specifies the location of the parameter value",
+                    "pattern": "^\\$message\\.(header|payload)#(\\/(([^\\/~])|(~[01]))*)*"
+                },
+                "$ref": {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/ReferenceObject.json"
+                }
+            }
+        },
+        "http://asyncapi.com/definitions/2.4.0/schema.json": {
+            "$id": "http://asyncapi.com/definitions/2.4.0/schema.json",
+            "allOf": [
+                {
+                    "$ref": "http://json-schema.org/draft-07/schema#"
+                },
+                {
+                    "patternProperties": {
+                        "^x-[\\w\\d\\.\\x2d_]+$": {
+                            "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+                        }
+                    },
+                    "properties": {
+                        "additionalProperties": {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/2.4.0/schema.json"
+                                },
+                                {
+                                    "type": "boolean"
+                                }
+                            ],
+                            "default": {}
+                        },
+                        "items": {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/2.4.0/schema.json"
+                                },
+                                {
+                                    "type": "array",
+                                    "minItems": 1,
+                                    "items": {
+                                        "$ref": "http://asyncapi.com/definitions/2.4.0/schema.json"
+                                    }
+                                }
+                            ],
+                            "default": {}
+                        },
+                        "allOf": {
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                                "$ref": "http://asyncapi.com/definitions/2.4.0/schema.json"
+                            }
+                        },
+                        "oneOf": {
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                                "$ref": "http://asyncapi.com/definitions/2.4.0/schema.json"
+                            }
+                        },
+                        "anyOf": {
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                                "$ref": "http://asyncapi.com/definitions/2.4.0/schema.json"
+                            }
+                        },
+                        "not": {
+                            "$ref": "http://asyncapi.com/definitions/2.4.0/schema.json"
+                        },
+                        "properties": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "$ref": "http://asyncapi.com/definitions/2.4.0/schema.json"
+                            },
+                            "default": {}
+                        },
+                        "patternProperties": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "$ref": "http://asyncapi.com/definitions/2.4.0/schema.json"
+                            },
+                            "default": {}
+                        },
+                        "propertyNames": {
+                            "$ref": "http://asyncapi.com/definitions/2.4.0/schema.json"
+                        },
+                        "contains": {
+                            "$ref": "http://asyncapi.com/definitions/2.4.0/schema.json"
+                        },
+                        "discriminator": {
+                            "type": "string"
+                        },
+                        "externalDocs": {
+                            "$ref": "http://asyncapi.com/definitions/2.4.0/externalDocs.json"
+                        },
+                        "deprecated": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    }
+                }
+            ]
+        },
+        "http://json-schema.org/draft-07/schema": {
+            "$id": "http://json-schema.org/draft-07/schema",
+            "title": "Core schema meta-schema",
+            "definitions": {
+                "schemaArray": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "#"
+                    }
+                },
+                "nonNegativeInteger": {
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "nonNegativeIntegerDefault0": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/nonNegativeInteger"
+                        },
+                        {
+                            "default": 0
+                        }
+                    ]
+                },
+                "simpleTypes": {
+                    "enum": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "null",
+                        "number",
+                        "object",
+                        "string"
+                    ]
+                },
+                "stringArray": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "uniqueItems": true,
+                    "default": []
+                }
+            },
+            "type": [
+                "object",
+                "boolean"
+            ],
+            "properties": {
+                "$id": {
+                    "type": "string",
+                    "format": "uri-reference"
+                },
+                "$schema": {
+                    "type": "string",
+                    "format": "uri"
+                },
+                "$ref": {
+                    "type": "string",
+                    "format": "uri-reference"
+                },
+                "$comment": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "default": true,
+                "readOnly": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "writeOnly": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "examples": {
+                    "type": "array",
+                    "items": true
+                },
+                "multipleOf": {
+                    "type": "number",
+                    "exclusiveMinimum": 0
+                },
+                "maximum": {
+                    "type": "number"
+                },
+                "exclusiveMaximum": {
+                    "type": "number"
+                },
+                "minimum": {
+                    "type": "number"
+                },
+                "exclusiveMinimum": {
+                    "type": "number"
+                },
+                "maxLength": {
+                    "$ref": "#/definitions/nonNegativeInteger"
+                },
+                "minLength": {
+                    "$ref": "#/definitions/nonNegativeIntegerDefault0"
+                },
+                "pattern": {
+                    "type": "string",
+                    "format": "regex"
+                },
+                "additionalItems": {
+                    "$ref": "#"
+                },
+                "items": {
+                    "anyOf": [
+                        {
+                            "$ref": "#"
+                        },
+                        {
+                            "$ref": "#/definitions/schemaArray"
+                        }
+                    ],
+                    "default": true
+                },
+                "maxItems": {
+                    "$ref": "#/definitions/nonNegativeInteger"
+                },
+                "minItems": {
+                    "$ref": "#/definitions/nonNegativeIntegerDefault0"
+                },
+                "uniqueItems": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "contains": {
+                    "$ref": "#"
+                },
+                "maxProperties": {
+                    "$ref": "#/definitions/nonNegativeInteger"
+                },
+                "minProperties": {
+                    "$ref": "#/definitions/nonNegativeIntegerDefault0"
+                },
+                "required": {
+                    "$ref": "#/definitions/stringArray"
+                },
+                "additionalProperties": {
+                    "$ref": "#"
+                },
+                "definitions": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#"
+                    },
+                    "default": {}
+                },
+                "properties": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#"
+                    },
+                    "default": {}
+                },
+                "patternProperties": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#"
+                    },
+                    "propertyNames": {
+                        "format": "regex"
+                    },
+                    "default": {}
+                },
+                "dependencies": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "anyOf": [
+                            {
+                                "$ref": "#"
+                            },
+                            {
+                                "$ref": "#/definitions/stringArray"
+                            }
+                        ]
+                    }
+                },
+                "propertyNames": {
+                    "$ref": "#"
+                },
+                "const": true,
+                "enum": {
+                    "type": "array",
+                    "items": true,
+                    "minItems": 1,
+                    "uniqueItems": true
+                },
+                "type": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/simpleTypes"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/simpleTypes"
+                            },
+                            "minItems": 1,
+                            "uniqueItems": true
+                        }
+                    ]
+                },
+                "format": {
+                    "type": "string"
+                },
+                "contentMediaType": {
+                    "type": "string"
+                },
+                "contentEncoding": {
+                    "type": "string"
+                },
+                "if": {
+                    "$ref": "#"
+                },
+                "then": {
+                    "$ref": "#"
+                },
+                "else": {
+                    "$ref": "#"
+                },
+                "allOf": {
+                    "$ref": "#/definitions/schemaArray"
+                },
+                "anyOf": {
+                    "$ref": "#/definitions/schemaArray"
+                },
+                "oneOf": {
+                    "$ref": "#/definitions/schemaArray"
+                },
+                "not": {
+                    "$ref": "#"
+                }
+            },
+            "default": true
+        },
+        "http://asyncapi.com/definitions/2.4.0/externalDocs.json": {
+            "$id": "http://asyncapi.com/definitions/2.4.0/externalDocs.json",
+            "type": "object",
+            "additionalProperties": false,
+            "description": "information about external documentation",
+            "required": [
+                "url"
+            ],
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string",
+                    "format": "uri"
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+                }
+            }
+        },
+        "http://asyncapi.com/definitions/2.4.0/operation.json": {
+            "$id": "http://asyncapi.com/definitions/2.4.0/operation.json",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "traits": {
+                    "type": "array",
+                    "items": {
+                        "oneOf": [
+                            {
+                                "$ref": "http://asyncapi.com/definitions/2.4.0/Reference.json"
+                            },
+                            {
+                                "$ref": "http://asyncapi.com/definitions/2.4.0/operationTrait.json"
+                            },
+                            {
+                                "type": "array",
+                                "items": [
+                                    {
+                                        "oneOf": [
+                                            {
+                                                "$ref": "http://asyncapi.com/definitions/2.4.0/Reference.json"
+                                            },
+                                            {
+                                                "$ref": "http://asyncapi.com/definitions/2.4.0/operationTrait.json"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "type": "object",
+                                        "additionalItems": true
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "summary": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "security": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "http://asyncapi.com/definitions/2.4.0/SecurityRequirement.json"
+                    }
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "http://asyncapi.com/definitions/2.4.0/tag.json"
+                    },
+                    "uniqueItems": true
+                },
+                "externalDocs": {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/externalDocs.json"
+                },
+                "operationId": {
+                    "type": "string"
+                },
+                "bindings": {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/bindingsObject.json"
+                },
+                "message": {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/message.json"
+                }
+            }
+        },
+        "http://asyncapi.com/definitions/2.4.0/operationTrait.json": {
+            "$id": "http://asyncapi.com/definitions/2.4.0/operationTrait.json",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "summary": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "http://asyncapi.com/definitions/2.4.0/tag.json"
+                    },
+                    "uniqueItems": true
+                },
+                "externalDocs": {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/externalDocs.json"
+                },
+                "operationId": {
+                    "type": "string"
+                },
+                "security": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "http://asyncapi.com/definitions/2.4.0/SecurityRequirement.json"
+                    }
+                },
+                "bindings": {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/bindingsObject.json"
+                }
+            }
+        },
+        "http://asyncapi.com/definitions/2.4.0/tag.json": {
+            "$id": "http://asyncapi.com/definitions/2.4.0/tag.json",
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "name"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "externalDocs": {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/externalDocs.json"
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+                }
+            }
+        },
+        "http://asyncapi.com/definitions/2.4.0/message.json": {
+            "$id": "http://asyncapi.com/definitions/2.4.0/message.json",
+            "oneOf": [
+                {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/Reference.json"
+                },
+                {
+                    "oneOf": [
+                        {
+                            "type": "object",
+                            "required": [
+                                "oneOf"
+                            ],
+                            "additionalProperties": false,
+                            "properties": {
+                                "oneOf": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "http://asyncapi.com/definitions/2.4.0/message.json"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "patternProperties": {
+                                "^x-[\\w\\d\\.\\x2d_]+$": {
+                                    "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+                                }
+                            },
+                            "properties": {
+                                "schemaFormat": {
+                                    "type": "string"
+                                },
+                                "contentType": {
+                                    "type": "string"
+                                },
+                                "headers": {
+                                    "allOf": [
+                                        {
+                                            "$ref": "http://asyncapi.com/definitions/2.4.0/schema.json"
+                                        },
+                                        {
+                                            "properties": {
+                                                "type": {
+                                                    "const": "object"
+                                                }
+                                            }
+                                        }
+                                    ]
+                                },
+                                "messageId": {
+                                    "type": "string"
+                                },
+                                "payload": {},
+                                "correlationId": {
+                                    "oneOf": [
+                                        {
+                                            "$ref": "http://asyncapi.com/definitions/2.4.0/Reference.json"
+                                        },
+                                        {
+                                            "$ref": "http://asyncapi.com/definitions/2.4.0/correlationId.json"
+                                        }
+                                    ]
+                                },
+                                "tags": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "http://asyncapi.com/definitions/2.4.0/tag.json"
+                                    },
+                                    "uniqueItems": true
+                                },
+                                "summary": {
+                                    "type": "string",
+                                    "description": "A brief summary of the message."
+                                },
+                                "name": {
+                                    "type": "string",
+                                    "description": "Name of the message."
+                                },
+                                "title": {
+                                    "type": "string",
+                                    "description": "A human-friendly title for the message."
+                                },
+                                "description": {
+                                    "type": "string",
+                                    "description": "A longer description of the message. CommonMark is allowed."
+                                },
+                                "externalDocs": {
+                                    "$ref": "http://asyncapi.com/definitions/2.4.0/externalDocs.json"
+                                },
+                                "deprecated": {
+                                    "type": "boolean",
+                                    "default": false
+                                },
+                                "examples": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "additionalProperties": false,
+                                        "anyOf": [
+                                            {
+                                                "required": [
+                                                    "payload"
+                                                ]
+                                            },
+                                            {
+                                                "required": [
+                                                    "headers"
+                                                ]
+                                            }
+                                        ],
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "Machine readable name of the message example."
+                                            },
+                                            "summary": {
+                                                "type": "string",
+                                                "description": "A brief summary of the message example."
+                                            },
+                                            "headers": {
+                                                "type": "object"
+                                            },
+                                            "payload": {}
+                                        }
+                                    }
+                                },
+                                "bindings": {
+                                    "$ref": "http://asyncapi.com/definitions/2.4.0/bindingsObject.json"
+                                },
+                                "traits": {
+                                    "type": "array",
+                                    "items": {
+                                        "oneOf": [
+                                            {
+                                                "$ref": "http://asyncapi.com/definitions/2.4.0/Reference.json"
+                                            },
+                                            {
+                                                "$ref": "http://asyncapi.com/definitions/2.4.0/messageTrait.json"
+                                            },
+                                            {
+                                                "type": "array",
+                                                "items": [
+                                                    {
+                                                        "oneOf": [
+                                                            {
+                                                                "$ref": "http://asyncapi.com/definitions/2.4.0/Reference.json"
+                                                            },
+                                                            {
+                                                                "$ref": "http://asyncapi.com/definitions/2.4.0/messageTrait.json"
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "type": "object",
+                                                        "additionalItems": true
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/2.4.0/correlationId.json": {
+            "$id": "http://asyncapi.com/definitions/2.4.0/correlationId.json",
+            "type": "object",
+            "required": [
+                "location"
+            ],
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "description": {
+                    "type": "string",
+                    "description": "A optional description of the correlation ID. GitHub Flavored Markdown is allowed."
+                },
+                "location": {
+                    "type": "string",
+                    "description": "A runtime expression that specifies the location of the correlation ID",
+                    "pattern": "^\\$message\\.(header|payload)#(\\/(([^\\/~])|(~[01]))*)*"
+                }
+            }
+        },
+        "http://asyncapi.com/definitions/2.4.0/messageTrait.json": {
+            "$id": "http://asyncapi.com/definitions/2.4.0/messageTrait.json",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "schemaFormat": {
+                    "type": "string"
+                },
+                "contentType": {
+                    "type": "string"
+                },
+                "headers": {
+                    "allOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/2.4.0/schema.json"
+                        },
+                        {
+                            "properties": {
+                                "type": {
+                                    "const": "object"
+                                }
+                            }
+                        }
+                    ]
+                },
+                "messageId": {
+                    "type": "string"
+                },
+                "correlationId": {
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/2.4.0/Reference.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/2.4.0/correlationId.json"
+                        }
+                    ]
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "http://asyncapi.com/definitions/2.4.0/tag.json"
+                    },
+                    "uniqueItems": true
+                },
+                "summary": {
+                    "type": "string",
+                    "description": "A brief summary of the message."
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Name of the message."
+                },
+                "title": {
+                    "type": "string",
+                    "description": "A human-friendly title for the message."
+                },
+                "description": {
+                    "type": "string",
+                    "description": "A longer description of the message. CommonMark is allowed."
+                },
+                "externalDocs": {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/externalDocs.json"
+                },
+                "deprecated": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "examples": {
+                    "type": "array",
+                    "items": {
+                        "type": "object"
+                    }
+                },
+                "bindings": {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/bindingsObject.json"
+                }
+            }
+        },
+        "http://asyncapi.com/definitions/2.4.0/components.json": {
+            "$id": "http://asyncapi.com/definitions/2.4.0/components.json",
+            "type": "object",
+            "description": "An object to hold a set of reusable objects for different aspects of the AsyncAPI Specification.",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "schemas": {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/schemas.json"
+                },
+                "servers": {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/servers.json"
+                },
+                "channels": {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/channels.json"
+                },
+                "serverVariables": {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/serverVariables.json"
+                },
+                "messages": {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/messages.json"
+                },
+                "securitySchemes": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^[\\w\\d\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/2.4.0/Reference.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/2.4.0/SecurityScheme.json"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "parameters": {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/parameters.json"
+                },
+                "correlationIds": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^[\\w\\d\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/2.4.0/Reference.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/2.4.0/correlationId.json"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "operationTraits": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "http://asyncapi.com/definitions/2.4.0/operationTrait.json"
+                    }
+                },
+                "messageTraits": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "http://asyncapi.com/definitions/2.4.0/messageTrait.json"
+                    }
+                },
+                "serverBindings": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "http://asyncapi.com/definitions/2.4.0/bindingsObject.json"
+                    }
+                },
+                "channelBindings": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "http://asyncapi.com/definitions/2.4.0/bindingsObject.json"
+                    }
+                },
+                "operationBindings": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "http://asyncapi.com/definitions/2.4.0/bindingsObject.json"
+                    }
+                },
+                "messageBindings": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "http://asyncapi.com/definitions/2.4.0/bindingsObject.json"
+                    }
+                }
+            }
+        },
+        "http://asyncapi.com/definitions/2.4.0/schemas.json": {
+            "$id": "http://asyncapi.com/definitions/2.4.0/schemas.json",
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "http://asyncapi.com/definitions/2.4.0/schema.json"
+            },
+            "description": "JSON objects describing schemas the API uses."
+        },
+        "http://asyncapi.com/definitions/2.4.0/messages.json": {
+            "$id": "http://asyncapi.com/definitions/2.4.0/messages.json",
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "http://asyncapi.com/definitions/2.4.0/message.json"
+            },
+            "description": "JSON objects describing the messages being consumed and produced by the API."
+        },
+        "http://asyncapi.com/definitions/2.4.0/SecurityScheme.json": {
+            "$id": "http://asyncapi.com/definitions/2.4.0/SecurityScheme.json",
+            "oneOf": [
+                {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/userPassword.json"
+                },
+                {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/apiKey.json"
+                },
+                {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/X509.json"
+                },
+                {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/symmetricEncryption.json"
+                },
+                {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/asymmetricEncryption.json"
+                },
+                {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/HTTPSecurityScheme.json"
+                },
+                {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/oauth2Flows.json"
+                },
+                {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/openIdConnect.json"
+                },
+                {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/SaslSecurityScheme.json"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/2.4.0/userPassword.json": {
+            "$id": "http://asyncapi.com/definitions/2.4.0/userPassword.json",
+            "type": "object",
+            "required": [
+                "type"
+            ],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "userPassword"
+                    ]
+                },
+                "description": {
+                    "type": "string"
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false
+        },
+        "http://asyncapi.com/definitions/2.4.0/apiKey.json": {
+            "$id": "http://asyncapi.com/definitions/2.4.0/apiKey.json",
+            "type": "object",
+            "required": [
+                "type",
+                "in"
+            ],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "apiKey"
+                    ]
+                },
+                "in": {
+                    "type": "string",
+                    "enum": [
+                        "user",
+                        "password"
+                    ]
+                },
+                "description": {
+                    "type": "string"
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false
+        },
+        "http://asyncapi.com/definitions/2.4.0/X509.json": {
+            "$id": "http://asyncapi.com/definitions/2.4.0/X509.json",
+            "type": "object",
+            "required": [
+                "type"
+            ],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "X509"
+                    ]
+                },
+                "description": {
+                    "type": "string"
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false
+        },
+        "http://asyncapi.com/definitions/2.4.0/symmetricEncryption.json": {
+            "$id": "http://asyncapi.com/definitions/2.4.0/symmetricEncryption.json",
+            "type": "object",
+            "required": [
+                "type"
+            ],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "symmetricEncryption"
+                    ]
+                },
+                "description": {
+                    "type": "string"
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false
+        },
+        "http://asyncapi.com/definitions/2.4.0/asymmetricEncryption.json": {
+            "$id": "http://asyncapi.com/definitions/2.4.0/asymmetricEncryption.json",
+            "type": "object",
+            "required": [
+                "type"
+            ],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "asymmetricEncryption"
+                    ]
+                },
+                "description": {
+                    "type": "string"
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false
+        },
+        "http://asyncapi.com/definitions/2.4.0/HTTPSecurityScheme.json": {
+            "$id": "http://asyncapi.com/definitions/2.4.0/HTTPSecurityScheme.json",
+            "oneOf": [
+                {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/NonBearerHTTPSecurityScheme.json"
+                },
+                {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/BearerHTTPSecurityScheme.json"
+                },
+                {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/APIKeyHTTPSecurityScheme.json"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/2.4.0/NonBearerHTTPSecurityScheme.json": {
+            "$id": "http://asyncapi.com/definitions/2.4.0/NonBearerHTTPSecurityScheme.json",
+            "not": {
+                "type": "object",
+                "properties": {
+                    "scheme": {
+                        "type": "string",
+                        "enum": [
+                            "bearer"
+                        ]
+                    }
+                }
+            },
+            "type": "object",
+            "required": [
+                "scheme",
+                "type"
+            ],
+            "properties": {
+                "scheme": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "http"
+                    ]
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false
+        },
+        "http://asyncapi.com/definitions/2.4.0/BearerHTTPSecurityScheme.json": {
+            "$id": "http://asyncapi.com/definitions/2.4.0/BearerHTTPSecurityScheme.json",
+            "type": "object",
+            "required": [
+                "type",
+                "scheme"
+            ],
+            "properties": {
+                "scheme": {
+                    "type": "string",
+                    "enum": [
+                        "bearer"
+                    ]
+                },
+                "bearerFormat": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "http"
+                    ]
+                },
+                "description": {
+                    "type": "string"
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false
+        },
+        "http://asyncapi.com/definitions/2.4.0/APIKeyHTTPSecurityScheme.json": {
+            "$id": "http://asyncapi.com/definitions/2.4.0/APIKeyHTTPSecurityScheme.json",
+            "type": "object",
+            "required": [
+                "type",
+                "name",
+                "in"
+            ],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "httpApiKey"
+                    ]
+                },
+                "name": {
+                    "type": "string"
+                },
+                "in": {
+                    "type": "string",
+                    "enum": [
+                        "header",
+                        "query",
+                        "cookie"
+                    ]
+                },
+                "description": {
+                    "type": "string"
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false
+        },
+        "http://asyncapi.com/definitions/2.4.0/oauth2Flows.json": {
+            "$id": "http://asyncapi.com/definitions/2.4.0/oauth2Flows.json",
+            "type": "object",
+            "required": [
+                "type",
+                "flows"
+            ],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "oauth2"
+                    ]
+                },
+                "description": {
+                    "type": "string"
+                },
+                "flows": {
+                    "type": "object",
+                    "properties": {
+                        "implicit": {
+                            "allOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/2.4.0/oauth2Flow.json"
+                                },
+                                {
+                                    "required": [
+                                        "authorizationUrl",
+                                        "scopes"
+                                    ]
+                                },
+                                {
+                                    "not": {
+                                        "required": [
+                                            "tokenUrl"
+                                        ]
+                                    }
+                                }
+                            ]
+                        },
+                        "password": {
+                            "allOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/2.4.0/oauth2Flow.json"
+                                },
+                                {
+                                    "required": [
+                                        "tokenUrl",
+                                        "scopes"
+                                    ]
+                                },
+                                {
+                                    "not": {
+                                        "required": [
+                                            "authorizationUrl"
+                                        ]
+                                    }
+                                }
+                            ]
+                        },
+                        "clientCredentials": {
+                            "allOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/2.4.0/oauth2Flow.json"
+                                },
+                                {
+                                    "required": [
+                                        "tokenUrl",
+                                        "scopes"
+                                    ]
+                                },
+                                {
+                                    "not": {
+                                        "required": [
+                                            "authorizationUrl"
+                                        ]
+                                    }
+                                }
+                            ]
+                        },
+                        "authorizationCode": {
+                            "allOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/2.4.0/oauth2Flow.json"
+                                },
+                                {
+                                    "required": [
+                                        "authorizationUrl",
+                                        "tokenUrl",
+                                        "scopes"
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+                }
+            }
+        },
+        "http://asyncapi.com/definitions/2.4.0/oauth2Flow.json": {
+            "$id": "http://asyncapi.com/definitions/2.4.0/oauth2Flow.json",
+            "type": "object",
+            "properties": {
+                "authorizationUrl": {
+                    "type": "string",
+                    "format": "uri"
+                },
+                "tokenUrl": {
+                    "type": "string",
+                    "format": "uri"
+                },
+                "refreshUrl": {
+                    "type": "string",
+                    "format": "uri"
+                },
+                "scopes": {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/oauth2Scopes.json"
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false
+        },
+        "http://asyncapi.com/definitions/2.4.0/oauth2Scopes.json": {
+            "$id": "http://asyncapi.com/definitions/2.4.0/oauth2Scopes.json",
+            "type": "object",
+            "additionalProperties": {
+                "type": "string"
+            }
+        },
+        "http://asyncapi.com/definitions/2.4.0/openIdConnect.json": {
+            "$id": "http://asyncapi.com/definitions/2.4.0/openIdConnect.json",
+            "type": "object",
+            "required": [
+                "type",
+                "openIdConnectUrl"
+            ],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "openIdConnect"
+                    ]
+                },
+                "description": {
+                    "type": "string"
+                },
+                "openIdConnectUrl": {
+                    "type": "string",
+                    "format": "uri"
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false
+        },
+        "http://asyncapi.com/definitions/2.4.0/SaslSecurityScheme.json": {
+            "$id": "http://asyncapi.com/definitions/2.4.0/SaslSecurityScheme.json",
+            "oneOf": [
+                {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/SaslPlainSecurityScheme.json"
+                },
+                {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/SaslScramSecurityScheme.json"
+                },
+                {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/SaslGssapiSecurityScheme.json"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/2.4.0/SaslPlainSecurityScheme.json": {
+            "$id": "http://asyncapi.com/definitions/2.4.0/SaslPlainSecurityScheme.json",
+            "type": "object",
+            "required": [
+                "type"
+            ],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "plain"
+                    ]
+                },
+                "description": {
+                    "type": "string"
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false
+        },
+        "http://asyncapi.com/definitions/2.4.0/SaslScramSecurityScheme.json": {
+            "$id": "http://asyncapi.com/definitions/2.4.0/SaslScramSecurityScheme.json",
+            "type": "object",
+            "required": [
+                "type"
+            ],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "scramSha256",
+                        "scramSha512"
+                    ]
+                },
+                "description": {
+                    "type": "string"
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false
+        },
+        "http://asyncapi.com/definitions/2.4.0/SaslGssapiSecurityScheme.json": {
+            "$id": "http://asyncapi.com/definitions/2.4.0/SaslGssapiSecurityScheme.json",
+            "type": "object",
+            "required": [
+                "type"
+            ],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "gssapi"
+                    ]
+                },
+                "description": {
+                    "type": "string"
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false
+        },
+        "http://asyncapi.com/definitions/2.4.0/parameters.json": {
+            "$id": "http://asyncapi.com/definitions/2.4.0/parameters.json",
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "http://asyncapi.com/definitions/2.4.0/parameter.json"
+            },
+            "description": "JSON objects describing re-usable channel parameters."
         }
-      },
-      "patternProperties": {
-        "^x-[\\w\\d\\.\\x2d_]+$": {
-          "$ref": "#/definitions/specificationExtension"
-        }
-      }
     },
-    "oauth2Flow": {
-      "type": "object",
-      "properties": {
-        "authorizationUrl": {
-          "type": "string",
-          "format": "uri"
-        },
-        "tokenUrl": {
-          "type": "string",
-          "format": "uri"
-        },
-        "refreshUrl": {
-          "type": "string",
-          "format": "uri"
-        },
-        "scopes": {
-          "$ref": "#/definitions/oauth2Scopes"
-        }
-      },
-      "patternProperties": {
-        "^x-[\\w\\d\\.\\x2d_]+$": {
-          "$ref": "#/definitions/specificationExtension"
-        }
-      },
-      "additionalProperties": false
-    },
-    "oauth2Scopes": {
-      "type": "object",
-      "additionalProperties": {
-        "type": "string"
-      }
-    },
-    "openIdConnect": {
-      "type": "object",
-      "required": [
-        "type",
-        "openIdConnectUrl"
-      ],
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": [
-            "openIdConnect"
-          ]
-        },
-        "description": {
-          "type": "string"
-        },
-        "openIdConnectUrl": {
-          "type": "string",
-          "format": "uri"
-        }
-      },
-      "patternProperties": {
-        "^x-[\\w\\d\\.\\x2d_]+$": {
-          "$ref": "#/definitions/specificationExtension"
-        }
-      },
-      "additionalProperties": false
-    },
-    "SecurityRequirement": {
-      "type": "object",
-      "additionalProperties": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        },
-        "uniqueItems": true
-      }
-    }
-  }
+    "description": "!!Auto generated!! \n Do not manually edit. "
 }


### PR DESCRIPTION
**Description**
This PR  primarily adds the new 2.4 schemas as split-out definitions.

Furthermore, the following changes are applied:
- Update with the latest master branch
- Fix an issue where one change in the components section for 2.3 was not applied

**Related issue(s)**
Related to https://github.com/asyncapi/spec-json-schemas/pull/184