### PR TITLE
ci: fix release workflow to support release branches

### DIFF
--- a/.github/workflows/if-nodejs-release.yml
+++ b/.github/workflows/if-nodejs-release.yml
@@ -9,12 +9,12 @@ on:
     branches:
       - master
       # below lines are not enough to have release supported for these branches
-      # make sure configuration of `semantic-release` package mentiones these branches
-      - next
+      # make sure configuration of `semantic-release` package mentions these branches
+      - next-spec
       - next-major
+      - next-major-spec
       - beta
       - alpha
-      - '**-release' # custom
 
 jobs:
 


### PR DESCRIPTION
when we changed release branches, we forgot to update the workflow that reacts to them, we forgot to change the names of branches in the config


Refs https://github.com/asyncapi/spec/pull/834