### PR TITLE
fix: generated index.d.ts file using tsc command (#287)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,14 +1,11 @@
 import type { JSONSchema7 } from 'json-schema';
 
-declare module '@asyncapi/specs' {
-  const specs: {
-    '2.0.0': JSONSchema7,
-    '2.1.0': JSONSchema7,
-    '2.2.0': JSONSchema7,
-    '2.3.0': JSONSchema7,
-    '2.4.0': JSONSchema7,
-    '2.5.0': JSONSchema7,
-  }
-
-  export default specs;
-}
+declare const _exports: {
+    '2.0.0': JSONSchema7;
+    '2.1.0': JSONSchema7;
+    '2.2.0': JSONSchema7;
+    '2.3.0': JSONSchema7;
+    '2.4.0': JSONSchema7;
+    '2.5.0': JSONSchema7;
+};
+export = _exports;


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**
Used tsc command to recreate index.d.ts (definiton file) for index.js since it could not be compiled. The reason is that the index.js file is a commonjs file, and the definition file does not allow module augmentation with exports when commonjs is used to the main module.

**Related issue(s)**
Fixes #287 