### PR TITLE
feat: add binding versions

### DIFF
--- a/bindings/amqp/0.2.0/channel.json
+++ b/bindings/amqp/0.2.0/channel.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "http://asyncapi.com/bindings/amqp/channel.json",
+  "$id": "http://asyncapi.com/bindings/amqp/0.2.0/channel.json",
   "title": "AMQP channel bindings object",
   "description": "This object contains information about the channel representation in AMQP.",
   "type": "object",
@@ -80,7 +80,6 @@
       ],
       "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
     }
-
   },
   "oneOf": [
     {

--- a/bindings/amqp/0.2.0/message.json
+++ b/bindings/amqp/0.2.0/message.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "http://asyncapi.com/bindings/amqp/message.json",
+  "$id": "http://asyncapi.com/bindings/amqp/0.2.0/message.json",
   "title": "AMQP message bindings object",
   "description": "This object contains information about the message representation in AMQP.",
   "type": "object",

--- a/bindings/amqp/0.2.0/operation.json
+++ b/bindings/amqp/0.2.0/operation.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "http://asyncapi.com/bindings/amqp/operation.json",
+  "$id": "http://asyncapi.com/bindings/amqp/0.2.0/operation.json",
   "title": "AMQP operation bindings object",
   "description": "This object contains information about the operation representation in AMQP.",
   "type": "object",

--- a/definitions/3.0.0/channelBindingsObject.json
+++ b/definitions/3.0.0/channelBindingsObject.json
@@ -9,7 +9,13 @@
   "properties": {
     "http": {},
     "ws": {},
-    "amqp": {},
+    "amqp": {
+      "oneOf": [
+        {
+          "$ref": "http://asyncapi.com/bindings/amqp/0.2.0/channel.json"
+        }
+      ]
+    },
     "amqp1": {},
     "mqtt": {},
     "mqtt5": {},

--- a/definitions/3.0.0/components.json
+++ b/definitions/3.0.0/components.json
@@ -71,25 +71,25 @@
     "serverBindings": {
       "type": "object",
       "additionalProperties": {
-        "$ref": "http://asyncapi.com/definitions/3.0.0/bindingsObject.json"
+        "$ref": "http://asyncapi.com/definitions/3.0.0/serverBindingsObject.json"
       }
     },
     "channelBindings": {
       "type": "object",
       "additionalProperties": {
-        "$ref": "http://asyncapi.com/definitions/3.0.0/bindingsObject.json"
+        "$ref": "http://asyncapi.com/definitions/3.0.0/channelBindingsObject.json"
       }
     },
     "operationBindings": {
       "type": "object",
       "additionalProperties": {
-        "$ref": "http://asyncapi.com/definitions/3.0.0/bindingsObject.json"
+        "$ref": "http://asyncapi.com/definitions/3.0.0/operationBindingsObject.json"
       }
     },
     "messageBindings": {
       "type": "object",
       "additionalProperties": {
-        "$ref": "http://asyncapi.com/definitions/3.0.0/bindingsObject.json"
+        "$ref": "http://asyncapi.com/definitions/3.0.0/messageBindingsObject.json"
       }
     }
   },


### PR DESCRIPTION
**Description**
This PR is a suggestion on how to handle binding versions as well as integrate them into the specification.

### Binding versioning
Each binding should now be located as:
```
bindings:
  amqp:
    0.2.0:
    x.x.x:
  kafka:
    ...
```

The binding `$id`s will now contain the accurate version, so instead of `"$id": "http://asyncapi.com/bindings/amqp/channel.json"` it will have `"$id": "http://asyncapi.com/bindings/amqp/0.2.0/channel.json"`.

This setup will allow us to work on bindings alongside the spec itself, and continuously release new binding versions.

### Integrating with spec
One of the core issues with bindings is that some binding versions might only fit together with specific versions of the spec. To allow for this finetuned control, we can now reference the binding versions exactly as they are compatible and leave out versions when necessary:

```json
    "amqp": {
      "oneOf": [
        {
          "$ref": "http://asyncapi.com/bindings/amqp/0.2.0/channel.json"
        }
      ]
    },
```

