### PR TITLE
docs: explain how JSON Schema files are served

### DIFF
--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1,0 +1,14 @@
+# AsyncAPI JSON Schema definitions
+
+All the JSON Schema documents for validating AsyncAPI documents are located here. 
+
+## Download and usage
+Files are served via `https://asyncapi.com/definitions/<asyncapi-version>.json`, for example, https://asyncapi.com/definitions/2.4.0.json. 
+
+In that way, documents are served with the proper `Content-Type` response header. It also allows us to measure AsyncAPI user adoption of those files ([More info in this Github Issue](https://github.com/asyncapi/website/issues/780)).
+We encourage you to **only** download the files from our website instead of from Github.
+
+### JSON Schema Store
+
+[JSON Schema Store](schemastore.org) is a universal JSON schema store, where schemas for popular JSON documents can be found.  
+AsyncAPI JSON Schema documents are also available in the store, meaning you can use their [plugins for most IDEs](https://www.schemastore.org/json/#editors), adding linting and validation automatically for all your AsyncAPI documents.

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -6,7 +6,7 @@ All the JSON Schema documents for validating AsyncAPI documents are located here
 Files are served via `https://asyncapi.com/definitions/<asyncapi-version>.json`, for example, https://asyncapi.com/definitions/2.4.0.json. 
 
 In that way, documents are served with the proper `Content-Type` response header. It also allows us to measure AsyncAPI user adoption of those files ([More info in this Github Issue](https://github.com/asyncapi/website/issues/780)).
-We encourage you to **only** download the files from our website instead of from Github.
+We encourage you to **only** download the files from our website instead of from GitHub.
 
 ### JSON Schema Store
 

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1,11 +1,11 @@
 # AsyncAPI JSON Schema definitions
 
-All the JSON Schema documents for validating AsyncAPI documents are located here. 
+All the JSON Schema documents for validating AsyncAPI documents are located here in this repository. 
 
 ## Download and usage
 Files are served via `https://asyncapi.com/definitions/<asyncapi-version>.json`, for example, https://asyncapi.com/definitions/2.4.0.json. 
 
-In that way, documents are served with the proper `Content-Type` response header. It also allows us to measure AsyncAPI user adoption of those files ([More info in this Github Issue](https://github.com/asyncapi/website/issues/780)).
+In that way, documents are served with the proper `Content-Type` response header. It also allows us to measure AsyncAPI user adoption of those files ([More info in this GitHub Issue](https://github.com/asyncapi/website/issues/780)).
 We encourage you to **only** download the files from our website instead of from GitHub.
 
 ### JSON Schema Store

--- a/test/index.js
+++ b/test/index.js
@@ -12,7 +12,8 @@ describe('AsyncAPI', () => {
     const files = fs.readdirSync('schemas');
     files.forEach(file => {
       const fileName = path.parse(file).name;
-      
+      if (fileName == "README") return;
+
       const asyncapi = require('..');
       assert(typeof asyncapi[fileName] === 'object', `Returned object does not contain ${fileName}.`);
 


### PR DESCRIPTION
**Description**

This PR adds a `README.md` file under `/schemas` directory so we can explain what's the preferable way for downloading/using AsyncAPI JSON Schema documents.

**Related issue(s)**
https://github.com/asyncapi/website/pull/680#issuecomment-1153700681