### PR TITLE
feat: add googlepubsub bindings

### DIFF
--- a/schemas/2.5.0.json
+++ b/schemas/2.5.0.json
@@ -295,7 +295,8 @@
                 "stomp": {},
                 "redis": {},
                 "ibmmq": {},
-                "solace": {}
+                "solace": {},
+                "googlepubsub": {}
             }
         },
         "http://asyncapi.com/definitions/2.5.0/channels.json": {


### PR DESCRIPTION
Add the Google Cloud Pub/Sub bindings _(`googlepubsub`)_ to the bindings list.

**Related issue(s)**
Bindings PR: https://github.com/asyncapi/bindings/pull/141
Spec PR: https://github.com/asyncapi/spec/pull/836
