### PR TITLE
feat: add schema listing all Schema-Store JSON Schema docs

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 module.exports = {
-  'all.schema-store': require('./schemas/all.schema-store.json'),
   '1.0.0': require('./schemas/1.0.0.json'),
   '1.1.0': require('./schemas/1.1.0.json'),
   '1.2.0': require('./schemas/1.2.0.json'),

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 module.exports = {
+  'all.schema-store': require('./schemas/all.schema-store.json'),
   '1.0.0': require('./schemas/1.0.0.json'),
   '1.1.0': require('./schemas/1.1.0.json'),
   '1.2.0': require('./schemas/1.2.0.json'),

--- a/schemas/all.schema-store.json
+++ b/schemas/all.schema-store.json
@@ -1,0 +1,149 @@
+{
+  "$id": "http://asyncapi.com/schema-store/all.schema-store.json",
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "title": "JSON Schema documents for all AsyncAPI spec versions",
+  "description": "All AsyncAPI JSON Schema documents listed in one file. Needed for serving all documents through schemastore.org",
+  "type": "object",
+  "oneOf": [
+    {
+      "allOf": [
+        {
+          "properties": {
+            "asyncapi": {
+              "const": "1.0.0"
+            }
+          }
+        },
+        {
+          "$ref": "http://asyncapi.com/schema-store/1.0.0.json"
+        }
+      ]
+    },
+    {
+      "allOf": [
+        {
+          "properties": {
+            "asyncapi": {
+              "const": "1.1.0"
+            }
+          }
+        },
+        {
+          "$ref": "http://asyncapi.com/schema-store/1.1.0.json"
+        }
+      ]
+    },
+    {
+      "allOf": [
+        {
+          "properties": {
+            "asyncapi": {
+              "const": "1.2.0"
+            }
+          }
+        },
+        {
+          "$ref": "http://asyncapi.com/schema-store/1.2.0.json"
+        }
+      ]
+    },
+    {
+      "allOf": [
+        {
+          "properties": {
+            "asyncapi": {
+              "const": "2.0.0-rc1"
+            }
+          }
+        },
+        {
+          "$ref": "http://asyncapi.com/schema-store/2.0.0-rc1.json"
+        }
+      ]
+    },
+    {
+      "allOf": [
+        {
+          "properties": {
+            "asyncapi": {
+              "const": "2.0.0-rc2"
+            }
+          }
+        },
+        {
+          "$ref": "http://asyncapi.com/schema-store/2.0.0-rc2.json"
+        }
+      ]
+    },
+    {
+      "allOf": [
+        {
+          "properties": {
+            "asyncapi": {
+              "const": "2.0.0"
+            }
+          }
+        },
+        {
+          "$ref": "http://asyncapi.com/schema-store/2.0.0.json"
+        }
+      ]
+    },
+    {
+      "allOf": [
+        {
+          "properties": {
+            "asyncapi": {
+              "const": "2.1.0"
+            }
+          }
+        },
+        {
+          "$ref": "http://asyncapi.com/schema-store/2.1.0.json"
+        }
+      ]
+    },
+    {
+      "allOf": [
+        {
+          "properties": {
+            "asyncapi": {
+              "const": "2.2.0"
+            }
+          }
+        },
+        {
+          "$ref": "http://asyncapi.com/schema-store/2.2.0.json"
+        }
+      ]
+    },
+    {
+      "allOf": [
+        {
+          "properties": {
+            "asyncapi": {
+              "const": "2.3.0"
+            }
+          }
+        },
+        {
+          "$ref": "http://asyncapi.com/schema-store/2.3.0.json"
+        }
+      ]
+    },
+    {
+      "allOf": [
+        {
+          "properties": {
+            "asyncapi": {
+              "const": "2.4.0"
+            }
+          }
+        },
+        {
+          "$ref": "http://asyncapi.com/schema-store/2.4.0.json"
+        }
+      ]
+    }
+  ]
+}

--- a/test/index.js
+++ b/test/index.js
@@ -9,10 +9,11 @@ describe('AsyncAPI', () => {
   });
 
   it('should check if json schema is exported and if it matches the original file', () => {
+    const skipFiles = ["README", "all.schema-store"];
     const files = fs.readdirSync('schemas');
     files.forEach(file => {
       const fileName = path.parse(file).name;
-      if (fileName == "README") return;
+      if (skipFiles.includes(fileName)) return;
 
       const asyncapi = require('..');
       assert(typeof asyncapi[fileName] === 'object', `Returned object does not contain ${fileName}.`);


### PR DESCRIPTION
**Description**

Partially fixes https://github.com/asyncapi/spec-json-schemas/issues/236, [pending a PR](https://github.com/SchemaStore/schemastore/compare/master...smoya:feat/asyncapiVersions?expand=1) on JSON Schema-Store repository.

This PR adds a new schema file that lists all JSON Schema files for all AsyncAPI spec versions. This is required for [Schema-Store](https://www.schemastore.org/) IDE plugins to support all versions.

**Related issue(s)**
https://github.com/asyncapi/spec-json-schemas/issues/236