### PR TITLE
feat: add specific binding schemas

### DIFF
--- a/definitions/3.0.0/channelBindingsObject.json
+++ b/definitions/3.0.0/channelBindingsObject.json
@@ -1,6 +1,11 @@
 {
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "patternProperties": {
+    "^x-[\\w\\d\\.\\-\\_]+$": {
+      "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+    }
+  },
   "properties": {
     "http": {},
     "ws": {},
@@ -20,5 +25,5 @@
     "solace": {}
   },
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "http://asyncapi.com/definitions/3.0.0/bindingsObject.json"
+  "$id": "http://asyncapi.com/definitions/3.0.0/channelBindingsObject.json"
 }

--- a/definitions/3.0.0/channelItem.json
+++ b/definitions/3.0.0/channelItem.json
@@ -39,7 +39,7 @@
       "default": false
     },
     "bindings": {
-      "$ref": "http://asyncapi.com/definitions/3.0.0/bindingsObject.json"
+      "$ref": "http://asyncapi.com/definitions/3.0.0/channelBindingsObject.json"
     }
   },
   "$schema": "http://json-schema.org/draft-07/schema#",

--- a/definitions/3.0.0/message.json
+++ b/definitions/3.0.0/message.json
@@ -127,7 +127,7 @@
               }
             },
             "bindings": {
-              "$ref": "http://asyncapi.com/definitions/3.0.0/bindingsObject.json"
+              "$ref": "http://asyncapi.com/definitions/3.0.0/messageBindingsObject.json"
             },
             "traits": {
               "type": "array",

--- a/definitions/3.0.0/messageBindingsObject.json
+++ b/definitions/3.0.0/messageBindingsObject.json
@@ -1,0 +1,29 @@
+{
+  "type": "object",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^x-[\\w\\d\\.\\-\\_]+$": {
+      "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+    }
+  },
+  "properties": {
+    "http": {},
+    "ws": {},
+    "amqp": {},
+    "amqp1": {},
+    "mqtt": {},
+    "mqtt5": {},
+    "kafka": {},
+    "anypointmq": {},
+    "nats": {},
+    "jms": {},
+    "sns": {},
+    "sqs": {},
+    "stomp": {},
+    "redis": {},
+    "ibmmq": {},
+    "solace": {}
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/definitions/3.0.0/messageBindingsObject.json"
+}

--- a/definitions/3.0.0/messageTrait.json
+++ b/definitions/3.0.0/messageTrait.json
@@ -77,7 +77,7 @@
       }
     },
     "bindings": {
-      "$ref": "http://asyncapi.com/definitions/3.0.0/bindingsObject.json"
+      "$ref": "http://asyncapi.com/definitions/3.0.0/messageBindingsObject.json"
     }
   },
   "$schema": "http://json-schema.org/draft-07/schema#",

--- a/definitions/3.0.0/operation.json
+++ b/definitions/3.0.0/operation.json
@@ -65,7 +65,7 @@
       "type": "string"
     },
     "bindings": {
-      "$ref": "http://asyncapi.com/definitions/3.0.0/bindingsObject.json"
+      "$ref": "http://asyncapi.com/definitions/3.0.0/operationBindingsObject.json"
     },
     "message": {
       "$ref": "http://asyncapi.com/definitions/3.0.0/message.json"

--- a/definitions/3.0.0/operationBindingsObject.json
+++ b/definitions/3.0.0/operationBindingsObject.json
@@ -1,0 +1,29 @@
+{
+  "type": "object",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^x-[\\w\\d\\.\\-\\_]+$": {
+      "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+    }
+  },
+  "properties": {
+    "http": {},
+    "ws": {},
+    "amqp": {},
+    "amqp1": {},
+    "mqtt": {},
+    "mqtt5": {},
+    "kafka": {},
+    "anypointmq": {},
+    "nats": {},
+    "jms": {},
+    "sns": {},
+    "sqs": {},
+    "stomp": {},
+    "redis": {},
+    "ibmmq": {},
+    "solace": {}
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/definitions/3.0.0/operationBindingsObject.json"
+}

--- a/definitions/3.0.0/operationTrait.json
+++ b/definitions/3.0.0/operationTrait.json
@@ -33,7 +33,7 @@
       }
     },
     "bindings": {
-      "$ref": "http://asyncapi.com/definitions/3.0.0/bindingsObject.json"
+      "$ref": "http://asyncapi.com/definitions/3.0.0/operationBindingsObject.json"
     }
   },
   "$schema": "http://json-schema.org/draft-07/schema#",

--- a/definitions/3.0.0/server.json
+++ b/definitions/3.0.0/server.json
@@ -35,7 +35,7 @@
       }
     },
     "bindings": {
-      "$ref": "http://asyncapi.com/definitions/3.0.0/bindingsObject.json"
+      "$ref": "http://asyncapi.com/definitions/3.0.0/serverBindingsObject.json"
     }
   },
   "$schema": "http://json-schema.org/draft-07/schema#",

--- a/definitions/3.0.0/serverBindingsObject.json
+++ b/definitions/3.0.0/serverBindingsObject.json
@@ -1,0 +1,29 @@
+{
+  "type": "object",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^x-[\\w\\d\\.\\-\\_]+$": {
+      "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+    }
+  },
+  "properties": {
+    "http": {},
+    "ws": {},
+    "amqp": {},
+    "amqp1": {},
+    "mqtt": {},
+    "mqtt5": {},
+    "kafka": {},
+    "anypointmq": {},
+    "nats": {},
+    "jms": {},
+    "sns": {},
+    "sqs": {},
+    "stomp": {},
+    "redis": {},
+    "ibmmq": {},
+    "solace": {}
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/definitions/3.0.0/serverBindingsObject.json"
+}


### PR DESCRIPTION
**Description**
This PR adds 2 changes to the JSON Schema documents.

1. It fixes an issue where we allow all extensions regardless of the use of `x-`, which should not be allowed. Whether we want to propagate this across all versions, not so sure? 🤔  
2. It splits the generic `bindingsObject` into the 4 specific bindings for operation, channel, message, and server.


Related to https://github.com/asyncapi/spec/issues/507
Related to https://github.com/asyncapi/bindings/issues/113