### PR TITLE
feat: modify bundling to create refs pointing to local definitions

### DIFF
--- a/definitions/2.5.0/channelItem.json
+++ b/definitions/2.5.0/channelItem.json
@@ -13,7 +13,7 @@
     "parameters": {
       "type": "object",
       "additionalProperties": {
-        "$ref": "http://asyncapi.com/definitions/2.5.0/parameter.json"
+        "$ref": "http://asyncapi.com/definitions/2.5.0/parameters.json"
       }
     },
     "description": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,11245 @@
 {
   "name": "@asyncapi/specs",
   "version": "4.0.1",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "@asyncapi/specs",
+      "version": "4.0.1",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.11",
+        "json-schema-traverse": "^1.0.0"
+      },
+      "devDependencies": {
+        "@semantic-release/commit-analyzer": "^8.0.1",
+        "@semantic-release/github": "7.2.3",
+        "@semantic-release/npm": "^7.0.3",
+        "@semantic-release/release-notes-generator": "^9.0.1",
+        "conventional-changelog-conventionalcommits": "^4.2.3",
+        "mocha": "^10.0.0",
+        "nyc": "^15.1.0",
+        "semantic-release": "19.0.3"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+      "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/highlight": "^7.8.3"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.12.13.tgz",
+      "integrity": "sha512-BQKE9kXkPlXHPeqissfxo0lySWJcYdEP0hdtJOH/iJfDdhOCcgtNCjftCJg3qqauB4h+lz2N6ixM++b9DN1Tcw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.12.13",
+        "@babel/generator": "^7.12.13",
+        "@babel/helper-module-transforms": "^7.12.13",
+        "@babel/helpers": "^7.12.13",
+        "@babel/parser": "^7.12.13",
+        "@babel/template": "^7.12.13",
+        "@babel/traverse": "^7.12.13",
+        "@babel/types": "^7.12.13",
+        "convert-source-map": "^1.7.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.1",
+        "json5": "^2.1.2",
+        "lodash": "^4.17.19",
+        "semver": "^5.4.1",
+        "source-map": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/@babel/code-frame": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+      "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/highlight": "^7.12.13"
+      }
+    },
+    "node_modules/@babel/core/node_modules/@babel/highlight": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.12.13.tgz",
+      "integrity": "sha512-kocDQvIbgMKlWxXe9fof3TQ+gkIPOUSEYhJjqUjvKMez3krV7vbzYCDq39Oj11UAVK7JqPVGQPlgE85dPNlQww==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.12.11",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      }
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/@babel/core/node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.13.tgz",
+      "integrity": "sha512-9qQ8Fgo8HaSvHEt6A5+BATP7XktD/AdAnObUeTRz5/e2y3kbrxZgz32qUJJsdmwUvBJzF4AeV21nGTNwv05Mpw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.12.13",
+        "jsesc": "^2.5.1",
+        "source-map": "^0.5.0"
+      }
+    },
+    "node_modules/@babel/generator/node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@babel/helper-function-name": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
+      "integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-get-function-arity": "^7.12.13",
+        "@babel/template": "^7.12.13",
+        "@babel/types": "^7.12.13"
+      }
+    },
+    "node_modules/@babel/helper-get-function-arity": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
+      "integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.12.13"
+      }
+    },
+    "node_modules/@babel/helper-member-expression-to-functions": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.13.tgz",
+      "integrity": "sha512-B+7nN0gIL8FZ8SvMcF+EPyB21KnCcZHQZFczCxbiNGV/O0rsrSBlWGLzmtBJ3GMjSVMIm4lpFhR+VdVBuIsUcQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.12.13"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.13.tgz",
+      "integrity": "sha512-NGmfvRp9Rqxy0uHSSVP+SRIW1q31a7Ji10cLBcqSDUngGentY4FRiHOFZFE1CLU5eiL0oE8reH7Tg1y99TDM/g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.12.13"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.12.13.tgz",
+      "integrity": "sha512-acKF7EjqOR67ASIlDTupwkKM1eUisNAjaSduo5Cz+793ikfnpe7p4Q7B7EWU2PCoSTPWsQkR7hRUWEIZPiVLGA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.12.13",
+        "@babel/helper-replace-supers": "^7.12.13",
+        "@babel/helper-simple-access": "^7.12.13",
+        "@babel/helper-split-export-declaration": "^7.12.13",
+        "@babel/helper-validator-identifier": "^7.12.11",
+        "@babel/template": "^7.12.13",
+        "@babel/traverse": "^7.12.13",
+        "@babel/types": "^7.12.13",
+        "lodash": "^4.17.19"
+      }
+    },
+    "node_modules/@babel/helper-optimise-call-expression": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.13.tgz",
+      "integrity": "sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.12.13"
+      }
+    },
+    "node_modules/@babel/helper-replace-supers": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.13.tgz",
+      "integrity": "sha512-pctAOIAMVStI2TMLhozPKbf5yTEXc0OJa0eENheb4w09SrgOWEs+P4nTOZYJQCqs8JlErGLDPDJTiGIp3ygbLg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-member-expression-to-functions": "^7.12.13",
+        "@babel/helper-optimise-call-expression": "^7.12.13",
+        "@babel/traverse": "^7.12.13",
+        "@babel/types": "^7.12.13"
+      }
+    },
+    "node_modules/@babel/helper-simple-access": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.12.13.tgz",
+      "integrity": "sha512-0ski5dyYIHEfwpWGx5GPWhH35j342JaflmCeQmsPWcrOQDtCN6C1zKAVRFVbK53lPW2c9TsuLLSUDf0tIGJ5hA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.12.13"
+      }
+    },
+    "node_modules/@babel/helper-split-export-declaration": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
+      "integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.12.13"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+      "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+      "dev": true
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.12.13.tgz",
+      "integrity": "sha512-oohVzLRZ3GQEk4Cjhfs9YkJA4TdIDTObdBEZGrd6F/T0GPSnuV6l22eMcxlvcvzVIPH3VTtxbseudM1zIE+rPQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/template": "^7.12.13",
+        "@babel/traverse": "^7.12.13",
+        "@babel/types": "^7.12.13"
+      }
+    },
+    "node_modules/@babel/highlight": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+      "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^2.0.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^4.0.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.13.tgz",
+      "integrity": "sha512-z7n7ybOUzaRc3wwqLpAX8UFIXsrVXUJhtNGBwAnLz6d1KUapqyq7ad2La8gZ6CXhHmGAIL32cop8Tst4/PNWLw==",
+      "dev": true,
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
+      "integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.12.13",
+        "@babel/parser": "^7.12.13",
+        "@babel/types": "^7.12.13"
+      }
+    },
+    "node_modules/@babel/template/node_modules/@babel/code-frame": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+      "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/highlight": "^7.12.13"
+      }
+    },
+    "node_modules/@babel/template/node_modules/@babel/highlight": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.12.13.tgz",
+      "integrity": "sha512-kocDQvIbgMKlWxXe9fof3TQ+gkIPOUSEYhJjqUjvKMez3krV7vbzYCDq39Oj11UAVK7JqPVGQPlgE85dPNlQww==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.12.11",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.13.tgz",
+      "integrity": "sha512-3Zb4w7eE/OslI0fTp8c7b286/cQps3+vdLW3UcwC8VSJC6GbKn55aeVVu2QJNuCDoeKyptLOFrPq8WqZZBodyA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.12.13",
+        "@babel/generator": "^7.12.13",
+        "@babel/helper-function-name": "^7.12.13",
+        "@babel/helper-split-export-declaration": "^7.12.13",
+        "@babel/parser": "^7.12.13",
+        "@babel/types": "^7.12.13",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0",
+        "lodash": "^4.17.19"
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/@babel/code-frame": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+      "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/highlight": "^7.12.13"
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/@babel/highlight": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.12.13.tgz",
+      "integrity": "sha512-kocDQvIbgMKlWxXe9fof3TQ+gkIPOUSEYhJjqUjvKMez3krV7vbzYCDq39Oj11UAVK7JqPVGQPlgE85dPNlQww==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.12.11",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.13.tgz",
+      "integrity": "sha512-oKrdZTld2im1z8bDwTOQvUbxKwE+854zc16qWZQlcTqMN00pWxHQ4ZeOq0yDMnisOpRykH2/5Qqcrk/OlbAjiQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.12.11",
+        "lodash": "^4.17.19",
+        "to-fast-properties": "^2.0.0"
+      }
+    },
+    "node_modules/@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+      "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+      "dev": true,
+      "dependencies": {
+        "camelcase": "^5.3.1",
+        "find-up": "^4.1.0",
+        "get-package-type": "^0.1.0",
+        "js-yaml": "^3.13.1",
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.2.tgz",
+      "integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@octokit/auth-token": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.5.0.tgz",
+      "integrity": "sha512-r5FVUJCOLl19AxiuZD2VRZ/ORjp/4IN98Of6YJoJOkY75CIBuYfmiNHGrDwXr+aLGG55igl9QrxX3hbiXlLb+g==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/types": "^6.0.3"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.6.0.tgz",
+      "integrity": "sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/auth-token": "^2.4.4",
+        "@octokit/graphql": "^4.5.8",
+        "@octokit/request": "^5.6.3",
+        "@octokit/request-error": "^2.0.5",
+        "@octokit/types": "^6.0.3",
+        "before-after-hook": "^2.2.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.12.tgz",
+      "integrity": "sha512-lF3puPwkQWGfkMClXb4k/eUT/nZKQfxinRWJrdZaJO85Dqwo/G0yOC434Jr2ojwafWJMYqFGFa5ms4jJUgujdA==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/types": "^6.0.3",
+        "is-plain-object": "^5.0.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.8.0.tgz",
+      "integrity": "sha512-0gv+qLSBLKF0z8TKaSKTsS39scVKF9dbMxJpj3U0vC7wjNWFuIpL/z76Qe2fiuCbDRcJSavkXsVtMS6/dtQQsg==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/request": "^5.6.0",
+        "@octokit/types": "^6.0.3",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-11.2.0.tgz",
+      "integrity": "sha512-PBsVO+15KSlGmiI8QAzaqvsNlZlrDlyAJYcrXBCvVUxCp7VnXjkwPoFHgjEJXx3WF9BAwkA6nfCUA7i9sODzKA==",
+      "dev": true
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.17.0.tgz",
+      "integrity": "sha512-tzMbrbnam2Mt4AhuyCHvpRkS0oZ5MvwwcQPYGtMv4tUa5kkzG58SVB0fcsLulOZQeRnOgdkZWkRUiyBlh0Bkyw==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/types": "^6.34.0"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=2"
+      }
+    },
+    "node_modules/@octokit/plugin-request-log": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
+      "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
+      "dev": true,
+      "peerDependencies": {
+        "@octokit/core": ">=3"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.13.0.tgz",
+      "integrity": "sha512-uJjMTkN1KaOIgNtUPMtIXDOjx6dGYysdIFhgA52x4xSadQCz3b/zJexvITDVpANnfKPW/+E0xkOvLntqMYpviA==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/types": "^6.34.0",
+        "deprecation": "^2.3.1"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=3"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.3.tgz",
+      "integrity": "sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/endpoint": "^6.0.1",
+        "@octokit/request-error": "^2.1.0",
+        "@octokit/types": "^6.16.1",
+        "is-plain-object": "^5.0.0",
+        "node-fetch": "^2.6.7",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.1.0.tgz",
+      "integrity": "sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/types": "^6.0.3",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/@octokit/rest": {
+      "version": "18.12.0",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.12.0.tgz",
+      "integrity": "sha512-gDPiOHlyGavxr72y0guQEhLsemgVjwRePayJ+FcKc2SJqKUbxbkvf5kAZEWA/MKvsfYlQAMVzNJE3ezQcxMJ2Q==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/core": "^3.5.1",
+        "@octokit/plugin-paginate-rest": "^2.16.8",
+        "@octokit/plugin-request-log": "^1.0.4",
+        "@octokit/plugin-rest-endpoint-methods": "^5.12.0"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "6.34.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.34.0.tgz",
+      "integrity": "sha512-s1zLBjWhdEI2zwaoSgyOFoKSl109CUcVBCc7biPJ3aAf6LGLU6szDvi31JPU7bxfla2lqfhjbbg/5DdFNxOwHw==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/openapi-types": "^11.2.0"
+      }
+    },
+    "node_modules/@semantic-release/commit-analyzer": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-8.0.1.tgz",
+      "integrity": "sha512-5bJma/oB7B4MtwUkZC2Bf7O1MHfi4gWe4mA+MIQ3lsEV0b422Bvl1z5HRpplDnMLHH3EXMoRdEng6Ds5wUqA3A==",
+      "dev": true,
+      "dependencies": {
+        "conventional-changelog-angular": "^5.0.0",
+        "conventional-commits-filter": "^2.0.0",
+        "conventional-commits-parser": "^3.0.7",
+        "debug": "^4.0.0",
+        "import-from": "^3.0.0",
+        "lodash": "^4.17.4",
+        "micromatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=10.18"
+      },
+      "peerDependencies": {
+        "semantic-release": ">=16.0.0 <18.0.0"
+      }
+    },
+    "node_modules/@semantic-release/error": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-2.2.0.tgz",
+      "integrity": "sha512-9Tj/qn+y2j+sjCI3Jd+qseGtHjOAeg7dU2/lVcqIQ9TV3QDaDXDYXcoOHU+7o2Hwh8L8ymL4gfuO7KxDs3q2zg==",
+      "dev": true
+    },
+    "node_modules/@semantic-release/github": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-7.2.3.tgz",
+      "integrity": "sha512-lWjIVDLal+EQBzy697ayUNN8MoBpp+jYIyW2luOdqn5XBH4d9bQGfTnjuLyzARZBHejqh932HVjiH/j4+R7VHw==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/rest": "^18.0.0",
+        "@semantic-release/error": "^2.2.0",
+        "aggregate-error": "^3.0.0",
+        "bottleneck": "^2.18.1",
+        "debug": "^4.0.0",
+        "dir-glob": "^3.0.0",
+        "fs-extra": "^10.0.0",
+        "globby": "^11.0.0",
+        "http-proxy-agent": "^4.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "issue-parser": "^6.0.0",
+        "lodash": "^4.17.4",
+        "mime": "^2.4.3",
+        "p-filter": "^2.0.0",
+        "p-retry": "^4.0.0",
+        "url-join": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10.18"
+      },
+      "peerDependencies": {
+        "semantic-release": ">=16.0.0 <18.0.0"
+      }
+    },
+    "node_modules/@semantic-release/npm": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-7.1.3.tgz",
+      "integrity": "sha512-x52kQ/jR09WjuWdaTEHgQCvZYMOTx68WnS+TZ4fya5ZAJw4oRtJETtrvUw10FdfM28d/keInQdc66R1Gw5+OEQ==",
+      "dev": true,
+      "dependencies": {
+        "@semantic-release/error": "^2.2.0",
+        "aggregate-error": "^3.0.0",
+        "execa": "^5.0.0",
+        "fs-extra": "^10.0.0",
+        "lodash": "^4.17.15",
+        "nerf-dart": "^1.0.0",
+        "normalize-url": "^6.0.0",
+        "npm": "^7.0.0",
+        "rc": "^1.2.8",
+        "read-pkg": "^5.0.0",
+        "registry-auth-token": "^4.0.0",
+        "semver": "^7.1.2",
+        "tempy": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10.19"
+      },
+      "peerDependencies": {
+        "semantic-release": ">=16.0.0 <18.0.0"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/semver": {
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@semantic-release/release-notes-generator": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-9.0.3.tgz",
+      "integrity": "sha512-hMZyddr0u99OvM2SxVOIelHzly+PP3sYtJ8XOLHdMp8mrluN5/lpeTnIO27oeCYdupY/ndoGfvrqDjHqkSyhVg==",
+      "dev": true,
+      "dependencies": {
+        "conventional-changelog-angular": "^5.0.0",
+        "conventional-changelog-writer": "^4.0.0",
+        "conventional-commits-filter": "^2.0.0",
+        "conventional-commits-parser": "^3.0.0",
+        "debug": "^4.0.0",
+        "get-stream": "^6.0.0",
+        "import-from": "^3.0.0",
+        "into-stream": "^6.0.0",
+        "lodash": "^4.17.4",
+        "read-pkg-up": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=10.18"
+      },
+      "peerDependencies": {
+        "semantic-release": ">=15.8.0 <18.0.0"
+      }
+    },
+    "node_modules/@tootallnate/once": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.11",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
+      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="
+    },
+    "node_modules/@types/minimist": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
+      "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
+      "dev": true
+    },
+    "node_modules/@types/normalize-package-data": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
+      "dev": true
+    },
+    "node_modules/@types/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
+      "dev": true
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "dev": true
+    },
+    "node_modules/@ungap/promise-all-settled": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
+      "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
+      "dev": true
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/aggregate-error": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",
+      "integrity": "sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==",
+      "dev": true,
+      "dependencies": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-colors": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-5.0.0.tgz",
+      "integrity": "sha512-5GFMVX8HqE/TB+FuBJGuO5XG0WrsA6ptUqoODaT/n9mmUaZFkqnBueB4leqGBCmrUHnCnC4PCZTCd0E7QQ83bA==",
+      "dev": true,
+      "dependencies": {
+        "type-fest": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ansicolors": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
+      "integrity": "sha512-QXu7BPrP29VllRxH8GwB7x5iX5qWKAAMLqKQGWTeLWVlNHNOpVMJ91dsxQAIWXpjuW5wqvxu3Jd/nRjrJ+0pqg==",
+      "dev": true
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+      "dev": true,
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/append-transform": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-2.0.0.tgz",
+      "integrity": "sha512-7yeyCEurROLQJFv5Xj4lEGTy0borxepjFv1g22oAdqFu//SrAlDl1O1Nxx15SH1RoliUml6p8dwJW9jvZughhg==",
+      "dev": true,
+      "dependencies": {
+        "default-require-extensions": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/archy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+      "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+      "dev": true
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/argv-formatter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/argv-formatter/-/argv-formatter-1.0.0.tgz",
+      "integrity": "sha1-oMoMvCmltz6Dbuvhy/bF4OTrgvk=",
+      "dev": true
+    },
+    "node_modules/array-ify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
+      "integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4=",
+      "dev": true
+    },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "node_modules/before-after-hook": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.2.tgz",
+      "integrity": "sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ==",
+      "dev": true
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/bottleneck": {
+      "version": "2.19.5",
+      "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
+      "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
+      "dev": true
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "dependencies": {
+        "fill-range": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
+    "node_modules/caching-transform": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-4.0.0.tgz",
+      "integrity": "sha512-kpqOvwXnjjN44D89K5ccQC+RUrsy7jB/XLlRrx0D7/2HNcTPqzsb6XgYoErwko6QsV184CA2YgS1fxDiiDZMWA==",
+      "dev": true,
+      "dependencies": {
+        "hasha": "^5.0.0",
+        "make-dir": "^3.0.0",
+        "package-hash": "^4.0.0",
+        "write-file-atomic": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/camelcase-keys": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
+      "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
+      "dev": true,
+      "dependencies": {
+        "camelcase": "^5.3.1",
+        "map-obj": "^4.0.0",
+        "quick-lru": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cardinal": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-2.1.1.tgz",
+      "integrity": "sha512-JSr5eOgoEymtYHBjNWyjrMqet9Am2miJhlfKNdqLp6zoeAh0KN5dRAcxlecj5mAJrmQomgiOBj35xHLrFjqBpw==",
+      "dev": true,
+      "dependencies": {
+        "ansicolors": "~0.3.2",
+        "redeyed": "~2.1.0"
+      },
+      "bin": {
+        "cdl": "bin/cdl.js"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/chalk/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/cli-table3": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.2.tgz",
+      "integrity": "sha512-QyavHCaIC80cMivimWu4aWHilIpiDpfm3hGmqAmXVL1UsnbLuBSMd21hTX6VY4ZSDSM73ESLeF8TOYId3rBTbw==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      },
+      "optionalDependencies": {
+        "@colors/colors": "1.5.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "node_modules/commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+      "dev": true
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "node_modules/conventional-changelog-angular": {
+      "version": "5.0.13",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.13.tgz",
+      "integrity": "sha512-i/gipMxs7s8L/QeuavPF2hLnJgH6pEZAttySB6aiQLWcX3puWDL3ACVmvBhJGxnAy52Qc15ua26BufY6KpmrVA==",
+      "dev": true,
+      "dependencies": {
+        "compare-func": "^2.0.0",
+        "q": "^1.5.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/conventional-changelog-angular/node_modules/compare-func": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
+      "integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
+      "dev": true,
+      "dependencies": {
+        "array-ify": "^1.0.0",
+        "dot-prop": "^5.1.0"
+      }
+    },
+    "node_modules/conventional-changelog-angular/node_modules/dot-prop": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+      "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
+      "dev": true,
+      "dependencies": {
+        "is-obj": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/conventional-changelog-angular/node_modules/is-obj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/conventional-changelog-conventionalcommits": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-4.6.3.tgz",
+      "integrity": "sha512-LTTQV4fwOM4oLPad317V/QNQ1FY4Hju5qeBIM1uTHbrnCE+Eg4CdRZ3gO2pUeR+tzWdp80M2j3qFFEDWVqOV4g==",
+      "dev": true,
+      "dependencies": {
+        "compare-func": "^2.0.0",
+        "lodash": "^4.17.15",
+        "q": "^1.5.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/conventional-changelog-conventionalcommits/node_modules/compare-func": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
+      "integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
+      "dev": true,
+      "dependencies": {
+        "array-ify": "^1.0.0",
+        "dot-prop": "^5.1.0"
+      }
+    },
+    "node_modules/conventional-changelog-conventionalcommits/node_modules/dot-prop": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+      "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
+      "dev": true,
+      "dependencies": {
+        "is-obj": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/conventional-changelog-conventionalcommits/node_modules/is-obj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/conventional-changelog-writer": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.1.0.tgz",
+      "integrity": "sha512-WwKcUp7WyXYGQmkLsX4QmU42AZ1lqlvRW9mqoyiQzdD+rJWbTepdWoKJuwXTS+yq79XKnQNa93/roViPQrAQgw==",
+      "dev": true,
+      "dependencies": {
+        "compare-func": "^2.0.0",
+        "conventional-commits-filter": "^2.0.7",
+        "dateformat": "^3.0.0",
+        "handlebars": "^4.7.6",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.15",
+        "meow": "^8.0.0",
+        "semver": "^6.0.0",
+        "split": "^1.0.0",
+        "through2": "^4.0.0"
+      },
+      "bin": {
+        "conventional-changelog-writer": "cli.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/conventional-changelog-writer/node_modules/compare-func": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
+      "integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
+      "dev": true,
+      "dependencies": {
+        "array-ify": "^1.0.0",
+        "dot-prop": "^5.1.0"
+      }
+    },
+    "node_modules/conventional-changelog-writer/node_modules/dot-prop": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+      "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
+      "dev": true,
+      "dependencies": {
+        "is-obj": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/conventional-changelog-writer/node_modules/is-obj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/conventional-changelog-writer/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/conventional-commits-filter": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-2.0.7.tgz",
+      "integrity": "sha512-ASS9SamOP4TbCClsRHxIHXRfcGCnIoQqkvAzCSbZzTFLfcTqJVugB0agRgsEELsqaeWgsXv513eS116wnlSSPA==",
+      "dev": true,
+      "dependencies": {
+        "lodash.ismatch": "^4.4.0",
+        "modify-values": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/conventional-commits-parser": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.2.4.tgz",
+      "integrity": "sha512-nK7sAtfi+QXbxHCYfhpZsfRtaitZLIA6889kFIouLvz6repszQDgxBu7wf2WbU+Dco7sAnNCJYERCwt54WPC2Q==",
+      "dev": true,
+      "dependencies": {
+        "is-text-path": "^1.0.1",
+        "JSONStream": "^1.0.4",
+        "lodash": "^4.17.15",
+        "meow": "^8.0.0",
+        "split2": "^3.0.0",
+        "through2": "^4.0.0"
+      },
+      "bin": {
+        "conventional-commits-parser": "cli.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+      "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.1"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "node_modules/cosmiconfig": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.0.tgz",
+      "integrity": "sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==",
+      "dev": true,
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cosmiconfig/node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cosmiconfig/node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/crypto-random-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
+      "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dateformat": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
+      "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+      "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+      "deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/decamelize-keys": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+      "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
+      "dev": true,
+      "dependencies": {
+        "decamelize": "^1.1.0",
+        "map-obj": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/decamelize-keys/node_modules/map-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/default-require-extensions": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-3.0.0.tgz",
+      "integrity": "sha512-ek6DpXq/SCpvjhpFsLFRVtIxJCRw6fUR42lYMVZuUMK7n8eMz4Uh5clckdBjEpLhn/gEBZo7hDJnJcwdKLKQjg==",
+      "dev": true,
+      "dependencies": {
+        "strip-bom": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/default-require-extensions/node_modules/strip-bom": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/del": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/del/-/del-6.1.1.tgz",
+      "integrity": "sha512-ua8BhapfP0JUJKC/zV9yHHDW/rDoDxP4Zhn3AkA6/xT6gY7jYXJiaeyBZznYVujhZZET+UgcbZiQ7sN3WqcImg==",
+      "dev": true,
+      "dependencies": {
+        "globby": "^11.0.1",
+        "graceful-fs": "^4.2.4",
+        "is-glob": "^4.0.1",
+        "is-path-cwd": "^2.2.0",
+        "is-path-inside": "^3.0.2",
+        "p-map": "^4.0.0",
+        "rimraf": "^3.0.2",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/del/node_modules/p-map": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+      "dev": true,
+      "dependencies": {
+        "aggregate-error": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deprecation": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
+      "dev": true
+    },
+    "node_modules/diff": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dir-glob/node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+      "dev": true,
+      "dependencies": {
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/env-ci": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/env-ci/-/env-ci-5.0.2.tgz",
+      "integrity": "sha512-Xc41mKvjouTXD3Oy9AqySz1IeyvJvHZ20Twf5ZLYbNpPPIuCnL/qHCmNlD01LoNy0JTunw9HPYVptD19Ac7Mbw==",
+      "dev": true,
+      "dependencies": {
+        "execa": "^4.0.0",
+        "java-properties": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10.13"
+      }
+    },
+    "node_modules/env-ci/node_modules/execa": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+      "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "get-stream": "^5.0.0",
+        "human-signals": "^1.1.1",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.0",
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/env-ci/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+      "dev": true
+    },
+    "node_modules/escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.0.0.tgz",
+      "integrity": "sha512-ov6w/2LCiuyO4RLYGdpFGjkcs0wMTgGE8PrkTHikeUy5iJekXyPIKUjifk5CsE0pt7sMCrMZ3YNqoCj6idQOnQ==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/execa/node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/execa/node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/execa/node_modules/signal-exit": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
+      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+      "dev": true
+    },
+    "node_modules/fast-glob": {
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
+      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+      "dev": true,
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/figures": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-cache-dir": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
+      "integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
+      "dev": true,
+      "dependencies": {
+        "commondir": "^1.0.1",
+        "make-dir": "^3.0.2",
+        "pkg-dir": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
+      }
+    },
+    "node_modules/find-versions": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-4.0.0.tgz",
+      "integrity": "sha512-wgpWy002tA+wgmO27buH/9KzyEOQnKsG/R0yrcjPT9BOFm0zRBVQbZ95nRGXWMywS8YR5knRbpohio0bcJABxQ==",
+      "dev": true,
+      "dependencies": {
+        "semver-regex": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true,
+      "bin": {
+        "flat": "cli.js"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
+      "integrity": "sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/foreground-child/node_modules/cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/foreground-child/node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/foreground-child/node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/foreground-child/node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/foreground-child/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/from2": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+      "integrity": "sha512-OMcX/4IC/uqEPVgGeyfN22LJk6AZrMkRZHxcHBMBvHScDGgwTm2GT2Wkgtocyd3JfZffjj2kYUDXXII0Fk9W0g==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
+      }
+    },
+    "node_modules/fromentries": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.3.2.tgz",
+      "integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/fs-extra/node_modules/universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-package-type": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/git-log-parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/git-log-parser/-/git-log-parser-1.2.0.tgz",
+      "integrity": "sha1-LmpMGxP8AAKCB7p5WnrDFme5/Uo=",
+      "dev": true,
+      "dependencies": {
+        "argv-formatter": "~1.0.0",
+        "spawn-error-forwarder": "~1.0.0",
+        "split2": "~1.0.0",
+        "stream-combiner2": "~1.1.1",
+        "through2": "~2.0.0",
+        "traverse": "~0.6.6"
+      }
+    },
+    "node_modules/git-log-parser/node_modules/split2": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-1.0.0.tgz",
+      "integrity": "sha1-UuLiIdiMdfmnP5BVbiY/+WdysxQ=",
+      "dev": true,
+      "dependencies": {
+        "through2": "~2.0.0"
+      }
+    },
+    "node_modules/git-log-parser/node_modules/through2": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "dev": true,
+      "dependencies": {
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/globals": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+      "dev": true
+    },
+    "node_modules/handlebars": {
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.0",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
+    "node_modules/hard-rejection": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
+      "integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/hasha": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/hasha/-/hasha-5.2.2.tgz",
+      "integrity": "sha512-Hrp5vIK/xr5SkeN2onO32H0MgNZ0f17HRNH39WfL0SYUNOTZ5Lz1TJ8Pajo/87dYGEFlLMm7mIc/k/s6Bvz9HQ==",
+      "dev": true,
+      "dependencies": {
+        "is-stream": "^2.0.0",
+        "type-fest": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/hasha/node_modules/is-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/hasha/node_modules/type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/hook-std": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hook-std/-/hook-std-2.0.0.tgz",
+      "integrity": "sha512-zZ6T5WcuBMIUVh49iPQS9t977t7C0l7OtHrpeMb5uk48JdflRX0NSFvCekfYNmGQETnLq9W/isMyHl69kxGi8g==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/hosted-git-info": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+      "dev": true
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+      "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+      "dev": true,
+      "dependencies": {
+        "@tootallnate/once": "1",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.12.0"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "dev": true,
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-fresh/node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/import-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/import-from/-/import-from-3.0.0.tgz",
+      "integrity": "sha512-CiuXOFFSzkU5x/CR0+z7T91Iht4CXgfCxVOFRhh2Zyhg5wOpWvvDLQUsWl+gcN+QscYBjez8hDCt85O7RLDttQ==",
+      "dev": true,
+      "dependencies": {
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true
+    },
+    "node_modules/into-stream": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-6.0.0.tgz",
+      "integrity": "sha512-XHbaOAvP+uFKUFsOgoNPRjLkwB+I22JFPFe5OjTkQ0nwgj6+pSjb4NmB6VMxaPshLiOf+zcpOCBQuLwC1KHhZA==",
+      "dev": true,
+      "dependencies": {
+        "from2": "^2.3.0",
+        "p-is-promise": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
+      "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
+      "dev": true,
+      "dependencies": {
+        "has": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "dev": true,
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-path-cwd": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
+      "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-text-path": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
+      "integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
+      "dev": true,
+      "dependencies": {
+        "text-extensions": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "node_modules/issue-parser": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/issue-parser/-/issue-parser-6.0.0.tgz",
+      "integrity": "sha512-zKa/Dxq2lGsBIXQ7CUZWTHfvxPC2ej0KfO7fIPqLlHB9J2hJ7rGhZ5rilhuufylr4RXYPzJUeFjKxz305OsNlA==",
+      "dev": true,
+      "dependencies": {
+        "lodash.capitalize": "^4.2.1",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.uniqby": "^4.7.0"
+      },
+      "engines": {
+        "node": ">=10.13"
+      }
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
+      "integrity": "sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-hook": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-3.0.0.tgz",
+      "integrity": "sha512-Pt/uge1Q9s+5VAZ+pCo16TYMWPBIl+oaNIjgLQxcX0itS6ueeaA+pEfThZpH8WxhFgCiEb8sAJY6MdUKgiIWaQ==",
+      "dev": true,
+      "dependencies": {
+        "append-transform": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-instrument": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
+      "integrity": "sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.7.5",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-coverage": "^3.0.0",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-instrument/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/istanbul-lib-processinfo": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.2.tgz",
+      "integrity": "sha512-kOwpa7z9hme+IBPZMzQ5vdQj8srYgAtaRqeI48NGmAQ+/5yKiHLV0QbYqQpxsdEF0+w14SoB8YbnHKcXE2KnYw==",
+      "dev": true,
+      "dependencies": {
+        "archy": "^1.0.0",
+        "cross-spawn": "^7.0.0",
+        "istanbul-lib-coverage": "^3.0.0-alpha.1",
+        "make-dir": "^3.0.0",
+        "p-map": "^3.0.0",
+        "rimraf": "^3.0.0",
+        "uuid": "^3.3.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-processinfo/node_modules/cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/istanbul-lib-processinfo/node_modules/p-map": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
+      "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
+      "dev": true,
+      "dependencies": {
+        "aggregate-error": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-processinfo/node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-processinfo/node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-processinfo/node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-processinfo/node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "dev": true,
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
+    "node_modules/istanbul-lib-processinfo/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+      "integrity": "sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==",
+      "dev": true,
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^3.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.0.tgz",
+      "integrity": "sha512-c16LpFRkR8vQXyHZ5nLpY35JZtzj1PQY1iZmesUbf1FZHbIupcWfjgOXBY9YHkLEQ6puz1u4Dgj6qmU/DisrZg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.2.tgz",
+      "integrity": "sha512-9tZvz7AiR3PEDNGiV9vIouQ/EAcqMXFmkcA1CDFTwOB98OZVDL0PH9glHotf5Ugp6GCOTypfzGWI/OqjWNCRUw==",
+      "dev": true,
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/java-properties": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/java-properties/-/java-properties-1.0.2.tgz",
+      "integrity": "sha512-qjdpeo2yKlYTH7nFdK0vbZWuTCesk4o63v5iVOlhMQPfuIZQfW/HI35SjfhA+4qpg36rnFSvUK5b1m+ckIblQQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
+    "node_modules/js-yaml": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
+      "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true,
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true
+    },
+    "node_modules/json5": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+      "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
+      "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
+      "dev": true,
+      "dependencies": {
+        "universalify": "^1.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonfile/node_modules/universalify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
+      "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/jsonparse": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
+      "dev": true,
+      "engines": [
+        "node >= 0.2.0"
+      ]
+    },
+    "node_modules/JSONStream": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+      "dev": true,
+      "dependencies": {
+        "jsonparse": "^1.2.0",
+        "through": ">=2.2.7 <3"
+      },
+      "bin": {
+        "JSONStream": "bin.js"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
+      "dev": true
+    },
+    "node_modules/load-json-file": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+      "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^4.0.0",
+        "pify": "^3.0.0",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/load-json-file/node_modules/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
+      "dev": true,
+      "dependencies": {
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/load-json-file/node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
+    },
+    "node_modules/lodash.capitalize": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
+      "integrity": "sha512-kZzYOKspf8XVX5AvmQF94gQW0lejFVgb80G85bU4ZWzoJ6C03PQg3coYAUpSTpQWelrZELd3XWgHzw4Ck5kaIw==",
+      "dev": true
+    },
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+      "dev": true
+    },
+    "node_modules/lodash.flattendeep": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
+      "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+      "dev": true
+    },
+    "node_modules/lodash.ismatch": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
+      "integrity": "sha1-dWy1FQyjum8RCFp4hJZF8Yj4Xzc=",
+      "dev": true
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "dev": true
+    },
+    "node_modules/lodash.uniqby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
+      "integrity": "sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww==",
+      "dev": true
+    },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-symbols/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/log-symbols/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/log-symbols/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/log-symbols/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/log-symbols/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/log-symbols/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/map-obj": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
+      "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/marked": {
+      "version": "4.0.16",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.16.tgz",
+      "integrity": "sha512-wahonIQ5Jnyatt2fn8KqF/nIqZM8mh3oRu2+l5EANGMhu6RFjiSG52QNE2eWzFMI94HqYSgN184NurgNG6CztA==",
+      "dev": true,
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/marked-terminal": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-5.1.1.tgz",
+      "integrity": "sha512-+cKTOx9P4l7HwINYhzbrBSyzgxO2HaHKGZGuB1orZsMIgXYaJyfidT81VXRdpelW/PcHEWxywscePVgI/oUF6g==",
+      "dev": true,
+      "dependencies": {
+        "ansi-escapes": "^5.0.0",
+        "cardinal": "^2.1.1",
+        "chalk": "^5.0.0",
+        "cli-table3": "^0.6.1",
+        "node-emoji": "^1.11.0",
+        "supports-hyperlinks": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=14.13.1 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "marked": "^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0"
+      }
+    },
+    "node_modules/marked-terminal/node_modules/chalk": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
+      "integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w==",
+      "dev": true,
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/meow": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-8.1.2.tgz",
+      "integrity": "sha512-r85E3NdZ+mpYk1C6RjPFEMSE+s1iZMuHtsHAqY0DT3jZczl0diWUZ8g6oU7h0M9cD2EL+PzaYghhCLzR0ZNn5Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/minimist": "^1.2.0",
+        "camelcase-keys": "^6.2.2",
+        "decamelize-keys": "^1.1.0",
+        "hard-rejection": "^2.1.0",
+        "minimist-options": "4.1.0",
+        "normalize-package-data": "^3.0.0",
+        "read-pkg-up": "^7.0.1",
+        "redent": "^3.0.0",
+        "trim-newlines": "^3.0.0",
+        "type-fest": "^0.18.0",
+        "yargs-parser": "^20.2.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/meow/node_modules/hosted-git-info": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/meow/node_modules/normalize-package-data": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+      "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
+      "dev": true,
+      "dependencies": {
+        "hosted-git-info": "^4.0.1",
+        "is-core-module": "^2.5.0",
+        "semver": "^7.3.4",
+        "validate-npm-package-license": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/meow/node_modules/semver": {
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/meow/node_modules/type-fest": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
+      "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "dev": true,
+      "dependencies": {
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+      "dev": true
+    },
+    "node_modules/minimist-options": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
+      "integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
+      "dev": true,
+      "dependencies": {
+        "arrify": "^1.0.1",
+        "is-plain-obj": "^1.1.0",
+        "kind-of": "^6.0.3"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/mocha": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.0.0.tgz",
+      "integrity": "sha512-0Wl+elVUD43Y0BqPZBzZt8Tnkw9CMUdNYnUsTfOM1vuhJVZL+kiesFYsqwBkEEuEixaiPe5ZQdqDgX2jddhmoA==",
+      "dev": true,
+      "dependencies": {
+        "@ungap/promise-all-settled": "1.1.2",
+        "ansi-colors": "4.1.1",
+        "browser-stdout": "1.3.1",
+        "chokidar": "3.5.3",
+        "debug": "4.3.4",
+        "diff": "5.0.0",
+        "escape-string-regexp": "4.0.0",
+        "find-up": "5.0.0",
+        "glob": "7.2.0",
+        "he": "1.2.0",
+        "js-yaml": "4.1.0",
+        "log-symbols": "4.1.0",
+        "minimatch": "5.0.1",
+        "ms": "2.1.3",
+        "nanoid": "3.3.3",
+        "serialize-javascript": "6.0.0",
+        "strip-json-comments": "3.1.1",
+        "supports-color": "8.1.1",
+        "workerpool": "6.2.1",
+        "yargs": "16.2.0",
+        "yargs-parser": "20.2.4",
+        "yargs-unparser": "2.0.0"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha.js"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mochajs"
+      }
+    },
+    "node_modules/mocha/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/mocha/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
+    "node_modules/mocha/node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/mocha/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/mocha/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/mocha/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mocha/node_modules/debug/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "node_modules/mocha/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mocha/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mocha/node_modules/glob": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/mocha/node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/mocha/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/mocha/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/mocha/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mocha/node_modules/minimatch": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
+      "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mocha/node_modules/minimatch/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/mocha/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/mocha/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mocha/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mocha/node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/mocha/node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mocha/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/mocha/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/mocha/node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mocha/node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mocha/node_modules/yargs-parser": {
+      "version": "20.2.4",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+      "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/modify-values": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
+      "integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
+      "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
+      "dev": true,
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true
+    },
+    "node_modules/nerf-dart": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/nerf-dart/-/nerf-dart-1.0.0.tgz",
+      "integrity": "sha512-EZSPZB70jiVsivaBLYDCyntd5eH8NTSMOn3rB+HxwdmKThGELLdYv8qVIMWvZEFy9w8ZZpW9h9OB32l1rGtj7g==",
+      "dev": true
+    },
+    "node_modules/node-emoji": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.11.0.tgz",
+      "integrity": "sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.21"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-preload": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/node-preload/-/node-preload-0.2.1.tgz",
+      "integrity": "sha512-RM5oyBy45cLEoHqCeh+MNuFAxO0vTFBLskvQbOKnEE7YTTSN4tbN8QWDIPQ6L+WvKsB/qLEGpYe2ZZ9d4W9OIQ==",
+      "dev": true,
+      "dependencies": {
+        "process-on-spawn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
+      "dependencies": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "node_modules/normalize-package-data/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/normalize-url": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm": {
+      "version": "7.24.2",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-7.24.2.tgz",
+      "integrity": "sha512-120p116CE8VMMZ+hk8IAb1inCPk4Dj3VZw29/n2g6UI77urJKVYb7FZUDW8hY+EBnfsjI/2yrobBgFyzo7YpVQ==",
+      "bundleDependencies": [
+        "@isaacs/string-locale-compare",
+        "@npmcli/arborist",
+        "@npmcli/ci-detect",
+        "@npmcli/config",
+        "@npmcli/map-workspaces",
+        "@npmcli/package-json",
+        "@npmcli/run-script",
+        "abbrev",
+        "ansicolors",
+        "ansistyles",
+        "archy",
+        "cacache",
+        "chalk",
+        "chownr",
+        "cli-columns",
+        "cli-table3",
+        "columnify",
+        "fastest-levenshtein",
+        "glob",
+        "graceful-fs",
+        "hosted-git-info",
+        "ini",
+        "init-package-json",
+        "is-cidr",
+        "json-parse-even-better-errors",
+        "libnpmaccess",
+        "libnpmdiff",
+        "libnpmexec",
+        "libnpmfund",
+        "libnpmhook",
+        "libnpmorg",
+        "libnpmpack",
+        "libnpmpublish",
+        "libnpmsearch",
+        "libnpmteam",
+        "libnpmversion",
+        "make-fetch-happen",
+        "minipass",
+        "minipass-pipeline",
+        "mkdirp",
+        "mkdirp-infer-owner",
+        "ms",
+        "node-gyp",
+        "nopt",
+        "npm-audit-report",
+        "npm-install-checks",
+        "npm-package-arg",
+        "npm-pick-manifest",
+        "npm-profile",
+        "npm-registry-fetch",
+        "npm-user-validate",
+        "npmlog",
+        "opener",
+        "pacote",
+        "parse-conflict-json",
+        "qrcode-terminal",
+        "read",
+        "read-package-json",
+        "read-package-json-fast",
+        "readdir-scoped-modules",
+        "rimraf",
+        "semver",
+        "ssri",
+        "tar",
+        "text-table",
+        "tiny-relative-date",
+        "treeverse",
+        "validate-npm-package-name",
+        "which",
+        "write-file-atomic"
+      ],
+      "dev": true,
+      "dependencies": {
+        "@isaacs/string-locale-compare": "*",
+        "@npmcli/arborist": "*",
+        "@npmcli/ci-detect": "*",
+        "@npmcli/config": "*",
+        "@npmcli/map-workspaces": "*",
+        "@npmcli/package-json": "*",
+        "@npmcli/run-script": "*",
+        "abbrev": "*",
+        "ansicolors": "*",
+        "ansistyles": "*",
+        "archy": "*",
+        "cacache": "*",
+        "chalk": "*",
+        "chownr": "*",
+        "cli-columns": "*",
+        "cli-table3": "*",
+        "columnify": "*",
+        "fastest-levenshtein": "*",
+        "glob": "*",
+        "graceful-fs": "*",
+        "hosted-git-info": "*",
+        "ini": "*",
+        "init-package-json": "*",
+        "is-cidr": "*",
+        "json-parse-even-better-errors": "*",
+        "libnpmaccess": "*",
+        "libnpmdiff": "*",
+        "libnpmexec": "*",
+        "libnpmfund": "*",
+        "libnpmhook": "*",
+        "libnpmorg": "*",
+        "libnpmpack": "*",
+        "libnpmpublish": "*",
+        "libnpmsearch": "*",
+        "libnpmteam": "*",
+        "libnpmversion": "*",
+        "make-fetch-happen": "*",
+        "minipass": "*",
+        "minipass-pipeline": "*",
+        "mkdirp": "*",
+        "mkdirp-infer-owner": "*",
+        "ms": "*",
+        "node-gyp": "*",
+        "nopt": "*",
+        "npm-audit-report": "*",
+        "npm-install-checks": "*",
+        "npm-package-arg": "*",
+        "npm-pick-manifest": "*",
+        "npm-profile": "*",
+        "npm-registry-fetch": "*",
+        "npm-user-validate": "*",
+        "npmlog": "*",
+        "opener": "*",
+        "pacote": "*",
+        "parse-conflict-json": "*",
+        "qrcode-terminal": "*",
+        "read": "*",
+        "read-package-json": "*",
+        "read-package-json-fast": "*",
+        "readdir-scoped-modules": "*",
+        "rimraf": "*",
+        "semver": "*",
+        "ssri": "*",
+        "tar": "*",
+        "text-table": "*",
+        "tiny-relative-date": "*",
+        "treeverse": "*",
+        "validate-npm-package-name": "*",
+        "which": "*",
+        "write-file-atomic": "*"
+      },
+      "bin": {
+        "npm": "bin/npm-cli.js",
+        "npx": "bin/npx-cli.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/@gar/promisify": {
+      "version": "1.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/@isaacs/string-locale-compare": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/@npmcli/arborist": {
+      "version": "2.9.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@isaacs/string-locale-compare": "^1.0.1",
+        "@npmcli/installed-package-contents": "^1.0.7",
+        "@npmcli/map-workspaces": "^1.0.2",
+        "@npmcli/metavuln-calculator": "^1.1.0",
+        "@npmcli/move-file": "^1.1.0",
+        "@npmcli/name-from-folder": "^1.0.1",
+        "@npmcli/node-gyp": "^1.0.1",
+        "@npmcli/package-json": "^1.0.1",
+        "@npmcli/run-script": "^1.8.2",
+        "bin-links": "^2.2.1",
+        "cacache": "^15.0.3",
+        "common-ancestor-path": "^1.0.1",
+        "json-parse-even-better-errors": "^2.3.1",
+        "json-stringify-nice": "^1.1.4",
+        "mkdirp": "^1.0.4",
+        "mkdirp-infer-owner": "^2.0.0",
+        "npm-install-checks": "^4.0.0",
+        "npm-package-arg": "^8.1.5",
+        "npm-pick-manifest": "^6.1.0",
+        "npm-registry-fetch": "^11.0.0",
+        "pacote": "^11.3.5",
+        "parse-conflict-json": "^1.1.1",
+        "proc-log": "^1.0.0",
+        "promise-all-reject-late": "^1.0.0",
+        "promise-call-limit": "^1.0.1",
+        "read-package-json-fast": "^2.0.2",
+        "readdir-scoped-modules": "^1.1.0",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "ssri": "^8.0.1",
+        "treeverse": "^1.0.4",
+        "walk-up-path": "^1.0.0"
+      },
+      "bin": {
+        "arborist": "bin/index.js"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/npm/node_modules/@npmcli/ci-detect": {
+      "version": "1.3.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/@npmcli/config": {
+      "version": "2.3.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "ini": "^2.0.0",
+        "mkdirp-infer-owner": "^2.0.0",
+        "nopt": "^5.0.0",
+        "semver": "^7.3.4",
+        "walk-up-path": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/@npmcli/disparity-colors": {
+      "version": "1.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "ansi-styles": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/@npmcli/fs": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@gar/promisify": "^1.0.1",
+        "semver": "^7.3.5"
+      }
+    },
+    "node_modules/npm/node_modules/@npmcli/git": {
+      "version": "2.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/promise-spawn": "^1.3.2",
+        "lru-cache": "^6.0.0",
+        "mkdirp": "^1.0.4",
+        "npm-pick-manifest": "^6.1.1",
+        "promise-inflight": "^1.0.1",
+        "promise-retry": "^2.0.1",
+        "semver": "^7.3.5",
+        "which": "^2.0.2"
+      }
+    },
+    "node_modules/npm/node_modules/@npmcli/installed-package-contents": {
+      "version": "1.0.7",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "npm-bundled": "^1.1.1",
+        "npm-normalize-package-bin": "^1.0.1"
+      },
+      "bin": {
+        "installed-package-contents": "index.js"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/npm/node_modules/@npmcli/map-workspaces": {
+      "version": "1.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/name-from-folder": "^1.0.1",
+        "glob": "^7.1.6",
+        "minimatch": "^3.0.4",
+        "read-package-json-fast": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "cacache": "^15.0.5",
+        "pacote": "^11.1.11",
+        "semver": "^7.3.2"
+      }
+    },
+    "node_modules/npm/node_modules/@npmcli/move-file": {
+      "version": "1.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "mkdirp": "^1.0.4",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/@npmcli/name-from-folder": {
+      "version": "1.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/@npmcli/node-gyp": {
+      "version": "1.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/@npmcli/package-json": {
+      "version": "1.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "json-parse-even-better-errors": "^2.3.1"
+      }
+    },
+    "node_modules/npm/node_modules/@npmcli/promise-spawn": {
+      "version": "1.3.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "infer-owner": "^1.0.4"
+      }
+    },
+    "node_modules/npm/node_modules/@npmcli/run-script": {
+      "version": "1.8.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/node-gyp": "^1.0.2",
+        "@npmcli/promise-spawn": "^1.3.2",
+        "node-gyp": "^7.1.0",
+        "read-package-json-fast": "^2.0.1"
+      }
+    },
+    "node_modules/npm/node_modules/@tootallnate/once": {
+      "version": "1.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/npm/node_modules/abbrev": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/agent-base": {
+      "version": "6.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/agentkeepalive": {
+      "version": "4.1.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.0",
+        "depd": "^1.1.2",
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/aggregate-error": {
+      "version": "3.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/ajv": {
+      "version": "6.12.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/npm/node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/npm/node_modules/ansicolors": {
+      "version": "0.3.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/ansistyles": {
+      "version": "0.1.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/aproba": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/archy": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/are-we-there-yet": {
+      "version": "1.1.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/asap": {
+      "version": "2.0.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/asn1": {
+      "version": "0.2.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "node_modules/npm/node_modules/assert-plus": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/npm/node_modules/asynckit": {
+      "version": "0.4.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/aws-sign2": {
+      "version": "0.7.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/npm/node_modules/aws4": {
+      "version": "1.11.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "node_modules/npm/node_modules/bin-links": {
+      "version": "2.2.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "cmd-shim": "^4.0.1",
+        "mkdirp": "^1.0.3",
+        "npm-normalize-package-bin": "^1.0.0",
+        "read-cmd-shim": "^2.0.0",
+        "rimraf": "^3.0.0",
+        "write-file-atomic": "^3.0.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/binary-extensions": {
+      "version": "2.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/npm/node_modules/builtins": {
+      "version": "1.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/cacache": {
+      "version": "15.3.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/fs": "^1.0.0",
+        "@npmcli/move-file": "^1.0.1",
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "glob": "^7.1.4",
+        "infer-owner": "^1.0.4",
+        "lru-cache": "^6.0.0",
+        "minipass": "^3.1.1",
+        "minipass-collect": "^1.0.2",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.2",
+        "mkdirp": "^1.0.3",
+        "p-map": "^4.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^3.0.2",
+        "ssri": "^8.0.1",
+        "tar": "^6.0.2",
+        "unique-filename": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/npm/node_modules/caseless": {
+      "version": "0.12.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/npm/node_modules/chalk": {
+      "version": "4.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/npm/node_modules/chownr": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/cidr-regex": {
+      "version": "3.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "ip-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/clean-stack": {
+      "version": "2.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/cli-columns": {
+      "version": "3.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^2.0.0",
+        "strip-ansi": "^3.0.1"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/npm/node_modules/cli-table3": {
+      "version": "0.6.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4.1.0",
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      },
+      "optionalDependencies": {
+        "colors": "^1.1.2"
+      }
+    },
+    "node_modules/npm/node_modules/cli-table3/node_modules/ansi-regex": {
+      "version": "5.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/cli-table3/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/cli-table3/node_modules/string-width": {
+      "version": "4.2.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/cli-table3/node_modules/strip-ansi": {
+      "version": "6.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/clone": {
+      "version": "1.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/npm/node_modules/cmd-shim": {
+      "version": "4.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "mkdirp-infer-owner": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/code-point-at": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/color-convert": {
+      "version": "2.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/color-name": {
+      "version": "1.1.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/color-support": {
+      "version": "1.1.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "color-support": "bin.js"
+      }
+    },
+    "node_modules/npm/node_modules/colors": {
+      "version": "1.4.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/npm/node_modules/columnify": {
+      "version": "1.5.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "strip-ansi": "^3.0.0",
+        "wcwidth": "^1.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/combined-stream": {
+      "version": "1.0.8",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/npm/node_modules/common-ancestor-path": {
+      "version": "1.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/concat-map": {
+      "version": "0.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/console-control-strings": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/core-util-is": {
+      "version": "1.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/dashdash": {
+      "version": "1.14.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/npm/node_modules/debug": {
+      "version": "4.3.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/npm/node_modules/debug/node_modules/ms": {
+      "version": "2.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/debuglog": {
+      "version": "1.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/npm/node_modules/defaults": {
+      "version": "1.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone": "^1.0.2"
+      }
+    },
+    "node_modules/npm/node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/npm/node_modules/delegates": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/depd": {
+      "version": "1.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/npm/node_modules/dezalgo": {
+      "version": "1.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/npm/node_modules/diff": {
+      "version": "5.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/npm/node_modules/ecc-jsbn": {
+      "version": "0.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
+    "node_modules/npm/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/encoding": {
+      "version": "0.1.13",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
+    "node_modules/npm/node_modules/env-paths": {
+      "version": "2.2.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/err-code": {
+      "version": "2.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/extend": {
+      "version": "3.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/extsprintf": {
+      "version": "1.3.0",
+      "dev": true,
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/fastest-levenshtein": {
+      "version": "1.0.12",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/forever-agent": {
+      "version": "0.6.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/npm/node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/npm/node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/function-bind": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/gauge": {
+      "version": "3.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^1.0.3 || ^2.0.0",
+        "color-support": "^1.1.2",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.1",
+        "object-assign": "^4.1.1",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1 || ^2.0.0",
+        "strip-ansi": "^3.0.1 || ^4.0.0",
+        "wide-align": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/getpass": {
+      "version": "0.1.7",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/glob": {
+      "version": "7.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/npm/node_modules/graceful-fs": {
+      "version": "4.2.8",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/har-schema": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/har-validator": {
+      "version": "5.1.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.3",
+        "har-schema": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/has": {
+      "version": "1.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/npm/node_modules/has-flag": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/has-unicode": {
+      "version": "2.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/hosted-git-info": {
+      "version": "4.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/http-cache-semantics": {
+      "version": "4.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/npm/node_modules/http-proxy-agent": {
+      "version": "4.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/once": "1",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/npm/node_modules/http-signature": {
+      "version": "1.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      },
+      "engines": {
+        "node": ">=0.8",
+        "npm": ">=1.3.7"
+      }
+    },
+    "node_modules/npm/node_modules/https-proxy-agent": {
+      "version": "5.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/npm/node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/ignore-walk": {
+      "version": "3.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "minimatch": "^3.0.4"
+      }
+    },
+    "node_modules/npm/node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/npm/node_modules/indent-string": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/infer-owner": {
+      "version": "1.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/inflight": {
+      "version": "1.0.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/npm/node_modules/inherits": {
+      "version": "2.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/ini": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/init-package-json": {
+      "version": "2.0.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "npm-package-arg": "^8.1.5",
+        "promzard": "^0.3.0",
+        "read": "~1.0.1",
+        "read-package-json": "^4.1.1",
+        "semver": "^7.3.5",
+        "validate-npm-package-license": "^3.0.4",
+        "validate-npm-package-name": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/ip": {
+      "version": "1.1.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/ip-regex": {
+      "version": "4.3.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/is-cidr": {
+      "version": "4.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "cidr-regex": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/is-core-module": {
+      "version": "2.7.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "has": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/npm/node_modules/is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/is-lambda": {
+      "version": "1.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/is-typedarray": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/isexe": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/isstream": {
+      "version": "0.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/jsbn": {
+      "version": "0.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/json-schema": {
+      "version": "0.2.3",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/json-stringify-nice": {
+      "version": "1.1.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/npm/node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/jsonparse": {
+      "version": "1.3.1",
+      "dev": true,
+      "engines": [
+        "node >= 0.2.0"
+      ],
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/jsprim": {
+      "version": "1.4.1",
+      "dev": true,
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/just-diff": {
+      "version": "3.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/just-diff-apply": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/libnpmaccess": {
+      "version": "4.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^2.0.0",
+        "minipass": "^3.1.1",
+        "npm-package-arg": "^8.1.2",
+        "npm-registry-fetch": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmdiff": {
+      "version": "2.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/disparity-colors": "^1.0.1",
+        "@npmcli/installed-package-contents": "^1.0.7",
+        "binary-extensions": "^2.2.0",
+        "diff": "^5.0.0",
+        "minimatch": "^3.0.4",
+        "npm-package-arg": "^8.1.4",
+        "pacote": "^11.3.4",
+        "tar": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmexec": {
+      "version": "2.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/arborist": "^2.3.0",
+        "@npmcli/ci-detect": "^1.3.0",
+        "@npmcli/run-script": "^1.8.4",
+        "chalk": "^4.1.0",
+        "mkdirp-infer-owner": "^2.0.0",
+        "npm-package-arg": "^8.1.2",
+        "pacote": "^11.3.1",
+        "proc-log": "^1.0.0",
+        "read": "^1.0.7",
+        "read-package-json-fast": "^2.0.2",
+        "walk-up-path": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmfund": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/arborist": "^2.5.0"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmhook": {
+      "version": "6.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^2.0.0",
+        "npm-registry-fetch": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmorg": {
+      "version": "2.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^2.0.0",
+        "npm-registry-fetch": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmpack": {
+      "version": "2.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/run-script": "^1.8.3",
+        "npm-package-arg": "^8.1.0",
+        "pacote": "^11.2.6"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmpublish": {
+      "version": "4.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-package-data": "^3.0.2",
+        "npm-package-arg": "^8.1.2",
+        "npm-registry-fetch": "^11.0.0",
+        "semver": "^7.1.3",
+        "ssri": "^8.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmsearch": {
+      "version": "3.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "npm-registry-fetch": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmteam": {
+      "version": "2.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^2.0.0",
+        "npm-registry-fetch": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmversion": {
+      "version": "1.2.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/git": "^2.0.7",
+        "@npmcli/run-script": "^1.8.4",
+        "json-parse-even-better-errors": "^2.3.1",
+        "semver": "^7.3.5",
+        "stringify-package": "^1.0.1"
+      }
+    },
+    "node_modules/npm/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/make-fetch-happen": {
+      "version": "9.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "agentkeepalive": "^4.1.3",
+        "cacache": "^15.2.0",
+        "http-cache-semantics": "^4.1.0",
+        "http-proxy-agent": "^4.0.1",
+        "https-proxy-agent": "^5.0.0",
+        "is-lambda": "^1.0.1",
+        "lru-cache": "^6.0.0",
+        "minipass": "^3.1.3",
+        "minipass-collect": "^1.0.2",
+        "minipass-fetch": "^1.3.2",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "negotiator": "^0.6.2",
+        "promise-retry": "^2.0.1",
+        "socks-proxy-agent": "^6.0.0",
+        "ssri": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/npm/node_modules/mime-db": {
+      "version": "1.49.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/npm/node_modules/mime-types": {
+      "version": "2.1.32",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.49.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/npm/node_modules/minimatch": {
+      "version": "3.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/npm/node_modules/minipass": {
+      "version": "3.1.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/minipass-collect": {
+      "version": "1.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/npm/node_modules/minipass-fetch": {
+      "version": "1.4.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^3.1.0",
+        "minipass-sized": "^1.0.3",
+        "minizlib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "optionalDependencies": {
+        "encoding": "^0.1.12"
+      }
+    },
+    "node_modules/npm/node_modules/minipass-flush": {
+      "version": "1.0.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/npm/node_modules/minipass-json-stream": {
+      "version": "1.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "jsonparse": "^1.3.1",
+        "minipass": "^3.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/minipass-pipeline": {
+      "version": "1.2.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/minipass-sized": {
+      "version": "1.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/minizlib": {
+      "version": "2.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/npm/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/mkdirp-infer-owner": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "infer-owner": "^1.0.4",
+        "mkdirp": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/ms": {
+      "version": "2.1.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/mute-stream": {
+      "version": "0.0.8",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/negotiator": {
+      "version": "0.6.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/npm/node_modules/node-gyp": {
+      "version": "7.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.0",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.3",
+        "nopt": "^5.0.0",
+        "npmlog": "^4.1.2",
+        "request": "^2.88.2",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.2",
+        "tar": "^6.0.2",
+        "which": "^2.0.2"
+      },
+      "bin": {
+        "node-gyp": "bin/node-gyp.js"
+      },
+      "engines": {
+        "node": ">= 10.12.0"
+      }
+    },
+    "node_modules/npm/node_modules/node-gyp/node_modules/aproba": {
+      "version": "1.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/node-gyp/node_modules/gauge": {
+      "version": "2.7.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
+      }
+    },
+    "node_modules/npm/node_modules/node-gyp/node_modules/is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "number-is-nan": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/node-gyp/node_modules/npmlog": {
+      "version": "4.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/node-gyp/node_modules/string-width": {
+      "version": "1.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/nopt": {
+      "version": "5.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/normalize-package-data": {
+      "version": "3.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "hosted-git-info": "^4.0.1",
+        "is-core-module": "^2.5.0",
+        "semver": "^7.3.4",
+        "validate-npm-package-license": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/npm-audit-report": {
+      "version": "2.1.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/npm-bundled": {
+      "version": "1.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "npm-normalize-package-bin": "^1.0.1"
+      }
+    },
+    "node_modules/npm/node_modules/npm-install-checks": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "semver": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/npm-normalize-package-bin": {
+      "version": "1.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/npm-package-arg": {
+      "version": "8.1.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "hosted-git-info": "^4.0.1",
+        "semver": "^7.3.4",
+        "validate-npm-package-name": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/npm-packlist": {
+      "version": "2.2.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.6",
+        "ignore-walk": "^3.0.3",
+        "npm-bundled": "^1.1.1",
+        "npm-normalize-package-bin": "^1.0.1"
+      },
+      "bin": {
+        "npm-packlist": "bin/index.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/npm-pick-manifest": {
+      "version": "6.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "npm-install-checks": "^4.0.0",
+        "npm-normalize-package-bin": "^1.0.1",
+        "npm-package-arg": "^8.1.2",
+        "semver": "^7.3.4"
+      }
+    },
+    "node_modules/npm/node_modules/npm-profile": {
+      "version": "5.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "npm-registry-fetch": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/npm-registry-fetch": {
+      "version": "11.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "make-fetch-happen": "^9.0.1",
+        "minipass": "^3.1.3",
+        "minipass-fetch": "^1.3.0",
+        "minipass-json-stream": "^1.0.1",
+        "minizlib": "^2.0.0",
+        "npm-package-arg": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/npm-user-validate": {
+      "version": "1.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/npm/node_modules/npmlog": {
+      "version": "5.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "are-we-there-yet": "^2.0.0",
+        "console-control-strings": "^1.1.0",
+        "gauge": "^3.0.0",
+        "set-blocking": "^2.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/npmlog/node_modules/are-we-there-yet": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/number-is-nan": {
+      "version": "1.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/oauth-sign": {
+      "version": "0.9.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/npm/node_modules/object-assign": {
+      "version": "4.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/once": {
+      "version": "1.4.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/npm/node_modules/opener": {
+      "version": "1.5.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "(WTFPL OR MIT)",
+      "bin": {
+        "opener": "bin/opener-bin.js"
+      }
+    },
+    "node_modules/npm/node_modules/p-map": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "aggregate-error": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm/node_modules/pacote": {
+      "version": "11.3.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/git": "^2.1.0",
+        "@npmcli/installed-package-contents": "^1.0.6",
+        "@npmcli/promise-spawn": "^1.2.0",
+        "@npmcli/run-script": "^1.8.2",
+        "cacache": "^15.0.5",
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.1.0",
+        "infer-owner": "^1.0.4",
+        "minipass": "^3.1.3",
+        "mkdirp": "^1.0.3",
+        "npm-package-arg": "^8.0.1",
+        "npm-packlist": "^2.1.4",
+        "npm-pick-manifest": "^6.0.0",
+        "npm-registry-fetch": "^11.0.0",
+        "promise-retry": "^2.0.1",
+        "read-package-json-fast": "^2.0.1",
+        "rimraf": "^3.0.2",
+        "ssri": "^8.0.1",
+        "tar": "^6.1.0"
+      },
+      "bin": {
+        "pacote": "lib/bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/parse-conflict-json": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "json-parse-even-better-errors": "^2.3.0",
+        "just-diff": "^3.0.1",
+        "just-diff-apply": "^3.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/performance-now": {
+      "version": "2.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/proc-log": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/promise-all-reject-late": {
+      "version": "1.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/npm/node_modules/promise-call-limit": {
+      "version": "1.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/npm/node_modules/promise-inflight": {
+      "version": "1.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/promise-retry": {
+      "version": "2.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "err-code": "^2.0.2",
+        "retry": "^0.12.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/promzard": {
+      "version": "0.3.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "read": "1"
+      }
+    },
+    "node_modules/npm/node_modules/psl": {
+      "version": "1.8.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/punycode": {
+      "version": "2.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/qrcode-terminal": {
+      "version": "0.12.0",
+      "dev": true,
+      "inBundle": true,
+      "bin": {
+        "qrcode-terminal": "bin/qrcode-terminal.js"
+      }
+    },
+    "node_modules/npm/node_modules/qs": {
+      "version": "6.5.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/npm/node_modules/read": {
+      "version": "1.0.7",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "mute-stream": "~0.0.4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/npm/node_modules/read-cmd-shim": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/read-package-json": {
+      "version": "4.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "normalize-package-data": "^3.0.0",
+        "npm-normalize-package-bin": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/read-package-json-fast": {
+      "version": "2.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "json-parse-even-better-errors": "^2.3.0",
+        "npm-normalize-package-bin": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/readable-stream": {
+      "version": "3.6.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/npm/node_modules/readdir-scoped-modules": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "debuglog": "^1.0.1",
+        "dezalgo": "^1.0.0",
+        "graceful-fs": "^4.1.2",
+        "once": "^1.3.0"
+      }
+    },
+    "node_modules/npm/node_modules/request": {
+      "version": "2.88.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/npm/node_modules/request/node_modules/form-data": {
+      "version": "2.3.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
+    "node_modules/npm/node_modules/request/node_modules/tough-cookie": {
+      "version": "2.5.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/npm/node_modules/retry": {
+      "version": "0.12.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/npm/node_modules/rimraf": {
+      "version": "3.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/npm/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/semver": {
+      "version": "7.3.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/set-blocking": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/signal-exit": {
+      "version": "3.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/socks": {
+      "version": "2.6.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip": "^1.1.5",
+        "smart-buffer": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/socks-proxy-agent": {
+      "version": "6.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^6.0.2",
+        "debug": "^4.3.1",
+        "socks": "^2.6.1"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/npm/node_modules/spdx-correct": {
+      "version": "3.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/spdx-exceptions": {
+      "version": "2.3.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "CC-BY-3.0"
+    },
+    "node_modules/npm/node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/spdx-license-ids": {
+      "version": "3.0.10",
+      "dev": true,
+      "inBundle": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/npm/node_modules/sshpk": {
+      "version": "1.16.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/ssri": {
+      "version": "8.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/npm/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/npm/node_modules/string-width": {
+      "version": "2.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/string-width/node_modules/ansi-regex": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/string-width/node_modules/strip-ansi": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/stringify-package": {
+      "version": "1.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/strip-ansi": {
+      "version": "3.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/supports-color": {
+      "version": "7.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/tar": {
+      "version": "6.1.11",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^3.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/npm/node_modules/text-table": {
+      "version": "0.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/tiny-relative-date": {
+      "version": "1.3.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/treeverse": {
+      "version": "1.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/npm/node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "Unlicense"
+    },
+    "node_modules/npm/node_modules/typedarray-to-buffer": {
+      "version": "3.1.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-typedarray": "^1.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/unique-filename": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "unique-slug": "^2.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/unique-slug": {
+      "version": "2.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4"
+      }
+    },
+    "node_modules/npm/node_modules/uri-js": {
+      "version": "4.4.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/npm/node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/uuid": {
+      "version": "3.4.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
+    "node_modules/npm/node_modules/validate-npm-package-license": {
+      "version": "3.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/validate-npm-package-name": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "builtins": "^1.0.3"
+      }
+    },
+    "node_modules/npm/node_modules/verror": {
+      "version": "1.10.0",
+      "dev": true,
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
+    },
+    "node_modules/npm/node_modules/walk-up-path": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/wcwidth": {
+      "version": "1.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/npm/node_modules/which": {
+      "version": "2.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/npm/node_modules/wide-align": {
+      "version": "1.1.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^1.0.2 || 2"
+      }
+    },
+    "node_modules/npm/node_modules/wrappy": {
+      "version": "1.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/write-file-atomic": {
+      "version": "3.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "is-typedarray": "^1.0.0",
+        "signal-exit": "^3.0.2",
+        "typedarray-to-buffer": "^3.1.5"
+      }
+    },
+    "node_modules/npm/node_modules/yallist": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/nyc": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/nyc/-/nyc-15.1.0.tgz",
+      "integrity": "sha512-jMW04n9SxKdKi1ZMGhvUTHBN0EICCRkHemEoE5jm6mTYcqcdas0ATzgUgejlQUHMvpnOZqGB5Xxsv9KxJW1j8A==",
+      "dev": true,
+      "dependencies": {
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.2",
+        "caching-transform": "^4.0.0",
+        "convert-source-map": "^1.7.0",
+        "decamelize": "^1.2.0",
+        "find-cache-dir": "^3.2.0",
+        "find-up": "^4.1.0",
+        "foreground-child": "^2.0.0",
+        "get-package-type": "^0.1.0",
+        "glob": "^7.1.6",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-hook": "^3.0.0",
+        "istanbul-lib-instrument": "^4.0.0",
+        "istanbul-lib-processinfo": "^2.0.2",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.0",
+        "istanbul-reports": "^3.0.2",
+        "make-dir": "^3.0.0",
+        "node-preload": "^0.2.1",
+        "p-map": "^3.0.0",
+        "process-on-spawn": "^1.0.0",
+        "resolve-from": "^5.0.0",
+        "rimraf": "^3.0.0",
+        "signal-exit": "^3.0.2",
+        "spawn-wrap": "^2.0.0",
+        "test-exclude": "^6.0.0",
+        "yargs": "^15.0.2"
+      },
+      "bin": {
+        "nyc": "bin/nyc.js"
+      },
+      "engines": {
+        "node": ">=8.9"
+      }
+    },
+    "node_modules/nyc/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/nyc/node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/nyc/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/nyc/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/nyc/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/nyc/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/nyc/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/nyc/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/nyc/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/nyc/node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "dev": true
+    },
+    "node_modules/nyc/node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/nyc/node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "dev": true,
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-each-series": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.2.0.tgz",
+      "integrity": "sha512-ycIL2+1V32th+8scbpTvyHNaHe02z0sjgh91XXjAk+ZeXoPN4Z46DVUnzdso0aX4KckKw0FNNFHdjZ2UsZvxiA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-filter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-filter/-/p-filter-2.1.0.tgz",
+      "integrity": "sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==",
+      "dev": true,
+      "dependencies": {
+        "p-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-filter/node_modules/p-map": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+      "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/p-is-promise": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-3.0.0.tgz",
+      "integrity": "sha512-Wo8VsW4IRQSKVXsJCn7TomUaVtyfjVDn3nUP7kE967BQk0CwFpdbZs0X0uk5sW9mkBa9eNM7hCMaG93WUAwxYQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-map": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
+      "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
+      "dev": true,
+      "dependencies": {
+        "aggregate-error": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-reduce": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-2.1.0.tgz",
+      "integrity": "sha512-2USApvnsutq8uoxZBGbbWM0JIYLiEMJ9RlaN7fAzVNb9OZN0SHjjTTfIcb667XynS5Y1VhwDJVDa72TnPzAYWw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/package-hash": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/package-hash/-/package-hash-4.0.0.tgz",
+      "integrity": "sha512-whdkPIooSu/bASggZ96BWVvZTRMOFxnyUG5PnTSGKoJE2gd5mbVNmR2Nj20QFzxYYgAXpoqC+AiXzl+UMRh7zQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.15",
+        "hasha": "^5.0.0",
+        "lodash.flattendeep": "^4.4.0",
+        "release-zalgo": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pkg-conf": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-2.1.0.tgz",
+      "integrity": "sha512-C+VUP+8jis7EsQZIhDYmS5qlNtjv2yP4SNtjXK9AP1ZcTRlnSfuumaTnRfYZnYgUUYVIKqL0fRvmUGDV2fmp6g==",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^2.0.0",
+        "load-json-file": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pkg-conf/node_modules/find-up": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+      "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pkg-conf/node_modules/locate-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pkg-conf/node_modules/p-limit": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pkg-conf/node_modules/p-locate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pkg-conf/node_modules/p-try": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pkg-conf/node_modules/path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
+    },
+    "node_modules/process-on-spawn": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/process-on-spawn/-/process-on-spawn-1.0.0.tgz",
+      "integrity": "sha512-1WsPDsUSMmZH5LeMLegqkPDrsGgsWwk1Exipy2hvB0o/F0ASzbpIctSCcZIK1ykJvtTJULEH+20WOFjMvGnCTg==",
+      "dev": true,
+      "dependencies": {
+        "fromentries": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dev": true,
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.6.0",
+        "teleport": ">=0.2.0"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/quick-lru": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
+      "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/read-pkg": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+      "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+      "dev": true,
+      "dependencies": {
+        "@types/normalize-package-data": "^2.4.0",
+        "normalize-package-data": "^2.5.0",
+        "parse-json": "^5.0.0",
+        "type-fest": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/read-pkg-up": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+      "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^4.1.0",
+        "read-pkg": "^5.2.0",
+        "type-fest": "^0.8.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/read-pkg/node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg/node_modules/type-fest": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+      "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/redeyed": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-2.1.1.tgz",
+      "integrity": "sha512-FNpGGo1DycYAdnrKFxCMmKYgo/mILAqtRYbkdQD8Ep/Hk2PQ5+aEAEx+IU713RTDmuBaH0c8P5ZozurNu5ObRQ==",
+      "dev": true,
+      "dependencies": {
+        "esprima": "~4.0.0"
+      }
+    },
+    "node_modules/registry-auth-token": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.1.tgz",
+      "integrity": "sha512-6gkSb4U6aWJB4SF2ZvLb76yCBjcvufXBqvvEx1HbmKPkutswjW1xNVRY0+daljIYRbogN7O0etYSlbiaEQyMyw==",
+      "dev": true,
+      "dependencies": {
+        "rc": "^1.2.8"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/release-zalgo": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
+      "integrity": "sha512-gUAyHVHPPC5wdqX/LG4LWtRYtgjxyX78oanFNTMMyFEfOqdC54s3eE82imuWKbOeqYht2CrNf64Qb8vgmmtZGA==",
+      "dev": true,
+      "dependencies": {
+        "es6-error": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "dev": true
+    },
+    "node_modules/resolve": {
+      "version": "1.22.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
+      "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
+      "dev": true,
+      "dependencies": {
+        "is-core-module": "^2.9.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true,
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "node_modules/semantic-release": {
+      "version": "19.0.3",
+      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-19.0.3.tgz",
+      "integrity": "sha512-HaFbydST1cDKZHuFZxB8DTrBLJVK/AnDExpK0s3EqLIAAUAHUgnd+VSJCUtTYQKkAkauL8G9CucODrVCc7BuAA==",
+      "dev": true,
+      "dependencies": {
+        "@semantic-release/commit-analyzer": "^9.0.2",
+        "@semantic-release/error": "^3.0.0",
+        "@semantic-release/github": "^8.0.0",
+        "@semantic-release/npm": "^9.0.0",
+        "@semantic-release/release-notes-generator": "^10.0.0",
+        "aggregate-error": "^3.0.0",
+        "cosmiconfig": "^7.0.0",
+        "debug": "^4.0.0",
+        "env-ci": "^5.0.0",
+        "execa": "^5.0.0",
+        "figures": "^3.0.0",
+        "find-versions": "^4.0.0",
+        "get-stream": "^6.0.0",
+        "git-log-parser": "^1.2.0",
+        "hook-std": "^2.0.0",
+        "hosted-git-info": "^4.0.0",
+        "lodash": "^4.17.21",
+        "marked": "^4.0.10",
+        "marked-terminal": "^5.0.0",
+        "micromatch": "^4.0.2",
+        "p-each-series": "^2.1.0",
+        "p-reduce": "^2.0.0",
+        "read-pkg-up": "^7.0.0",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.3.2",
+        "semver-diff": "^3.1.1",
+        "signale": "^1.2.1",
+        "yargs": "^16.2.0"
+      },
+      "bin": {
+        "semantic-release": "bin/semantic-release.js"
+      },
+      "engines": {
+        "node": ">=16 || ^14.17"
+      }
+    },
+    "node_modules/semantic-release/node_modules/@semantic-release/commit-analyzer": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-9.0.2.tgz",
+      "integrity": "sha512-E+dr6L+xIHZkX4zNMe6Rnwg4YQrWNXK+rNsvwOPpdFppvZO1olE2fIgWhv89TkQErygevbjsZFSIxp+u6w2e5g==",
+      "dev": true,
+      "dependencies": {
+        "conventional-changelog-angular": "^5.0.0",
+        "conventional-commits-filter": "^2.0.0",
+        "conventional-commits-parser": "^3.2.3",
+        "debug": "^4.0.0",
+        "import-from": "^4.0.0",
+        "lodash": "^4.17.4",
+        "micromatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=14.17"
+      },
+      "peerDependencies": {
+        "semantic-release": ">=18.0.0-beta.1"
+      }
+    },
+    "node_modules/semantic-release/node_modules/@semantic-release/error": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-3.0.0.tgz",
+      "integrity": "sha512-5hiM4Un+tpl4cKw3lV4UgzJj+SmfNIDCLLw0TepzQxz9ZGV5ixnqkzIVF+3tp0ZHgcMKE+VNGHJjEeyFG2dcSw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/semantic-release/node_modules/@semantic-release/github": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-8.0.4.tgz",
+      "integrity": "sha512-But4e8oqqP3anZI5tjzZssZc2J6eoUdeeE0s7LVKKwyiAXJiQDWNNvtPOpgG2DsIz4+Exuse7cEQgjGMxwtLmg==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/rest": "^18.0.0",
+        "@semantic-release/error": "^2.2.0",
+        "aggregate-error": "^3.0.0",
+        "bottleneck": "^2.18.1",
+        "debug": "^4.0.0",
+        "dir-glob": "^3.0.0",
+        "fs-extra": "^10.0.0",
+        "globby": "^11.0.0",
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "issue-parser": "^6.0.0",
+        "lodash": "^4.17.4",
+        "mime": "^3.0.0",
+        "p-filter": "^2.0.0",
+        "p-retry": "^4.0.0",
+        "url-join": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.17"
+      },
+      "peerDependencies": {
+        "semantic-release": ">=18.0.0-beta.1"
+      }
+    },
+    "node_modules/semantic-release/node_modules/@semantic-release/github/node_modules/@semantic-release/error": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-2.2.0.tgz",
+      "integrity": "sha512-9Tj/qn+y2j+sjCI3Jd+qseGtHjOAeg7dU2/lVcqIQ9TV3QDaDXDYXcoOHU+7o2Hwh8L8ymL4gfuO7KxDs3q2zg==",
+      "dev": true
+    },
+    "node_modules/semantic-release/node_modules/@semantic-release/npm": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-9.0.1.tgz",
+      "integrity": "sha512-I5nVZklxBzfMFwemhRNbSrkiN/dsH3c7K9+KSk6jUnq0rdLFUuJt7EBsysq4Ir3moajQgFkfEryEHPqiKJj20g==",
+      "dev": true,
+      "dependencies": {
+        "@semantic-release/error": "^3.0.0",
+        "aggregate-error": "^3.0.0",
+        "execa": "^5.0.0",
+        "fs-extra": "^10.0.0",
+        "lodash": "^4.17.15",
+        "nerf-dart": "^1.0.0",
+        "normalize-url": "^6.0.0",
+        "npm": "^8.3.0",
+        "rc": "^1.2.8",
+        "read-pkg": "^5.0.0",
+        "registry-auth-token": "^4.0.0",
+        "semver": "^7.1.2",
+        "tempy": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16 || ^14.17"
+      },
+      "peerDependencies": {
+        "semantic-release": ">=19.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/@semantic-release/release-notes-generator": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-10.0.3.tgz",
+      "integrity": "sha512-k4x4VhIKneOWoBGHkx0qZogNjCldLPRiAjnIpMnlUh6PtaWXp/T+C9U7/TaNDDtgDa5HMbHl4WlREdxHio6/3w==",
+      "dev": true,
+      "dependencies": {
+        "conventional-changelog-angular": "^5.0.0",
+        "conventional-changelog-writer": "^5.0.0",
+        "conventional-commits-filter": "^2.0.0",
+        "conventional-commits-parser": "^3.2.3",
+        "debug": "^4.0.0",
+        "get-stream": "^6.0.0",
+        "import-from": "^4.0.0",
+        "into-stream": "^6.0.0",
+        "lodash": "^4.17.4",
+        "read-pkg-up": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.17"
+      },
+      "peerDependencies": {
+        "semantic-release": ">=18.0.0-beta.1"
+      }
+    },
+    "node_modules/semantic-release/node_modules/@tootallnate/once": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/semantic-release/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/semantic-release/node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/semantic-release/node_modules/conventional-changelog-writer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-5.0.1.tgz",
+      "integrity": "sha512-5WsuKUfxW7suLblAbFnxAcrvf6r+0b7GvNaWUwUIk0bXMnENP/PEieGKVUQrjPqwPT4o3EPAASBXiY6iHooLOQ==",
+      "dev": true,
+      "dependencies": {
+        "conventional-commits-filter": "^2.0.7",
+        "dateformat": "^3.0.0",
+        "handlebars": "^4.7.7",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.15",
+        "meow": "^8.0.0",
+        "semver": "^6.0.0",
+        "split": "^1.0.0",
+        "through2": "^4.0.0"
+      },
+      "bin": {
+        "conventional-changelog-writer": "cli.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semantic-release/node_modules/conventional-changelog-writer/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/semantic-release/node_modules/hosted-git-info": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.0.2.tgz",
+      "integrity": "sha512-c9OGXbZ3guC/xOlCg1Ci/VgWlwsqDv1yMQL1CWqXDL0hDjXuNcq0zuR4xqPSuasI3kqFDhqSyTjREz5gzq0fXg==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semantic-release/node_modules/http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "dev": true,
+      "dependencies": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/semantic-release/node_modules/import-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/import-from/-/import-from-4.0.0.tgz",
+      "integrity": "sha512-P9J71vT5nLlDeV8FHs5nNxaLbrpfAV5cF5srvbZfpwpcJoM/xZR3hiv+q+SAnuSmuGbXMWud063iIMx/V/EWZQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/semantic-release/node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "dev": true,
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm": {
+      "version": "8.12.1",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-8.12.1.tgz",
+      "integrity": "sha512-0yOlhfgu1UzP6UijnaFuIS2bES2H9D90EA5OVsf2iOZw7VBrjntXKEwKfCaFA6vMVWkCP8qnPwCxxPdnDVwlNw==",
+      "bundleDependencies": [
+        "@isaacs/string-locale-compare",
+        "@npmcli/arborist",
+        "@npmcli/ci-detect",
+        "@npmcli/config",
+        "@npmcli/fs",
+        "@npmcli/map-workspaces",
+        "@npmcli/package-json",
+        "@npmcli/run-script",
+        "abbrev",
+        "archy",
+        "cacache",
+        "chalk",
+        "chownr",
+        "cli-columns",
+        "cli-table3",
+        "columnify",
+        "fastest-levenshtein",
+        "glob",
+        "graceful-fs",
+        "hosted-git-info",
+        "ini",
+        "init-package-json",
+        "is-cidr",
+        "json-parse-even-better-errors",
+        "libnpmaccess",
+        "libnpmdiff",
+        "libnpmexec",
+        "libnpmfund",
+        "libnpmhook",
+        "libnpmorg",
+        "libnpmpack",
+        "libnpmpublish",
+        "libnpmsearch",
+        "libnpmteam",
+        "libnpmversion",
+        "make-fetch-happen",
+        "minipass",
+        "minipass-pipeline",
+        "mkdirp",
+        "mkdirp-infer-owner",
+        "ms",
+        "node-gyp",
+        "nopt",
+        "npm-audit-report",
+        "npm-install-checks",
+        "npm-package-arg",
+        "npm-pick-manifest",
+        "npm-profile",
+        "npm-registry-fetch",
+        "npm-user-validate",
+        "npmlog",
+        "opener",
+        "pacote",
+        "parse-conflict-json",
+        "proc-log",
+        "qrcode-terminal",
+        "read",
+        "read-package-json",
+        "read-package-json-fast",
+        "readdir-scoped-modules",
+        "rimraf",
+        "semver",
+        "ssri",
+        "tar",
+        "text-table",
+        "tiny-relative-date",
+        "treeverse",
+        "validate-npm-package-name",
+        "which",
+        "write-file-atomic"
+      ],
+      "dev": true,
+      "dependencies": {
+        "@isaacs/string-locale-compare": "^1.1.0",
+        "@npmcli/arborist": "^5.0.4",
+        "@npmcli/ci-detect": "^2.0.0",
+        "@npmcli/config": "^4.1.0",
+        "@npmcli/fs": "^2.1.0",
+        "@npmcli/map-workspaces": "^2.0.3",
+        "@npmcli/package-json": "^2.0.0",
+        "@npmcli/run-script": "^3.0.1",
+        "abbrev": "~1.1.1",
+        "archy": "~1.0.0",
+        "cacache": "^16.1.0",
+        "chalk": "^4.1.2",
+        "chownr": "^2.0.0",
+        "cli-columns": "^4.0.0",
+        "cli-table3": "^0.6.2",
+        "columnify": "^1.6.0",
+        "fastest-levenshtein": "^1.0.12",
+        "glob": "^8.0.1",
+        "graceful-fs": "^4.2.10",
+        "hosted-git-info": "^5.0.0",
+        "ini": "^3.0.0",
+        "init-package-json": "^3.0.2",
+        "is-cidr": "^4.0.2",
+        "json-parse-even-better-errors": "^2.3.1",
+        "libnpmaccess": "^6.0.2",
+        "libnpmdiff": "^4.0.2",
+        "libnpmexec": "^4.0.2",
+        "libnpmfund": "^3.0.1",
+        "libnpmhook": "^8.0.2",
+        "libnpmorg": "^4.0.2",
+        "libnpmpack": "^4.0.2",
+        "libnpmpublish": "^6.0.2",
+        "libnpmsearch": "^5.0.2",
+        "libnpmteam": "^4.0.2",
+        "libnpmversion": "^3.0.1",
+        "make-fetch-happen": "^10.1.6",
+        "minipass": "^3.1.6",
+        "minipass-pipeline": "^1.2.4",
+        "mkdirp": "^1.0.4",
+        "mkdirp-infer-owner": "^2.0.0",
+        "ms": "^2.1.2",
+        "node-gyp": "^9.0.0",
+        "nopt": "^5.0.0",
+        "npm-audit-report": "^3.0.0",
+        "npm-install-checks": "^5.0.0",
+        "npm-package-arg": "^9.0.2",
+        "npm-pick-manifest": "^7.0.1",
+        "npm-profile": "^6.0.3",
+        "npm-registry-fetch": "^13.1.1",
+        "npm-user-validate": "^1.0.1",
+        "npmlog": "^6.0.2",
+        "opener": "^1.5.2",
+        "pacote": "^13.6.0",
+        "parse-conflict-json": "^2.0.2",
+        "proc-log": "^2.0.1",
+        "qrcode-terminal": "^0.12.0",
+        "read": "~1.0.7",
+        "read-package-json": "^5.0.1",
+        "read-package-json-fast": "^2.0.3",
+        "readdir-scoped-modules": "^1.1.0",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.7",
+        "ssri": "^9.0.1",
+        "tar": "^6.1.11",
+        "text-table": "~0.2.0",
+        "tiny-relative-date": "^1.3.0",
+        "treeverse": "^2.0.0",
+        "validate-npm-package-name": "^4.0.0",
+        "which": "^2.0.2",
+        "write-file-atomic": "^4.0.1"
+      },
+      "bin": {
+        "npm": "bin/npm-cli.js",
+        "npx": "bin/npx-cli.js"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@colors/colors": {
+      "version": "1.5.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@gar/promisify": {
+      "version": "1.1.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@isaacs/string-locale-compare": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@npmcli/arborist": {
+      "version": "5.2.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@isaacs/string-locale-compare": "^1.1.0",
+        "@npmcli/installed-package-contents": "^1.0.7",
+        "@npmcli/map-workspaces": "^2.0.3",
+        "@npmcli/metavuln-calculator": "^3.0.1",
+        "@npmcli/move-file": "^2.0.0",
+        "@npmcli/name-from-folder": "^1.0.1",
+        "@npmcli/node-gyp": "^2.0.0",
+        "@npmcli/package-json": "^2.0.0",
+        "@npmcli/run-script": "^3.0.0",
+        "bin-links": "^3.0.0",
+        "cacache": "^16.0.6",
+        "common-ancestor-path": "^1.0.1",
+        "json-parse-even-better-errors": "^2.3.1",
+        "json-stringify-nice": "^1.1.4",
+        "mkdirp": "^1.0.4",
+        "mkdirp-infer-owner": "^2.0.0",
+        "nopt": "^5.0.0",
+        "npm-install-checks": "^5.0.0",
+        "npm-package-arg": "^9.0.0",
+        "npm-pick-manifest": "^7.0.0",
+        "npm-registry-fetch": "^13.0.0",
+        "npmlog": "^6.0.2",
+        "pacote": "^13.0.5",
+        "parse-conflict-json": "^2.0.1",
+        "proc-log": "^2.0.0",
+        "promise-all-reject-late": "^1.0.0",
+        "promise-call-limit": "^1.0.1",
+        "read-package-json-fast": "^2.0.2",
+        "readdir-scoped-modules": "^1.1.0",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.7",
+        "ssri": "^9.0.0",
+        "treeverse": "^2.0.0",
+        "walk-up-path": "^1.0.0"
+      },
+      "bin": {
+        "arborist": "bin/index.js"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@npmcli/ci-detect": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@npmcli/config": {
+      "version": "4.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/map-workspaces": "^2.0.2",
+        "ini": "^3.0.0",
+        "mkdirp-infer-owner": "^2.0.0",
+        "nopt": "^5.0.0",
+        "proc-log": "^2.0.0",
+        "read-package-json-fast": "^2.0.3",
+        "semver": "^7.3.5",
+        "walk-up-path": "^1.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@npmcli/disparity-colors": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "ansi-styles": "^4.3.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@npmcli/fs": {
+      "version": "2.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@gar/promisify": "^1.1.3",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@npmcli/git": {
+      "version": "3.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/promise-spawn": "^3.0.0",
+        "lru-cache": "^7.4.4",
+        "mkdirp": "^1.0.4",
+        "npm-pick-manifest": "^7.0.0",
+        "proc-log": "^2.0.0",
+        "promise-inflight": "^1.0.1",
+        "promise-retry": "^2.0.1",
+        "semver": "^7.3.5",
+        "which": "^2.0.2"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@npmcli/installed-package-contents": {
+      "version": "1.0.7",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "npm-bundled": "^1.1.1",
+        "npm-normalize-package-bin": "^1.0.1"
+      },
+      "bin": {
+        "installed-package-contents": "index.js"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@npmcli/map-workspaces": {
+      "version": "2.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/name-from-folder": "^1.0.1",
+        "glob": "^8.0.1",
+        "minimatch": "^5.0.1",
+        "read-package-json-fast": "^2.0.3"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
+      "version": "3.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "cacache": "^16.0.0",
+        "json-parse-even-better-errors": "^2.3.1",
+        "pacote": "^13.0.3",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@npmcli/move-file": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "mkdirp": "^1.0.4",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@npmcli/name-from-folder": {
+      "version": "1.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@npmcli/node-gyp": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@npmcli/package-json": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "json-parse-even-better-errors": "^2.3.1"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@npmcli/promise-spawn": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "infer-owner": "^1.0.4"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@npmcli/run-script": {
+      "version": "3.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/node-gyp": "^2.0.0",
+        "@npmcli/promise-spawn": "^3.0.0",
+        "node-gyp": "^9.0.0",
+        "read-package-json-fast": "^2.0.3"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@tootallnate/once": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/abbrev": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/agent-base": {
+      "version": "6.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/agentkeepalive": {
+      "version": "4.2.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.0",
+        "depd": "^1.1.2",
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/aggregate-error": {
+      "version": "3.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/aproba": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/archy": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/are-we-there-yet": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/asap": {
+      "version": "2.0.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/bin-links": {
+      "version": "3.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "cmd-shim": "^5.0.0",
+        "mkdirp-infer-owner": "^2.0.0",
+        "npm-normalize-package-bin": "^1.0.0",
+        "read-cmd-shim": "^3.0.0",
+        "rimraf": "^3.0.0",
+        "write-file-atomic": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/binary-extensions": {
+      "version": "2.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/builtins": {
+      "version": "5.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/cacache": {
+      "version": "16.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/fs": "^2.1.0",
+        "@npmcli/move-file": "^2.0.0",
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.1.0",
+        "glob": "^8.0.1",
+        "infer-owner": "^1.0.4",
+        "lru-cache": "^7.7.1",
+        "minipass": "^3.1.6",
+        "minipass-collect": "^1.0.2",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "mkdirp": "^1.0.4",
+        "p-map": "^4.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^3.0.2",
+        "ssri": "^9.0.0",
+        "tar": "^6.1.11",
+        "unique-filename": "^1.1.1"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/chalk": {
+      "version": "4.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/chownr": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/cidr-regex": {
+      "version": "3.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "ip-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/clean-stack": {
+      "version": "2.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/cli-columns": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/cli-table3": {
+      "version": "0.6.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      },
+      "optionalDependencies": {
+        "@colors/colors": "1.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/clone": {
+      "version": "1.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/cmd-shim": {
+      "version": "5.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "mkdirp-infer-owner": "^2.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/color-convert": {
+      "version": "2.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/color-name": {
+      "version": "1.1.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/color-support": {
+      "version": "1.1.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "color-support": "bin.js"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/columnify": {
+      "version": "1.6.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "strip-ansi": "^6.0.1",
+        "wcwidth": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/common-ancestor-path": {
+      "version": "1.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/concat-map": {
+      "version": "0.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/console-control-strings": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/debug": {
+      "version": "4.3.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/debug/node_modules/ms": {
+      "version": "2.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/debuglog": {
+      "version": "1.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/defaults": {
+      "version": "1.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone": "^1.0.2"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/delegates": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/depd": {
+      "version": "1.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/dezalgo": {
+      "version": "1.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/diff": {
+      "version": "5.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/encoding": {
+      "version": "0.1.13",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/env-paths": {
+      "version": "2.2.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/err-code": {
+      "version": "2.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/fastest-levenshtein": {
+      "version": "1.0.12",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/function-bind": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/gauge": {
+      "version": "4.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^1.0.3 || ^2.0.0",
+        "color-support": "^1.1.3",
+        "console-control-strings": "^1.1.0",
+        "has-unicode": "^2.0.1",
+        "signal-exit": "^3.0.7",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "wide-align": "^1.1.5"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/glob": {
+      "version": "8.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/graceful-fs": {
+      "version": "4.2.10",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/has": {
+      "version": "1.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/has-flag": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/has-unicode": {
+      "version": "2.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/hosted-git-info": {
+      "version": "5.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^7.5.1"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/http-cache-semantics": {
+      "version": "4.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/http-proxy-agent": {
+      "version": "5.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/ignore-walk": {
+      "version": "5.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "minimatch": "^5.0.1"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/indent-string": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/infer-owner": {
+      "version": "1.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/inflight": {
+      "version": "1.0.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/inherits": {
+      "version": "2.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/ini": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/init-package-json": {
+      "version": "3.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "npm-package-arg": "^9.0.1",
+        "promzard": "^0.3.0",
+        "read": "^1.0.7",
+        "read-package-json": "^5.0.0",
+        "semver": "^7.3.5",
+        "validate-npm-package-license": "^3.0.4",
+        "validate-npm-package-name": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/ip": {
+      "version": "1.1.8",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/ip-regex": {
+      "version": "4.3.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/is-cidr": {
+      "version": "4.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "cidr-regex": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/is-core-module": {
+      "version": "2.9.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "has": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/is-lambda": {
+      "version": "1.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/isexe": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/json-stringify-nice": {
+      "version": "1.1.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/jsonparse": {
+      "version": "1.3.1",
+      "dev": true,
+      "engines": [
+        "node >= 0.2.0"
+      ],
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/just-diff": {
+      "version": "5.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/just-diff-apply": {
+      "version": "5.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/libnpmaccess": {
+      "version": "6.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^2.0.0",
+        "minipass": "^3.1.1",
+        "npm-package-arg": "^9.0.1",
+        "npm-registry-fetch": "^13.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/libnpmdiff": {
+      "version": "4.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/disparity-colors": "^2.0.0",
+        "@npmcli/installed-package-contents": "^1.0.7",
+        "binary-extensions": "^2.2.0",
+        "diff": "^5.0.0",
+        "minimatch": "^5.0.1",
+        "npm-package-arg": "^9.0.1",
+        "pacote": "^13.0.5",
+        "tar": "^6.1.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/libnpmexec": {
+      "version": "4.0.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/arborist": "^5.0.0",
+        "@npmcli/ci-detect": "^2.0.0",
+        "@npmcli/run-script": "^3.0.0",
+        "chalk": "^4.1.0",
+        "mkdirp-infer-owner": "^2.0.0",
+        "npm-package-arg": "^9.0.1",
+        "npmlog": "^6.0.2",
+        "pacote": "^13.0.5",
+        "proc-log": "^2.0.0",
+        "read": "^1.0.7",
+        "read-package-json-fast": "^2.0.2",
+        "walk-up-path": "^1.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/libnpmfund": {
+      "version": "3.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/arborist": "^5.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/libnpmhook": {
+      "version": "8.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^2.0.0",
+        "npm-registry-fetch": "^13.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/libnpmorg": {
+      "version": "4.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^2.0.0",
+        "npm-registry-fetch": "^13.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/libnpmpack": {
+      "version": "4.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/run-script": "^3.0.0",
+        "npm-package-arg": "^9.0.1",
+        "pacote": "^13.5.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/libnpmpublish": {
+      "version": "6.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-package-data": "^4.0.0",
+        "npm-package-arg": "^9.0.1",
+        "npm-registry-fetch": "^13.0.0",
+        "semver": "^7.3.7",
+        "ssri": "^9.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/libnpmsearch": {
+      "version": "5.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "npm-registry-fetch": "^13.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/libnpmteam": {
+      "version": "4.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^2.0.0",
+        "npm-registry-fetch": "^13.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/libnpmversion": {
+      "version": "3.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/git": "^3.0.0",
+        "@npmcli/run-script": "^3.0.0",
+        "json-parse-even-better-errors": "^2.3.1",
+        "proc-log": "^2.0.0",
+        "semver": "^7.3.7"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/lru-cache": {
+      "version": "7.9.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/make-fetch-happen": {
+      "version": "10.1.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "agentkeepalive": "^4.2.1",
+        "cacache": "^16.1.0",
+        "http-cache-semantics": "^4.1.0",
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "is-lambda": "^1.0.1",
+        "lru-cache": "^7.7.1",
+        "minipass": "^3.1.6",
+        "minipass-collect": "^1.0.2",
+        "minipass-fetch": "^2.0.3",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "negotiator": "^0.6.3",
+        "promise-retry": "^2.0.1",
+        "socks-proxy-agent": "^6.1.1",
+        "ssri": "^9.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/minimatch": {
+      "version": "5.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/minipass": {
+      "version": "3.1.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/minipass-collect": {
+      "version": "1.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/minipass-fetch": {
+      "version": "2.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^3.1.6",
+        "minipass-sized": "^1.0.3",
+        "minizlib": "^2.1.2"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      },
+      "optionalDependencies": {
+        "encoding": "^0.1.13"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/minipass-flush": {
+      "version": "1.0.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/minipass-json-stream": {
+      "version": "1.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "jsonparse": "^1.3.1",
+        "minipass": "^3.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/minipass-pipeline": {
+      "version": "1.2.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/minipass-sized": {
+      "version": "1.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/minizlib": {
+      "version": "2.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/mkdirp-infer-owner": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "infer-owner": "^1.0.4",
+        "mkdirp": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/ms": {
+      "version": "2.1.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/mute-stream": {
+      "version": "0.0.8",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/negotiator": {
+      "version": "0.6.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/node-gyp": {
+      "version": "9.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.0",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.6",
+        "make-fetch-happen": "^10.0.3",
+        "nopt": "^5.0.0",
+        "npmlog": "^6.0.0",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "tar": "^6.1.2",
+        "which": "^2.0.2"
+      },
+      "bin": {
+        "node-gyp": "bin/node-gyp.js"
+      },
+      "engines": {
+        "node": "^12.22 || ^14.13 || >=16"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/node-gyp/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/node-gyp/node_modules/glob": {
+      "version": "7.2.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/node-gyp/node_modules/minimatch": {
+      "version": "3.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/nopt": {
+      "version": "5.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/normalize-package-data": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "hosted-git-info": "^5.0.0",
+        "is-core-module": "^2.8.1",
+        "semver": "^7.3.5",
+        "validate-npm-package-license": "^3.0.4"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/npm-audit-report": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/npm-bundled": {
+      "version": "1.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "npm-normalize-package-bin": "^1.0.1"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/npm-install-checks": {
+      "version": "5.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "semver": "^7.1.1"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/npm-normalize-package-bin": {
+      "version": "1.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/npm-package-arg": {
+      "version": "9.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "hosted-git-info": "^5.0.0",
+        "semver": "^7.3.5",
+        "validate-npm-package-name": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/npm-packlist": {
+      "version": "5.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^8.0.1",
+        "ignore-walk": "^5.0.1",
+        "npm-bundled": "^1.1.2",
+        "npm-normalize-package-bin": "^1.0.1"
+      },
+      "bin": {
+        "npm-packlist": "bin/index.js"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/npm-pick-manifest": {
+      "version": "7.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "npm-install-checks": "^5.0.0",
+        "npm-normalize-package-bin": "^1.0.1",
+        "npm-package-arg": "^9.0.0",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/npm-profile": {
+      "version": "6.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "npm-registry-fetch": "^13.0.1",
+        "proc-log": "^2.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/npm-registry-fetch": {
+      "version": "13.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "make-fetch-happen": "^10.0.6",
+        "minipass": "^3.1.6",
+        "minipass-fetch": "^2.0.3",
+        "minipass-json-stream": "^1.0.1",
+        "minizlib": "^2.1.2",
+        "npm-package-arg": "^9.0.1",
+        "proc-log": "^2.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/npm-user-validate": {
+      "version": "1.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/npmlog": {
+      "version": "6.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "are-we-there-yet": "^3.0.0",
+        "console-control-strings": "^1.1.0",
+        "gauge": "^4.0.3",
+        "set-blocking": "^2.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/once": {
+      "version": "1.4.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/opener": {
+      "version": "1.5.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "(WTFPL OR MIT)",
+      "bin": {
+        "opener": "bin/opener-bin.js"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/p-map": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "aggregate-error": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/pacote": {
+      "version": "13.6.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/git": "^3.0.0",
+        "@npmcli/installed-package-contents": "^1.0.7",
+        "@npmcli/promise-spawn": "^3.0.0",
+        "@npmcli/run-script": "^3.0.1",
+        "cacache": "^16.0.0",
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.1.0",
+        "infer-owner": "^1.0.4",
+        "minipass": "^3.1.6",
+        "mkdirp": "^1.0.4",
+        "npm-package-arg": "^9.0.0",
+        "npm-packlist": "^5.1.0",
+        "npm-pick-manifest": "^7.0.0",
+        "npm-registry-fetch": "^13.0.1",
+        "proc-log": "^2.0.0",
+        "promise-retry": "^2.0.1",
+        "read-package-json": "^5.0.0",
+        "read-package-json-fast": "^2.0.3",
+        "rimraf": "^3.0.2",
+        "ssri": "^9.0.0",
+        "tar": "^6.1.11"
+      },
+      "bin": {
+        "pacote": "lib/bin.js"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/parse-conflict-json": {
+      "version": "2.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "json-parse-even-better-errors": "^2.3.1",
+        "just-diff": "^5.0.1",
+        "just-diff-apply": "^5.2.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/proc-log": {
+      "version": "2.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/promise-all-reject-late": {
+      "version": "1.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/promise-call-limit": {
+      "version": "1.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/promise-inflight": {
+      "version": "1.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/promise-retry": {
+      "version": "2.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "err-code": "^2.0.2",
+        "retry": "^0.12.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/promzard": {
+      "version": "0.3.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "read": "1"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/qrcode-terminal": {
+      "version": "0.12.0",
+      "dev": true,
+      "inBundle": true,
+      "bin": {
+        "qrcode-terminal": "bin/qrcode-terminal.js"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/read": {
+      "version": "1.0.7",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "mute-stream": "~0.0.4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/read-cmd-shim": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/read-package-json": {
+      "version": "5.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^8.0.1",
+        "json-parse-even-better-errors": "^2.3.1",
+        "normalize-package-data": "^4.0.0",
+        "npm-normalize-package-bin": "^1.0.1"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/read-package-json-fast": {
+      "version": "2.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "json-parse-even-better-errors": "^2.3.0",
+        "npm-normalize-package-bin": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/readable-stream": {
+      "version": "3.6.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/readdir-scoped-modules": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "debuglog": "^1.0.1",
+        "dezalgo": "^1.0.0",
+        "graceful-fs": "^4.1.2",
+        "once": "^1.3.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/retry": {
+      "version": "0.12.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/rimraf": {
+      "version": "3.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/rimraf/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/rimraf/node_modules/glob": {
+      "version": "7.2.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/rimraf/node_modules/minimatch": {
+      "version": "3.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/semver": {
+      "version": "7.3.7",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/semver/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/set-blocking": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/socks": {
+      "version": "2.6.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip": "^1.1.5",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/socks-proxy-agent": {
+      "version": "6.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^6.0.2",
+        "debug": "^4.3.3",
+        "socks": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/spdx-correct": {
+      "version": "3.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/spdx-exceptions": {
+      "version": "2.3.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "CC-BY-3.0"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/spdx-license-ids": {
+      "version": "3.0.11",
+      "dev": true,
+      "inBundle": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/ssri": {
+      "version": "9.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/string-width": {
+      "version": "4.2.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/supports-color": {
+      "version": "7.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/tar": {
+      "version": "6.1.11",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^3.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/text-table": {
+      "version": "0.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/tiny-relative-date": {
+      "version": "1.3.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/treeverse": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/unique-filename": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "unique-slug": "^2.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/unique-slug": {
+      "version": "2.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/validate-npm-package-license": {
+      "version": "3.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/validate-npm-package-name": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "builtins": "^5.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/walk-up-path": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/wcwidth": {
+      "version": "1.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/which": {
+      "version": "2.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/wide-align": {
+      "version": "1.1.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^1.0.2 || 2 || 3 || 4"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/wrappy": {
+      "version": "1.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/write-file-atomic": {
+      "version": "4.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.7"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/yallist": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/semantic-release/node_modules/semver": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semantic-release/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/semantic-release/node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semantic-release/node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semver-diff": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-3.1.1.tgz",
+      "integrity": "sha512-GX0Ix/CJcHyB8c4ykpHGIAvLyOwOobtM/8d+TQkAd81/bEjgPHrfba41Vpesr7jX/t8Uh+R3EX9eAS5be+jQYg==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/semver-diff/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/semver-regex": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.4.tgz",
+      "integrity": "sha512-6IiqeZNgq01qGf0TId0t3NvKzSvUsjcpdEO3AQNeIjR6A2+ckTnQlDpl4qu1bjRv0RzN3FP9hzFmws3lKqRWkA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/serialize-javascript": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+      "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+      "dev": true,
+      "dependencies": {
+        "randombytes": "^2.1.0"
+      }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "dev": true
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true
+    },
+    "node_modules/signale": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/signale/-/signale-1.4.0.tgz",
+      "integrity": "sha512-iuh+gPf28RkltuJC7W5MRi6XAjTDCAPC/prJUpQoG4vIP3MJZ+GTydVnodXA7pwvTKb2cA0m9OFZW/cdWy/I/w==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^2.3.2",
+        "figures": "^2.0.0",
+        "pkg-conf": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/signale/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/signale/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/signale/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/signale/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true
+    },
+    "node_modules/signale/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/signale/node_modules/figures": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA==",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/signale/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/signale/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/spawn-error-forwarder": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/spawn-error-forwarder/-/spawn-error-forwarder-1.0.0.tgz",
+      "integrity": "sha512-gRjMgK5uFjbCvdibeGJuy3I5OYz6VLoVdsOJdA6wV0WlfQVLFueoqMxwwYD9RODdgb6oUIvlRlsyFSiQkMKu0g==",
+      "dev": true
+    },
+    "node_modules/spawn-wrap": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-2.0.0.tgz",
+      "integrity": "sha512-EeajNjfN9zMnULLwhZZQU3GWBoFNkbngTUPfaawT4RkMiviTxcX0qfhVbGey39mfctfDHkWtuecgQ8NJcyQWHg==",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^2.0.0",
+        "is-windows": "^1.0.2",
+        "make-dir": "^3.0.0",
+        "rimraf": "^3.0.0",
+        "signal-exit": "^3.0.2",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/spdx-correct": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
+      "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
+      "dev": true,
+      "dependencies": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-exceptions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
+      "dev": true
+    },
+    "node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-license-ids": {
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz",
+      "integrity": "sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA==",
+      "dev": true
+    },
+    "node_modules/split": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "dev": true,
+      "dependencies": {
+        "through": "2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/split2": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
+      "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
+      "dev": true,
+      "dependencies": {
+        "readable-stream": "^3.0.0"
+      }
+    },
+    "node_modules/split2/node_modules/readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true
+    },
+    "node_modules/stream-combiner2": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
+      "integrity": "sha512-3PnJbYgS56AeWgtKF5jtJRT6uFJe56Z0Hc5Ngg/6sI6rIt8iiMBTa9cvdyFfpMQjaVHr8dusbNeFGIIonxOvKw==",
+      "dev": true,
+      "dependencies": {
+        "duplexer2": "~0.1.0",
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+      "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/supports-hyperlinks": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz",
+      "integrity": "sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0",
+        "supports-color": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-hyperlinks/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-hyperlinks/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/temp-dir": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
+      "integrity": "sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tempy": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tempy/-/tempy-1.0.1.tgz",
+      "integrity": "sha512-biM9brNqxSc04Ee71hzFbryD11nX7VPhQQY32AdDmjFvodsRFz/3ufeoTZ6uYkRFfGo188tENcASNs3vTdsM0w==",
+      "dev": true,
+      "dependencies": {
+        "del": "^6.0.0",
+        "is-stream": "^2.0.0",
+        "temp-dir": "^2.0.0",
+        "type-fest": "^0.16.0",
+        "unique-string": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tempy/node_modules/type-fest": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.16.0.tgz",
+      "integrity": "sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "dev": true,
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/text-extensions": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz",
+      "integrity": "sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "dev": true
+    },
+    "node_modules/through2": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
+      "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
+      "dev": true,
+      "dependencies": {
+        "readable-stream": "3"
+      }
+    },
+    "node_modules/through2/node_modules/readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true
+    },
+    "node_modules/traverse": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+      "integrity": "sha512-kdf4JKs8lbARxWdp7RKdNzoJBhGUcIalSYibuGyHJbmk40pOysQ0+QPvlkCOICOivDWU2IJo2rkrxyTK2AH4fw==",
+      "dev": true
+    },
+    "node_modules/trim-newlines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
+      "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "dev": true,
+      "dependencies": {
+        "is-typedarray": "^1.0.0"
+      }
+    },
+    "node_modules/uglify-js": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.16.0.tgz",
+      "integrity": "sha512-FEikl6bR30n0T3amyBh3LoiBdqHRy/f4H80+My34HOesOKyHfOsxAPAxOoqC0JUnC1amnO0IwkYC3sko51caSw==",
+      "dev": true,
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/unique-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
+      "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
+      "dev": true,
+      "dependencies": {
+        "crypto-random-string": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/universal-user-agent": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+      "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==",
+      "dev": true
+    },
+    "node_modules/url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
+      "dev": true
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true
+    },
+    "node_modules/validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "dependencies": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/which-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q==",
+      "dev": true
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true
+    },
+    "node_modules/workerpool": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.1.tgz",
+      "integrity": "sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==",
+      "dev": true
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
+    },
+    "node_modules/write-file-atomic": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+      "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+      "dev": true,
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "is-typedarray": "^1.0.0",
+        "signal-exit": "^3.0.2",
+        "typedarray-to-buffer": "^3.1.5"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
+    "node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-unparser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+      "dev": true,
+      "dependencies": {
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-unparser/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yargs-unparser/node_modules/decamelize": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yargs-unparser/node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  },
   "dependencies": {
     "@babel/code-frame": {
       "version": "7.8.3",
@@ -468,7 +11705,8 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
       "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@octokit/plugin-rest-endpoint-methods": {
       "version": "5.13.0",
@@ -661,16 +11899,6 @@
       "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
       "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
       "dev": true
-    },
-    "JSONStream": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
-      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
-      "dev": true,
-      "requires": {
-        "jsonparse": "^1.2.0",
-        "through": ">=2.2.7 <3"
-      }
     },
     "agent-base": {
       "version": "6.0.2",
@@ -1096,8 +12324,8 @@
       "integrity": "sha512-nK7sAtfi+QXbxHCYfhpZsfRtaitZLIA6889kFIouLvz6repszQDgxBu7wf2WbU+Dco7sAnNCJYERCwt54WPC2Q==",
       "dev": true,
       "requires": {
-        "JSONStream": "^1.0.4",
         "is-text-path": "^1.0.1",
+        "JSONStream": "^1.0.4",
         "lodash": "^4.17.15",
         "meow": "^8.0.0",
         "split2": "^3.0.0",
@@ -2225,6 +13453,11 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
     },
+    "json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -2263,6 +13496,16 @@
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true
+    },
+    "JSONStream": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+      "dev": true,
+      "requires": {
+        "jsonparse": "^1.2.0",
+        "through": ">=2.2.7 <3"
+      }
     },
     "kind-of": {
       "version": "6.0.3",
@@ -2951,76 +14194,76 @@
       "integrity": "sha512-120p116CE8VMMZ+hk8IAb1inCPk4Dj3VZw29/n2g6UI77urJKVYb7FZUDW8hY+EBnfsjI/2yrobBgFyzo7YpVQ==",
       "dev": true,
       "requires": {
-        "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^2.9.0",
-        "@npmcli/ci-detect": "^1.2.0",
-        "@npmcli/config": "^2.3.0",
-        "@npmcli/map-workspaces": "^1.0.4",
-        "@npmcli/package-json": "^1.0.1",
-        "@npmcli/run-script": "^1.8.6",
-        "abbrev": "~1.1.1",
-        "ansicolors": "~0.3.2",
-        "ansistyles": "~0.1.3",
-        "archy": "~1.0.0",
-        "cacache": "^15.3.0",
-        "chalk": "^4.1.2",
-        "chownr": "^2.0.0",
-        "cli-columns": "^3.1.2",
-        "cli-table3": "^0.6.0",
-        "columnify": "~1.5.4",
-        "fastest-levenshtein": "^1.0.12",
-        "glob": "^7.2.0",
-        "graceful-fs": "^4.2.8",
-        "hosted-git-info": "^4.0.2",
-        "ini": "^2.0.0",
-        "init-package-json": "^2.0.5",
-        "is-cidr": "^4.0.2",
-        "json-parse-even-better-errors": "^2.3.1",
-        "libnpmaccess": "^4.0.2",
-        "libnpmdiff": "^2.0.4",
-        "libnpmexec": "^2.0.1",
-        "libnpmfund": "^1.1.0",
-        "libnpmhook": "^6.0.2",
-        "libnpmorg": "^2.0.2",
-        "libnpmpack": "^2.0.1",
-        "libnpmpublish": "^4.0.1",
-        "libnpmsearch": "^3.1.1",
-        "libnpmteam": "^2.0.3",
-        "libnpmversion": "^1.2.1",
-        "make-fetch-happen": "^9.1.0",
-        "minipass": "^3.1.3",
-        "minipass-pipeline": "^1.2.4",
-        "mkdirp": "^1.0.4",
-        "mkdirp-infer-owner": "^2.0.0",
-        "ms": "^2.1.2",
-        "node-gyp": "^7.1.2",
-        "nopt": "^5.0.0",
-        "npm-audit-report": "^2.1.5",
-        "npm-install-checks": "^4.0.0",
-        "npm-package-arg": "^8.1.5",
-        "npm-pick-manifest": "^6.1.1",
-        "npm-profile": "^5.0.3",
-        "npm-registry-fetch": "^11.0.0",
-        "npm-user-validate": "^1.0.1",
-        "npmlog": "^5.0.1",
-        "opener": "^1.5.2",
-        "pacote": "^11.3.5",
-        "parse-conflict-json": "^1.1.1",
-        "qrcode-terminal": "^0.12.0",
-        "read": "~1.0.7",
-        "read-package-json": "^4.1.1",
-        "read-package-json-fast": "^2.0.3",
-        "readdir-scoped-modules": "^1.1.0",
-        "rimraf": "^3.0.2",
-        "semver": "^7.3.5",
-        "ssri": "^8.0.1",
-        "tar": "^6.1.11",
-        "text-table": "~0.2.0",
-        "tiny-relative-date": "^1.3.0",
-        "treeverse": "^1.0.4",
-        "validate-npm-package-name": "~3.0.0",
-        "which": "^2.0.2",
-        "write-file-atomic": "^3.0.3"
+        "@isaacs/string-locale-compare": "*",
+        "@npmcli/arborist": "*",
+        "@npmcli/ci-detect": "*",
+        "@npmcli/config": "*",
+        "@npmcli/map-workspaces": "*",
+        "@npmcli/package-json": "*",
+        "@npmcli/run-script": "*",
+        "abbrev": "*",
+        "ansicolors": "*",
+        "ansistyles": "*",
+        "archy": "*",
+        "cacache": "*",
+        "chalk": "*",
+        "chownr": "*",
+        "cli-columns": "*",
+        "cli-table3": "*",
+        "columnify": "*",
+        "fastest-levenshtein": "*",
+        "glob": "*",
+        "graceful-fs": "*",
+        "hosted-git-info": "*",
+        "ini": "*",
+        "init-package-json": "*",
+        "is-cidr": "*",
+        "json-parse-even-better-errors": "*",
+        "libnpmaccess": "*",
+        "libnpmdiff": "*",
+        "libnpmexec": "*",
+        "libnpmfund": "*",
+        "libnpmhook": "*",
+        "libnpmorg": "*",
+        "libnpmpack": "*",
+        "libnpmpublish": "*",
+        "libnpmsearch": "*",
+        "libnpmteam": "*",
+        "libnpmversion": "*",
+        "make-fetch-happen": "*",
+        "minipass": "*",
+        "minipass-pipeline": "*",
+        "mkdirp": "*",
+        "mkdirp-infer-owner": "*",
+        "ms": "*",
+        "node-gyp": "*",
+        "nopt": "*",
+        "npm-audit-report": "*",
+        "npm-install-checks": "*",
+        "npm-package-arg": "*",
+        "npm-pick-manifest": "*",
+        "npm-profile": "*",
+        "npm-registry-fetch": "*",
+        "npm-user-validate": "*",
+        "npmlog": "*",
+        "opener": "*",
+        "pacote": "*",
+        "parse-conflict-json": "*",
+        "qrcode-terminal": "*",
+        "read": "*",
+        "read-package-json": "*",
+        "read-package-json-fast": "*",
+        "readdir-scoped-modules": "*",
+        "rimraf": "*",
+        "semver": "*",
+        "ssri": "*",
+        "tar": "*",
+        "text-table": "*",
+        "tiny-relative-date": "*",
+        "treeverse": "*",
+        "validate-npm-package-name": "*",
+        "which": "*",
+        "write-file-atomic": "*"
       },
       "dependencies": {
         "@gar/promisify": {
@@ -3322,7 +14565,8 @@
         },
         "balanced-match": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "bcrypt-pbkdf": {
           "version": "1.0.2",
@@ -3353,6 +14597,7 @@
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3535,7 +14780,8 @@
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
@@ -4154,6 +15400,14 @@
             "mime-db": "1.49.0"
           }
         },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
         "minipass": {
           "version": "3.1.5",
           "bundled": true,
@@ -4583,6 +15837,11 @@
           "bundled": true,
           "dev": true
         },
+        "qs": {
+          "version": "6.5.2",
+          "bundled": true,
+          "dev": true
+        },
         "read": {
           "version": "1.0.7",
           "bundled": true,
@@ -4802,6 +16061,14 @@
             "minipass": "^3.1.1"
           }
         },
+        "string_decoder": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          }
+        },
         "string-width": {
           "version": "2.1.1",
           "bundled": true,
@@ -4824,14 +16091,6 @@
                 "ansi-regex": "^3.0.0"
               }
             }
-          }
-        },
-        "string_decoder": {
-          "version": "1.3.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.2.0"
           }
         },
         "stringify-package": {
@@ -5456,12 +16715,6 @@
       "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==",
       "dev": true
     },
-    "qs": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
-      "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
-      "dev": true
-    },
     "queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -5864,15 +17117,6 @@
             "color-convert": "^2.0.1"
           }
         },
-        "brace-expansion": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-          "dev": true,
-          "requires": {
-            "balanced-match": "^1.0.0"
-          }
-        },
         "cliui": {
           "version": "7.0.4",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -5955,15 +17199,6 @@
           "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
           "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
           "dev": true
-        },
-        "minimatch": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
-          "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^2.0.1"
-          }
         },
         "npm": {
           "version": "8.12.1",
@@ -6306,7 +17541,8 @@
             },
             "balanced-match": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "bin-links": {
               "version": "3.0.1",
@@ -6329,6 +17565,7 @@
             "brace-expansion": {
               "version": "2.0.1",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "balanced-match": "^1.0.0"
               }
@@ -6936,6 +18173,14 @@
                 "ssri": "^9.0.0"
               }
             },
+            "minimatch": {
+              "version": "5.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "brace-expansion": "^2.0.1"
+              }
+            },
             "minipass": {
               "version": "3.1.6",
               "bundled": true,
@@ -7076,8 +18321,7 @@
                 },
                 "minimatch": {
                   "version": "3.1.2",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-                  "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "brace-expansion": "^1.1.7"
@@ -7401,8 +18645,7 @@
                 },
                 "minimatch": {
                   "version": "3.1.2",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-                  "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "brace-expansion": "^1.1.7"
@@ -7509,6 +18752,14 @@
                 "minipass": "^3.1.1"
               }
             },
+            "string_decoder": {
+              "version": "1.3.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "safe-buffer": "~5.2.0"
+              }
+            },
             "string-width": {
               "version": "4.2.3",
               "bundled": true,
@@ -7517,14 +18768,6 @@
                 "emoji-regex": "^8.0.0",
                 "is-fullwidth-code-point": "^3.0.0",
                 "strip-ansi": "^6.0.1"
-              }
-            },
-            "string_decoder": {
-              "version": "1.3.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "safe-buffer": "~5.2.0"
               }
             },
             "strip-ansi": {
@@ -7950,6 +19193,15 @@
         "readable-stream": "^2.0.2"
       }
     },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "string-width": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
@@ -7959,15 +19211,6 @@
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
         "strip-ansi": "^6.0.0"
-      }
-    },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "~5.1.0"
       }
     },
     "strip-ansi": {

--- a/package.json
+++ b/package.json
@@ -38,13 +38,13 @@
   },
   "homepage": "https://github.com/asyncapi/spec-json-schemas#readme",
   "devDependencies": {
-    "mocha": "^10.0.0",
-    "nyc": "^15.1.0",
     "@semantic-release/commit-analyzer": "^8.0.1",
     "@semantic-release/github": "7.2.3",
     "@semantic-release/npm": "^7.0.3",
     "@semantic-release/release-notes-generator": "^9.0.1",
     "conventional-changelog-conventionalcommits": "^4.2.3",
+    "mocha": "^10.0.0",
+    "nyc": "^15.1.0",
     "semantic-release": "19.0.3"
   },
   "release": {
@@ -85,6 +85,7 @@
     ]
   },
   "dependencies": {
-    "@types/json-schema": "^7.0.11"
+    "@types/json-schema": "^7.0.11",
+    "json-schema-traverse": "^1.0.0"
   }
 }

--- a/schemas/1.0.0.json
+++ b/schemas/1.0.0.json
@@ -11,7 +11,7 @@
     "additionalProperties": false,
     "patternProperties": {
         "^x-": {
-            "$ref": "http://asyncapi.com/definitions/1.0.0/vendorExtension.json"
+            "$ref": "#/definitions/vendorExtension"
         }
     },
     "properties": {
@@ -23,7 +23,7 @@
             "description": "The AsyncAPI specification version of this document."
         },
         "info": {
-            "$ref": "http://asyncapi.com/definitions/1.0.0/info.json"
+            "$ref": "#/definitions/info"
         },
         "baseTopic": {
             "type": "string",
@@ -34,41 +34,41 @@
         "servers": {
             "type": "array",
             "items": {
-                "$ref": "http://asyncapi.com/definitions/1.0.0/server.json"
+                "$ref": "#/definitions/server"
             },
             "uniqueItems": true
         },
         "topics": {
-            "$ref": "http://asyncapi.com/definitions/1.0.0/topics.json"
+            "$ref": "#/definitions/topics"
         },
         "components": {
-            "$ref": "http://asyncapi.com/definitions/1.0.0/components.json"
+            "$ref": "#/definitions/components"
         },
         "tags": {
             "type": "array",
             "items": {
-                "$ref": "http://asyncapi.com/definitions/1.0.0/tag.json"
+                "$ref": "#/definitions/tag"
             },
             "uniqueItems": true
         },
         "security": {
             "type": "array",
             "items": {
-                "$ref": "http://asyncapi.com/definitions/1.0.0/SecurityRequirement.json"
+                "$ref": "#/definitions/SecurityRequirement"
             }
         },
         "externalDocs": {
-            "$ref": "http://asyncapi.com/definitions/1.0.0/externalDocs.json"
+            "$ref": "#/definitions/externalDocs"
         }
     },
     "definitions": {
-        "http://asyncapi.com/definitions/1.0.0/vendorExtension.json": {
+        "vendorExtension": {
             "id": "http://asyncapi.com/definitions/1.0.0/vendorExtension.json",
             "description": "Any property starting with x- is valid.",
             "additionalProperties": true,
             "additionalItems": true
         },
-        "http://asyncapi.com/definitions/1.0.0/info.json": {
+        "info": {
             "id": "http://asyncapi.com/definitions/1.0.0/info.json",
             "type": "object",
             "description": "General information about the API.",
@@ -79,7 +79,7 @@
             "additionalProperties": false,
             "patternProperties": {
                 "^x-": {
-                    "$ref": "http://asyncapi.com/definitions/1.0.0/vendorExtension.json"
+                    "$ref": "#/definitions/vendorExtension"
                 }
             },
             "properties": {
@@ -101,14 +101,14 @@
                     "format": "uri"
                 },
                 "contact": {
-                    "$ref": "http://asyncapi.com/definitions/1.0.0/contact.json"
+                    "$ref": "#/definitions/contact"
                 },
                 "license": {
-                    "$ref": "http://asyncapi.com/definitions/1.0.0/license.json"
+                    "$ref": "#/definitions/license"
                 }
             }
         },
-        "http://asyncapi.com/definitions/1.0.0/contact.json": {
+        "contact": {
             "id": "http://asyncapi.com/definitions/1.0.0/contact.json",
             "type": "object",
             "description": "Contact information for the owners of the API.",
@@ -131,11 +131,11 @@
             },
             "patternProperties": {
                 "^x-": {
-                    "$ref": "http://asyncapi.com/definitions/1.0.0/vendorExtension.json"
+                    "$ref": "#/definitions/vendorExtension"
                 }
             }
         },
-        "http://asyncapi.com/definitions/1.0.0/license.json": {
+        "license": {
             "id": "http://asyncapi.com/definitions/1.0.0/license.json",
             "type": "object",
             "required": [
@@ -155,11 +155,11 @@
             },
             "patternProperties": {
                 "^x-": {
-                    "$ref": "http://asyncapi.com/definitions/1.0.0/vendorExtension.json"
+                    "$ref": "#/definitions/vendorExtension"
                 }
             }
         },
-        "http://asyncapi.com/definitions/1.0.0/server.json": {
+        "server": {
             "id": "http://asyncapi.com/definitions/1.0.0/server.json",
             "type": "object",
             "description": "An object representing a Server.",
@@ -170,7 +170,7 @@
             "additionalProperties": false,
             "patternProperties": {
                 "^x-": {
-                    "$ref": "http://asyncapi.com/definitions/1.0.0/vendorExtension.json"
+                    "$ref": "#/definitions/vendorExtension"
                 }
             },
             "properties": {
@@ -201,18 +201,18 @@
                     "type": "string"
                 },
                 "variables": {
-                    "$ref": "http://asyncapi.com/definitions/1.0.0/serverVariables.json"
+                    "$ref": "#/definitions/serverVariables"
                 }
             }
         },
-        "http://asyncapi.com/definitions/1.0.0/serverVariables.json": {
+        "serverVariables": {
             "id": "http://asyncapi.com/definitions/1.0.0/serverVariables.json",
             "type": "object",
             "additionalProperties": {
-                "$ref": "http://asyncapi.com/definitions/1.0.0/serverVariable.json"
+                "$ref": "#/definitions/serverVariable"
             }
         },
-        "http://asyncapi.com/definitions/1.0.0/serverVariable.json": {
+        "serverVariable": {
             "id": "http://asyncapi.com/definitions/1.0.0/serverVariable.json",
             "type": "object",
             "description": "An object representing a Server Variable for server URL template substitution.",
@@ -220,7 +220,7 @@
             "additionalProperties": false,
             "patternProperties": {
                 "^x-": {
-                    "$ref": "http://asyncapi.com/definitions/1.0.0/vendorExtension.json"
+                    "$ref": "#/definitions/vendorExtension"
                 }
             },
             "properties": {
@@ -239,27 +239,27 @@
                 }
             }
         },
-        "http://asyncapi.com/definitions/1.0.0/topics.json": {
+        "topics": {
             "id": "http://asyncapi.com/definitions/1.0.0/topics.json",
             "type": "object",
             "description": "Relative paths to the individual topics. They must be relative to the 'baseTopic'.",
             "patternProperties": {
                 "^x-": {
-                    "$ref": "http://asyncapi.com/definitions/1.0.0/vendorExtension.json"
+                    "$ref": "#/definitions/vendorExtension"
                 },
                 "^[^.]": {
-                    "$ref": "http://asyncapi.com/definitions/1.0.0/topicItem.json"
+                    "$ref": "#/definitions/topicItem"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/1.0.0/topicItem.json": {
+        "topicItem": {
             "id": "http://asyncapi.com/definitions/1.0.0/topicItem.json",
             "type": "object",
             "additionalProperties": false,
             "patternProperties": {
                 "^x-": {
-                    "$ref": "http://asyncapi.com/definitions/1.0.0/vendorExtension.json"
+                    "$ref": "#/definitions/vendorExtension"
                 }
             },
             "minProperties": 1,
@@ -268,10 +268,10 @@
                     "type": "string"
                 },
                 "publish": {
-                    "$ref": "http://asyncapi.com/definitions/1.0.0/message.json"
+                    "$ref": "#/definitions/message"
                 },
                 "subscribe": {
-                    "$ref": "http://asyncapi.com/definitions/1.0.0/message.json"
+                    "$ref": "#/definitions/message"
                 },
                 "deprecated": {
                     "type": "boolean",
@@ -279,13 +279,13 @@
                 }
             }
         },
-        "http://asyncapi.com/definitions/1.0.0/message.json": {
+        "message": {
             "id": "http://asyncapi.com/definitions/1.0.0/message.json",
             "type": "object",
             "additionalProperties": false,
             "patternProperties": {
                 "^x-": {
-                    "$ref": "http://asyncapi.com/definitions/1.0.0/vendorExtension.json"
+                    "$ref": "#/definitions/vendorExtension"
                 }
             },
             "properties": {
@@ -293,15 +293,15 @@
                     "type": "string"
                 },
                 "headers": {
-                    "$ref": "http://asyncapi.com/definitions/1.0.0/schema.json"
+                    "$ref": "#/definitions/schema"
                 },
                 "payload": {
-                    "$ref": "http://asyncapi.com/definitions/1.0.0/schema.json"
+                    "$ref": "#/definitions/schema"
                 },
                 "tags": {
                     "type": "array",
                     "items": {
-                        "$ref": "http://asyncapi.com/definitions/1.0.0/tag.json"
+                        "$ref": "#/definitions/tag"
                     },
                     "uniqueItems": true
                 },
@@ -314,7 +314,7 @@
                     "description": "A longer description of the message. CommonMark is allowed."
                 },
                 "externalDocs": {
-                    "$ref": "http://asyncapi.com/definitions/1.0.0/externalDocs.json"
+                    "$ref": "#/definitions/externalDocs"
                 },
                 "deprecated": {
                     "type": "boolean",
@@ -323,13 +323,13 @@
                 "example": {}
             }
         },
-        "http://asyncapi.com/definitions/1.0.0/schema.json": {
+        "schema": {
             "id": "http://asyncapi.com/definitions/1.0.0/schema.json",
             "type": "object",
             "description": "A deterministic version of a JSON Schema object.",
             "patternProperties": {
                 "^x-": {
-                    "$ref": "http://asyncapi.com/definitions/1.0.0/vendorExtension.json"
+                    "$ref": "#/definitions/vendorExtension"
                 }
             },
             "properties": {
@@ -340,63 +340,63 @@
                     "type": "string"
                 },
                 "title": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/properties/title"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "description": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/properties/description"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "default": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/properties/default"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "multipleOf": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/properties/multipleOf"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "maximum": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/properties/maximum"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "exclusiveMaximum": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/properties/exclusiveMaximum"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "minimum": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/properties/minimum"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "exclusiveMinimum": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/properties/exclusiveMinimum"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "maxLength": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "minLength": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "pattern": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/properties/pattern"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "maxItems": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "minItems": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "uniqueItems": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/properties/uniqueItems"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "maxProperties": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "minProperties": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "required": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/definitions/stringArray"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "enum": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/properties/enum"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "additionalProperties": {
                     "anyOf": [
                         {
-                            "$ref": "http://asyncapi.com/definitions/1.0.0/schema.json"
+                            "$ref": "#/definitions/schema"
                         },
                         {
                             "type": "boolean"
@@ -405,18 +405,18 @@
                     "default": {}
                 },
                 "type": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/properties/type"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "items": {
                     "anyOf": [
                         {
-                            "$ref": "http://asyncapi.com/definitions/1.0.0/schema.json"
+                            "$ref": "#/definitions/schema"
                         },
                         {
                             "type": "array",
                             "minItems": 1,
                             "items": {
-                                "$ref": "http://asyncapi.com/definitions/1.0.0/schema.json"
+                                "$ref": "#/definitions/schema"
                             }
                         }
                     ],
@@ -426,13 +426,13 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "http://asyncapi.com/definitions/1.0.0/schema.json"
+                        "$ref": "#/definitions/schema"
                     }
                 },
                 "properties": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "http://asyncapi.com/definitions/1.0.0/schema.json"
+                        "$ref": "#/definitions/schema"
                     },
                     "default": {}
                 },
@@ -444,16 +444,16 @@
                     "default": false
                 },
                 "xml": {
-                    "$ref": "http://asyncapi.com/definitions/1.0.0/xml.json"
+                    "$ref": "#/definitions/xml"
                 },
                 "externalDocs": {
-                    "$ref": "http://asyncapi.com/definitions/1.0.0/externalDocs.json"
+                    "$ref": "#/definitions/externalDocs"
                 },
                 "example": {}
             },
             "additionalProperties": false
         },
-        "http://json-schema.org/draft-04/schema": {
+        "json-schema-draft-07-schema": {
             "id": "http://json-schema.org/draft-04/schema",
             "description": "Core schema meta-schema",
             "definitions": {
@@ -461,7 +461,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#"
+                        "$ref": "#/definitions/json-schema-draft-07-schema"
                     }
                 },
                 "positiveInteger": {
@@ -471,7 +471,7 @@
                 "positiveIntegerDefault0": {
                     "allOf": [
                         {
-                            "$ref": "#/definitions/positiveInteger"
+                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/positiveInteger"
                         },
                         {
                             "default": 0
@@ -533,10 +533,10 @@
                     "default": false
                 },
                 "maxLength": {
-                    "$ref": "#/definitions/positiveInteger"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/positiveInteger"
                 },
                 "minLength": {
-                    "$ref": "#/definitions/positiveIntegerDefault0"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/positiveIntegerDefault0"
                 },
                 "pattern": {
                     "type": "string",
@@ -548,7 +548,7 @@
                             "type": "boolean"
                         },
                         {
-                            "$ref": "#"
+                            "$ref": "#/definitions/json-schema-draft-07-schema"
                         }
                     ],
                     "default": {}
@@ -556,32 +556,32 @@
                 "items": {
                     "anyOf": [
                         {
-                            "$ref": "#"
+                            "$ref": "#/definitions/json-schema-draft-07-schema"
                         },
                         {
-                            "$ref": "#/definitions/schemaArray"
+                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/schemaArray"
                         }
                     ],
                     "default": {}
                 },
                 "maxItems": {
-                    "$ref": "#/definitions/positiveInteger"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/positiveInteger"
                 },
                 "minItems": {
-                    "$ref": "#/definitions/positiveIntegerDefault0"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/positiveIntegerDefault0"
                 },
                 "uniqueItems": {
                     "type": "boolean",
                     "default": false
                 },
                 "maxProperties": {
-                    "$ref": "#/definitions/positiveInteger"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/positiveInteger"
                 },
                 "minProperties": {
-                    "$ref": "#/definitions/positiveIntegerDefault0"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/positiveIntegerDefault0"
                 },
                 "required": {
-                    "$ref": "#/definitions/stringArray"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/stringArray"
                 },
                 "additionalProperties": {
                     "anyOf": [
@@ -589,7 +589,7 @@
                             "type": "boolean"
                         },
                         {
-                            "$ref": "#"
+                            "$ref": "#/definitions/json-schema-draft-07-schema"
                         }
                     ],
                     "default": {}
@@ -597,21 +597,21 @@
                 "definitions": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "#"
+                        "$ref": "#/definitions/json-schema-draft-07-schema"
                     },
                     "default": {}
                 },
                 "properties": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "#"
+                        "$ref": "#/definitions/json-schema-draft-07-schema"
                     },
                     "default": {}
                 },
                 "patternProperties": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "#"
+                        "$ref": "#/definitions/json-schema-draft-07-schema"
                     },
                     "default": {}
                 },
@@ -620,10 +620,10 @@
                     "additionalProperties": {
                         "anyOf": [
                             {
-                                "$ref": "#"
+                                "$ref": "#/definitions/json-schema-draft-07-schema"
                             },
                             {
-                                "$ref": "#/definitions/stringArray"
+                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/stringArray"
                             }
                         ]
                     }
@@ -636,12 +636,12 @@
                 "type": {
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/simpleTypes"
+                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/simpleTypes"
                         },
                         {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/simpleTypes"
+                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/simpleTypes"
                             },
                             "minItems": 1,
                             "uniqueItems": true
@@ -652,16 +652,16 @@
                     "type": "string"
                 },
                 "allOf": {
-                    "$ref": "#/definitions/schemaArray"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/schemaArray"
                 },
                 "anyOf": {
-                    "$ref": "#/definitions/schemaArray"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/schemaArray"
                 },
                 "oneOf": {
-                    "$ref": "#/definitions/schemaArray"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/schemaArray"
                 },
                 "not": {
-                    "$ref": "#"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 }
             },
             "dependencies": {
@@ -674,7 +674,7 @@
             },
             "default": {}
         },
-        "http://asyncapi.com/definitions/1.0.0/xml.json": {
+        "xml": {
             "id": "http://asyncapi.com/definitions/1.0.0/xml.json",
             "type": "object",
             "additionalProperties": false,
@@ -698,7 +698,7 @@
                 }
             }
         },
-        "http://asyncapi.com/definitions/1.0.0/externalDocs.json": {
+        "externalDocs": {
             "id": "http://asyncapi.com/definitions/1.0.0/externalDocs.json",
             "type": "object",
             "additionalProperties": false,
@@ -717,11 +717,11 @@
             },
             "patternProperties": {
                 "^x-": {
-                    "$ref": "http://asyncapi.com/definitions/1.0.0/vendorExtension.json"
+                    "$ref": "#/definitions/vendorExtension"
                 }
             }
         },
-        "http://asyncapi.com/definitions/1.0.0/tag.json": {
+        "tag": {
             "id": "http://asyncapi.com/definitions/1.0.0/tag.json",
             "type": "object",
             "additionalProperties": false,
@@ -736,26 +736,26 @@
                     "type": "string"
                 },
                 "externalDocs": {
-                    "$ref": "http://asyncapi.com/definitions/1.0.0/externalDocs.json"
+                    "$ref": "#/definitions/externalDocs"
                 }
             },
             "patternProperties": {
                 "^x-": {
-                    "$ref": "http://asyncapi.com/definitions/1.0.0/vendorExtension.json"
+                    "$ref": "#/definitions/vendorExtension"
                 }
             }
         },
-        "http://asyncapi.com/definitions/1.0.0/components.json": {
+        "components": {
             "id": "http://asyncapi.com/definitions/1.0.0/components.json",
             "type": "object",
             "description": "An object to hold a set of reusable objects for different aspects of the AsyncAPI Specification.",
             "additionalProperties": false,
             "properties": {
                 "schemas": {
-                    "$ref": "http://asyncapi.com/definitions/1.0.0/schemas.json"
+                    "$ref": "#/definitions/schemas"
                 },
                 "messages": {
-                    "$ref": "http://asyncapi.com/definitions/1.0.0/messages.json"
+                    "$ref": "#/definitions/messages"
                 },
                 "securitySchemes": {
                     "type": "object",
@@ -763,10 +763,10 @@
                         "^[a-zA-Z0-9\\.\\-_]+$": {
                             "oneOf": [
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/1.0.0/Reference.json"
+                                    "$ref": "#/definitions/Reference"
                                 },
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/1.0.0/SecurityScheme.json"
+                                    "$ref": "#/definitions/SecurityScheme"
                                 }
                             ]
                         }
@@ -774,23 +774,23 @@
                 }
             }
         },
-        "http://asyncapi.com/definitions/1.0.0/schemas.json": {
+        "schemas": {
             "id": "http://asyncapi.com/definitions/1.0.0/schemas.json",
             "type": "object",
             "additionalProperties": {
-                "$ref": "http://asyncapi.com/definitions/1.0.0/schema.json"
+                "$ref": "#/definitions/schema"
             },
             "description": "JSON objects describing schemas the API uses."
         },
-        "http://asyncapi.com/definitions/1.0.0/messages.json": {
+        "messages": {
             "id": "http://asyncapi.com/definitions/1.0.0/messages.json",
             "type": "object",
             "additionalProperties": {
-                "$ref": "http://asyncapi.com/definitions/1.0.0/message.json"
+                "$ref": "#/definitions/message"
             },
             "description": "JSON objects describing the messages being consumed and produced by the API."
         },
-        "http://asyncapi.com/definitions/1.0.0/Reference.json": {
+        "Reference": {
             "id": "http://asyncapi.com/definitions/1.0.0/Reference.json",
             "type": "object",
             "required": [
@@ -803,30 +803,30 @@
                 }
             }
         },
-        "http://asyncapi.com/definitions/1.0.0/SecurityScheme.json": {
+        "SecurityScheme": {
             "id": "http://asyncapi.com/definitions/1.0.0/SecurityScheme.json",
             "oneOf": [
                 {
-                    "$ref": "http://asyncapi.com/definitions/1.0.0/userPassword.json"
+                    "$ref": "#/definitions/userPassword"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/1.0.0/apiKey.json"
+                    "$ref": "#/definitions/apiKey"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/1.0.0/X509.json"
+                    "$ref": "#/definitions/X509"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/1.0.0/symmetricEncryption.json"
+                    "$ref": "#/definitions/symmetricEncryption"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/1.0.0/asymmetricEncryption.json"
+                    "$ref": "#/definitions/asymmetricEncryption"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/1.0.0/HTTPSecurityScheme.json"
+                    "$ref": "#/definitions/HTTPSecurityScheme"
                 }
             ]
         },
-        "http://asyncapi.com/definitions/1.0.0/userPassword.json": {
+        "userPassword": {
             "id": "http://asyncapi.com/definitions/1.0.0/userPassword.json",
             "type": "object",
             "required": [
@@ -848,7 +848,7 @@
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/1.0.0/apiKey.json": {
+        "apiKey": {
             "id": "http://asyncapi.com/definitions/1.0.0/apiKey.json",
             "type": "object",
             "required": [
@@ -878,7 +878,7 @@
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/1.0.0/X509.json": {
+        "X509": {
             "id": "http://asyncapi.com/definitions/1.0.0/X509.json",
             "type": "object",
             "required": [
@@ -900,7 +900,7 @@
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/1.0.0/symmetricEncryption.json": {
+        "symmetricEncryption": {
             "id": "http://asyncapi.com/definitions/1.0.0/symmetricEncryption.json",
             "type": "object",
             "required": [
@@ -922,7 +922,7 @@
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/1.0.0/asymmetricEncryption.json": {
+        "asymmetricEncryption": {
             "id": "http://asyncapi.com/definitions/1.0.0/asymmetricEncryption.json",
             "type": "object",
             "required": [
@@ -944,21 +944,21 @@
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/1.0.0/HTTPSecurityScheme.json": {
+        "HTTPSecurityScheme": {
             "id": "http://asyncapi.com/definitions/1.0.0/HTTPSecurityScheme.json",
             "oneOf": [
                 {
-                    "$ref": "http://asyncapi.com/definitions/1.0.0/NonBearerHTTPSecurityScheme.json"
+                    "$ref": "#/definitions/NonBearerHTTPSecurityScheme"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/1.0.0/BearerHTTPSecurityScheme.json"
+                    "$ref": "#/definitions/BearerHTTPSecurityScheme"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/1.0.0/APIKeyHTTPSecurityScheme.json"
+                    "$ref": "#/definitions/APIKeyHTTPSecurityScheme"
                 }
             ]
         },
-        "http://asyncapi.com/definitions/1.0.0/NonBearerHTTPSecurityScheme.json": {
+        "NonBearerHTTPSecurityScheme": {
             "id": "http://asyncapi.com/definitions/1.0.0/NonBearerHTTPSecurityScheme.json",
             "not": {
                 "type": "object",
@@ -995,7 +995,7 @@
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/1.0.0/BearerHTTPSecurityScheme.json": {
+        "BearerHTTPSecurityScheme": {
             "id": "http://asyncapi.com/definitions/1.0.0/BearerHTTPSecurityScheme.json",
             "type": "object",
             "required": [
@@ -1027,7 +1027,7 @@
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/1.0.0/APIKeyHTTPSecurityScheme.json": {
+        "APIKeyHTTPSecurityScheme": {
             "id": "http://asyncapi.com/definitions/1.0.0/APIKeyHTTPSecurityScheme.json",
             "type": "object",
             "required": [
@@ -1062,7 +1062,7 @@
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/1.0.0/SecurityRequirement.json": {
+        "SecurityRequirement": {
             "id": "http://asyncapi.com/definitions/1.0.0/SecurityRequirement.json",
             "type": "object",
             "additionalProperties": {

--- a/schemas/1.1.0.json
+++ b/schemas/1.1.0.json
@@ -11,7 +11,7 @@
     "additionalProperties": false,
     "patternProperties": {
         "^x-": {
-            "$ref": "http://asyncapi.com/definitions/1.1.0/vendorExtension.json"
+            "$ref": "#/definitions/vendorExtension"
         }
     },
     "properties": {
@@ -24,7 +24,7 @@
             "description": "The AsyncAPI specification version of this document."
         },
         "info": {
-            "$ref": "http://asyncapi.com/definitions/1.1.0/info.json"
+            "$ref": "#/definitions/info"
         },
         "baseTopic": {
             "type": "string",
@@ -35,41 +35,41 @@
         "servers": {
             "type": "array",
             "items": {
-                "$ref": "http://asyncapi.com/definitions/1.1.0/server.json"
+                "$ref": "#/definitions/server"
             },
             "uniqueItems": true
         },
         "topics": {
-            "$ref": "http://asyncapi.com/definitions/1.1.0/topics.json"
+            "$ref": "#/definitions/topics"
         },
         "components": {
-            "$ref": "http://asyncapi.com/definitions/1.1.0/components.json"
+            "$ref": "#/definitions/components"
         },
         "tags": {
             "type": "array",
             "items": {
-                "$ref": "http://asyncapi.com/definitions/1.1.0/tag.json"
+                "$ref": "#/definitions/tag"
             },
             "uniqueItems": true
         },
         "security": {
             "type": "array",
             "items": {
-                "$ref": "http://asyncapi.com/definitions/1.1.0/SecurityRequirement.json"
+                "$ref": "#/definitions/SecurityRequirement"
             }
         },
         "externalDocs": {
-            "$ref": "http://asyncapi.com/definitions/1.1.0/externalDocs.json"
+            "$ref": "#/definitions/externalDocs"
         }
     },
     "definitions": {
-        "http://asyncapi.com/definitions/1.1.0/vendorExtension.json": {
+        "vendorExtension": {
             "id": "http://asyncapi.com/definitions/1.1.0/vendorExtension.json",
             "description": "Any property starting with x- is valid.",
             "additionalProperties": true,
             "additionalItems": true
         },
-        "http://asyncapi.com/definitions/1.1.0/info.json": {
+        "info": {
             "id": "http://asyncapi.com/definitions/1.1.0/info.json",
             "type": "object",
             "description": "General information about the API.",
@@ -80,7 +80,7 @@
             "additionalProperties": false,
             "patternProperties": {
                 "^x-": {
-                    "$ref": "http://asyncapi.com/definitions/1.1.0/vendorExtension.json"
+                    "$ref": "#/definitions/vendorExtension"
                 }
             },
             "properties": {
@@ -102,14 +102,14 @@
                     "format": "uri"
                 },
                 "contact": {
-                    "$ref": "http://asyncapi.com/definitions/1.1.0/contact.json"
+                    "$ref": "#/definitions/contact"
                 },
                 "license": {
-                    "$ref": "http://asyncapi.com/definitions/1.1.0/license.json"
+                    "$ref": "#/definitions/license"
                 }
             }
         },
-        "http://asyncapi.com/definitions/1.1.0/contact.json": {
+        "contact": {
             "id": "http://asyncapi.com/definitions/1.1.0/contact.json",
             "type": "object",
             "description": "Contact information for the owners of the API.",
@@ -132,11 +132,11 @@
             },
             "patternProperties": {
                 "^x-": {
-                    "$ref": "http://asyncapi.com/definitions/1.1.0/vendorExtension.json"
+                    "$ref": "#/definitions/vendorExtension"
                 }
             }
         },
-        "http://asyncapi.com/definitions/1.1.0/license.json": {
+        "license": {
             "id": "http://asyncapi.com/definitions/1.1.0/license.json",
             "type": "object",
             "required": [
@@ -156,11 +156,11 @@
             },
             "patternProperties": {
                 "^x-": {
-                    "$ref": "http://asyncapi.com/definitions/1.1.0/vendorExtension.json"
+                    "$ref": "#/definitions/vendorExtension"
                 }
             }
         },
-        "http://asyncapi.com/definitions/1.1.0/server.json": {
+        "server": {
             "id": "http://asyncapi.com/definitions/1.1.0/server.json",
             "type": "object",
             "description": "An object representing a Server.",
@@ -171,7 +171,7 @@
             "additionalProperties": false,
             "patternProperties": {
                 "^x-": {
-                    "$ref": "http://asyncapi.com/definitions/1.1.0/vendorExtension.json"
+                    "$ref": "#/definitions/vendorExtension"
                 }
             },
             "properties": {
@@ -203,18 +203,18 @@
                     "type": "string"
                 },
                 "variables": {
-                    "$ref": "http://asyncapi.com/definitions/1.1.0/serverVariables.json"
+                    "$ref": "#/definitions/serverVariables"
                 }
             }
         },
-        "http://asyncapi.com/definitions/1.1.0/serverVariables.json": {
+        "serverVariables": {
             "id": "http://asyncapi.com/definitions/1.1.0/serverVariables.json",
             "type": "object",
             "additionalProperties": {
-                "$ref": "http://asyncapi.com/definitions/1.1.0/serverVariable.json"
+                "$ref": "#/definitions/serverVariable"
             }
         },
-        "http://asyncapi.com/definitions/1.1.0/serverVariable.json": {
+        "serverVariable": {
             "id": "http://asyncapi.com/definitions/1.1.0/serverVariable.json",
             "type": "object",
             "description": "An object representing a Server Variable for server URL template substitution.",
@@ -222,7 +222,7 @@
             "additionalProperties": false,
             "patternProperties": {
                 "^x-": {
-                    "$ref": "http://asyncapi.com/definitions/1.1.0/vendorExtension.json"
+                    "$ref": "#/definitions/vendorExtension"
                 }
             },
             "properties": {
@@ -241,27 +241,27 @@
                 }
             }
         },
-        "http://asyncapi.com/definitions/1.1.0/topics.json": {
+        "topics": {
             "id": "http://asyncapi.com/definitions/1.1.0/topics.json",
             "type": "object",
             "description": "Relative paths to the individual topics. They must be relative to the 'baseTopic'.",
             "patternProperties": {
                 "^x-": {
-                    "$ref": "http://asyncapi.com/definitions/1.1.0/vendorExtension.json"
+                    "$ref": "#/definitions/vendorExtension"
                 },
                 "^[^.]": {
-                    "$ref": "http://asyncapi.com/definitions/1.1.0/topicItem.json"
+                    "$ref": "#/definitions/topicItem"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/1.1.0/topicItem.json": {
+        "topicItem": {
             "id": "http://asyncapi.com/definitions/1.1.0/topicItem.json",
             "type": "object",
             "additionalProperties": false,
             "patternProperties": {
                 "^x-": {
-                    "$ref": "http://asyncapi.com/definitions/1.1.0/vendorExtension.json"
+                    "$ref": "#/definitions/vendorExtension"
                 }
             },
             "minProperties": 1,
@@ -274,14 +274,14 @@
                     "uniqueItems": true,
                     "minItems": 1,
                     "items": {
-                        "$ref": "http://asyncapi.com/definitions/1.1.0/parameter.json"
+                        "$ref": "#/definitions/parameter"
                     }
                 },
                 "publish": {
-                    "$ref": "http://asyncapi.com/definitions/1.1.0/operation.json"
+                    "$ref": "#/definitions/operation"
                 },
                 "subscribe": {
-                    "$ref": "http://asyncapi.com/definitions/1.1.0/operation.json"
+                    "$ref": "#/definitions/operation"
                 },
                 "deprecated": {
                     "type": "boolean",
@@ -289,12 +289,12 @@
                 }
             }
         },
-        "http://asyncapi.com/definitions/1.1.0/parameter.json": {
+        "parameter": {
             "id": "http://asyncapi.com/definitions/1.1.0/parameter.json",
             "additionalProperties": false,
             "patternProperties": {
                 "^x-": {
-                    "$ref": "http://asyncapi.com/definitions/1.1.0/vendorExtension.json"
+                    "$ref": "#/definitions/vendorExtension"
                 }
             },
             "properties": {
@@ -307,17 +307,17 @@
                     "description": "The name of the parameter."
                 },
                 "schema": {
-                    "$ref": "http://asyncapi.com/definitions/1.1.0/schema.json"
+                    "$ref": "#/definitions/schema"
                 }
             }
         },
-        "http://asyncapi.com/definitions/1.1.0/schema.json": {
+        "schema": {
             "id": "http://asyncapi.com/definitions/1.1.0/schema.json",
             "type": "object",
             "description": "A deterministic version of a JSON Schema object.",
             "patternProperties": {
                 "^x-": {
-                    "$ref": "http://asyncapi.com/definitions/1.1.0/vendorExtension.json"
+                    "$ref": "#/definitions/vendorExtension"
                 }
             },
             "properties": {
@@ -328,63 +328,63 @@
                     "type": "string"
                 },
                 "title": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/properties/title"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "description": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/properties/description"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "default": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/properties/default"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "multipleOf": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/properties/multipleOf"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "maximum": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/properties/maximum"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "exclusiveMaximum": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/properties/exclusiveMaximum"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "minimum": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/properties/minimum"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "exclusiveMinimum": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/properties/exclusiveMinimum"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "maxLength": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "minLength": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "pattern": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/properties/pattern"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "maxItems": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "minItems": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "uniqueItems": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/properties/uniqueItems"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "maxProperties": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "minProperties": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "required": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/definitions/stringArray"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "enum": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/properties/enum"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "additionalProperties": {
                     "anyOf": [
                         {
-                            "$ref": "http://asyncapi.com/definitions/1.1.0/schema.json"
+                            "$ref": "#/definitions/schema"
                         },
                         {
                             "type": "boolean"
@@ -393,18 +393,18 @@
                     "default": {}
                 },
                 "type": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/properties/type"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "items": {
                     "anyOf": [
                         {
-                            "$ref": "http://asyncapi.com/definitions/1.1.0/schema.json"
+                            "$ref": "#/definitions/schema"
                         },
                         {
                             "type": "array",
                             "minItems": 1,
                             "items": {
-                                "$ref": "http://asyncapi.com/definitions/1.1.0/schema.json"
+                                "$ref": "#/definitions/schema"
                             }
                         }
                     ],
@@ -414,30 +414,30 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "http://asyncapi.com/definitions/1.1.0/schema.json"
+                        "$ref": "#/definitions/schema"
                     }
                 },
                 "oneOf": {
                     "type": "array",
                     "minItems": 2,
                     "items": {
-                        "$ref": "http://asyncapi.com/definitions/1.1.0/schema.json"
+                        "$ref": "#/definitions/schema"
                     }
                 },
                 "anyOf": {
                     "type": "array",
                     "minItems": 2,
                     "items": {
-                        "$ref": "http://asyncapi.com/definitions/1.1.0/schema.json"
+                        "$ref": "#/definitions/schema"
                     }
                 },
                 "not": {
-                    "$ref": "http://asyncapi.com/definitions/1.1.0/schema.json"
+                    "$ref": "#/definitions/schema"
                 },
                 "properties": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "http://asyncapi.com/definitions/1.1.0/schema.json"
+                        "$ref": "#/definitions/schema"
                     },
                     "default": {}
                 },
@@ -449,16 +449,16 @@
                     "default": false
                 },
                 "xml": {
-                    "$ref": "http://asyncapi.com/definitions/1.1.0/xml.json"
+                    "$ref": "#/definitions/xml"
                 },
                 "externalDocs": {
-                    "$ref": "http://asyncapi.com/definitions/1.1.0/externalDocs.json"
+                    "$ref": "#/definitions/externalDocs"
                 },
                 "example": {}
             },
             "additionalProperties": false
         },
-        "http://json-schema.org/draft-04/schema": {
+        "json-schema-draft-07-schema": {
             "id": "http://json-schema.org/draft-04/schema",
             "description": "Core schema meta-schema",
             "definitions": {
@@ -466,7 +466,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#"
+                        "$ref": "#/definitions/json-schema-draft-07-schema"
                     }
                 },
                 "positiveInteger": {
@@ -476,7 +476,7 @@
                 "positiveIntegerDefault0": {
                     "allOf": [
                         {
-                            "$ref": "#/definitions/positiveInteger"
+                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/positiveInteger"
                         },
                         {
                             "default": 0
@@ -538,10 +538,10 @@
                     "default": false
                 },
                 "maxLength": {
-                    "$ref": "#/definitions/positiveInteger"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/positiveInteger"
                 },
                 "minLength": {
-                    "$ref": "#/definitions/positiveIntegerDefault0"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/positiveIntegerDefault0"
                 },
                 "pattern": {
                     "type": "string",
@@ -553,7 +553,7 @@
                             "type": "boolean"
                         },
                         {
-                            "$ref": "#"
+                            "$ref": "#/definitions/json-schema-draft-07-schema"
                         }
                     ],
                     "default": {}
@@ -561,32 +561,32 @@
                 "items": {
                     "anyOf": [
                         {
-                            "$ref": "#"
+                            "$ref": "#/definitions/json-schema-draft-07-schema"
                         },
                         {
-                            "$ref": "#/definitions/schemaArray"
+                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/schemaArray"
                         }
                     ],
                     "default": {}
                 },
                 "maxItems": {
-                    "$ref": "#/definitions/positiveInteger"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/positiveInteger"
                 },
                 "minItems": {
-                    "$ref": "#/definitions/positiveIntegerDefault0"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/positiveIntegerDefault0"
                 },
                 "uniqueItems": {
                     "type": "boolean",
                     "default": false
                 },
                 "maxProperties": {
-                    "$ref": "#/definitions/positiveInteger"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/positiveInteger"
                 },
                 "minProperties": {
-                    "$ref": "#/definitions/positiveIntegerDefault0"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/positiveIntegerDefault0"
                 },
                 "required": {
-                    "$ref": "#/definitions/stringArray"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/stringArray"
                 },
                 "additionalProperties": {
                     "anyOf": [
@@ -594,7 +594,7 @@
                             "type": "boolean"
                         },
                         {
-                            "$ref": "#"
+                            "$ref": "#/definitions/json-schema-draft-07-schema"
                         }
                     ],
                     "default": {}
@@ -602,21 +602,21 @@
                 "definitions": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "#"
+                        "$ref": "#/definitions/json-schema-draft-07-schema"
                     },
                     "default": {}
                 },
                 "properties": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "#"
+                        "$ref": "#/definitions/json-schema-draft-07-schema"
                     },
                     "default": {}
                 },
                 "patternProperties": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "#"
+                        "$ref": "#/definitions/json-schema-draft-07-schema"
                     },
                     "default": {}
                 },
@@ -625,10 +625,10 @@
                     "additionalProperties": {
                         "anyOf": [
                             {
-                                "$ref": "#"
+                                "$ref": "#/definitions/json-schema-draft-07-schema"
                             },
                             {
-                                "$ref": "#/definitions/stringArray"
+                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/stringArray"
                             }
                         ]
                     }
@@ -641,12 +641,12 @@
                 "type": {
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/simpleTypes"
+                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/simpleTypes"
                         },
                         {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/simpleTypes"
+                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/simpleTypes"
                             },
                             "minItems": 1,
                             "uniqueItems": true
@@ -657,16 +657,16 @@
                     "type": "string"
                 },
                 "allOf": {
-                    "$ref": "#/definitions/schemaArray"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/schemaArray"
                 },
                 "anyOf": {
-                    "$ref": "#/definitions/schemaArray"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/schemaArray"
                 },
                 "oneOf": {
-                    "$ref": "#/definitions/schemaArray"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/schemaArray"
                 },
                 "not": {
-                    "$ref": "#"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 }
             },
             "dependencies": {
@@ -679,7 +679,7 @@
             },
             "default": {}
         },
-        "http://asyncapi.com/definitions/1.1.0/xml.json": {
+        "xml": {
             "id": "http://asyncapi.com/definitions/1.1.0/xml.json",
             "type": "object",
             "additionalProperties": false,
@@ -703,7 +703,7 @@
                 }
             }
         },
-        "http://asyncapi.com/definitions/1.1.0/externalDocs.json": {
+        "externalDocs": {
             "id": "http://asyncapi.com/definitions/1.1.0/externalDocs.json",
             "type": "object",
             "additionalProperties": false,
@@ -722,15 +722,15 @@
             },
             "patternProperties": {
                 "^x-": {
-                    "$ref": "http://asyncapi.com/definitions/1.1.0/vendorExtension.json"
+                    "$ref": "#/definitions/vendorExtension"
                 }
             }
         },
-        "http://asyncapi.com/definitions/1.1.0/operation.json": {
+        "operation": {
             "id": "http://asyncapi.com/definitions/1.1.0/operation.json",
             "oneOf": [
                 {
-                    "$ref": "http://asyncapi.com/definitions/1.1.0/message.json"
+                    "$ref": "#/definitions/message"
                 },
                 {
                     "type": "object",
@@ -740,7 +740,7 @@
                     "additionalProperties": false,
                     "patternProperties": {
                         "^x-": {
-                            "$ref": "http://asyncapi.com/definitions/1.1.0/vendorExtension.json"
+                            "$ref": "#/definitions/vendorExtension"
                         }
                     },
                     "properties": {
@@ -748,20 +748,20 @@
                             "type": "array",
                             "minItems": 2,
                             "items": {
-                                "$ref": "http://asyncapi.com/definitions/1.1.0/message.json"
+                                "$ref": "#/definitions/message"
                             }
                         }
                     }
                 }
             ]
         },
-        "http://asyncapi.com/definitions/1.1.0/message.json": {
+        "message": {
             "id": "http://asyncapi.com/definitions/1.1.0/message.json",
             "type": "object",
             "additionalProperties": false,
             "patternProperties": {
                 "^x-": {
-                    "$ref": "http://asyncapi.com/definitions/1.1.0/vendorExtension.json"
+                    "$ref": "#/definitions/vendorExtension"
                 }
             },
             "properties": {
@@ -769,15 +769,15 @@
                     "type": "string"
                 },
                 "headers": {
-                    "$ref": "http://asyncapi.com/definitions/1.1.0/schema.json"
+                    "$ref": "#/definitions/schema"
                 },
                 "payload": {
-                    "$ref": "http://asyncapi.com/definitions/1.1.0/schema.json"
+                    "$ref": "#/definitions/schema"
                 },
                 "tags": {
                     "type": "array",
                     "items": {
-                        "$ref": "http://asyncapi.com/definitions/1.1.0/tag.json"
+                        "$ref": "#/definitions/tag"
                     },
                     "uniqueItems": true
                 },
@@ -790,7 +790,7 @@
                     "description": "A longer description of the message. CommonMark is allowed."
                 },
                 "externalDocs": {
-                    "$ref": "http://asyncapi.com/definitions/1.1.0/externalDocs.json"
+                    "$ref": "#/definitions/externalDocs"
                 },
                 "deprecated": {
                     "type": "boolean",
@@ -799,7 +799,7 @@
                 "example": {}
             }
         },
-        "http://asyncapi.com/definitions/1.1.0/tag.json": {
+        "tag": {
             "id": "http://asyncapi.com/definitions/1.1.0/tag.json",
             "type": "object",
             "additionalProperties": false,
@@ -814,26 +814,26 @@
                     "type": "string"
                 },
                 "externalDocs": {
-                    "$ref": "http://asyncapi.com/definitions/1.1.0/externalDocs.json"
+                    "$ref": "#/definitions/externalDocs"
                 }
             },
             "patternProperties": {
                 "^x-": {
-                    "$ref": "http://asyncapi.com/definitions/1.1.0/vendorExtension.json"
+                    "$ref": "#/definitions/vendorExtension"
                 }
             }
         },
-        "http://asyncapi.com/definitions/1.1.0/components.json": {
+        "components": {
             "id": "http://asyncapi.com/definitions/1.1.0/components.json",
             "type": "object",
             "description": "An object to hold a set of reusable objects for different aspects of the AsyncAPI Specification.",
             "additionalProperties": false,
             "properties": {
                 "schemas": {
-                    "$ref": "http://asyncapi.com/definitions/1.1.0/schemas.json"
+                    "$ref": "#/definitions/schemas"
                 },
                 "messages": {
-                    "$ref": "http://asyncapi.com/definitions/1.1.0/messages.json"
+                    "$ref": "#/definitions/messages"
                 },
                 "securitySchemes": {
                     "type": "object",
@@ -841,10 +841,10 @@
                         "^[a-zA-Z0-9\\.\\-_]+$": {
                             "oneOf": [
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/1.1.0/Reference.json"
+                                    "$ref": "#/definitions/Reference"
                                 },
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/1.1.0/SecurityScheme.json"
+                                    "$ref": "#/definitions/SecurityScheme"
                                 }
                             ]
                         }
@@ -852,23 +852,23 @@
                 }
             }
         },
-        "http://asyncapi.com/definitions/1.1.0/schemas.json": {
+        "schemas": {
             "id": "http://asyncapi.com/definitions/1.1.0/schemas.json",
             "type": "object",
             "additionalProperties": {
-                "$ref": "http://asyncapi.com/definitions/1.1.0/schema.json"
+                "$ref": "#/definitions/schema"
             },
             "description": "JSON objects describing schemas the API uses."
         },
-        "http://asyncapi.com/definitions/1.1.0/messages.json": {
+        "messages": {
             "id": "http://asyncapi.com/definitions/1.1.0/messages.json",
             "type": "object",
             "additionalProperties": {
-                "$ref": "http://asyncapi.com/definitions/1.1.0/message.json"
+                "$ref": "#/definitions/message"
             },
             "description": "JSON objects describing the messages being consumed and produced by the API."
         },
-        "http://asyncapi.com/definitions/1.1.0/Reference.json": {
+        "Reference": {
             "id": "http://asyncapi.com/definitions/1.1.0/Reference.json",
             "type": "object",
             "required": [
@@ -881,30 +881,30 @@
                 }
             }
         },
-        "http://asyncapi.com/definitions/1.1.0/SecurityScheme.json": {
+        "SecurityScheme": {
             "id": "http://asyncapi.com/definitions/1.1.0/SecurityScheme.json",
             "oneOf": [
                 {
-                    "$ref": "http://asyncapi.com/definitions/1.1.0/userPassword.json"
+                    "$ref": "#/definitions/userPassword"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/1.1.0/apiKey.json"
+                    "$ref": "#/definitions/apiKey"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/1.1.0/X509.json"
+                    "$ref": "#/definitions/X509"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/1.1.0/symmetricEncryption.json"
+                    "$ref": "#/definitions/symmetricEncryption"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/1.1.0/asymmetricEncryption.json"
+                    "$ref": "#/definitions/asymmetricEncryption"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/1.1.0/HTTPSecurityScheme.json"
+                    "$ref": "#/definitions/HTTPSecurityScheme"
                 }
             ]
         },
-        "http://asyncapi.com/definitions/1.1.0/userPassword.json": {
+        "userPassword": {
             "id": "http://asyncapi.com/definitions/1.1.0/userPassword.json",
             "type": "object",
             "required": [
@@ -926,7 +926,7 @@
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/1.1.0/apiKey.json": {
+        "apiKey": {
             "id": "http://asyncapi.com/definitions/1.1.0/apiKey.json",
             "type": "object",
             "required": [
@@ -956,7 +956,7 @@
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/1.1.0/X509.json": {
+        "X509": {
             "id": "http://asyncapi.com/definitions/1.1.0/X509.json",
             "type": "object",
             "required": [
@@ -978,7 +978,7 @@
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/1.1.0/symmetricEncryption.json": {
+        "symmetricEncryption": {
             "id": "http://asyncapi.com/definitions/1.1.0/symmetricEncryption.json",
             "type": "object",
             "required": [
@@ -1000,7 +1000,7 @@
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/1.1.0/asymmetricEncryption.json": {
+        "asymmetricEncryption": {
             "id": "http://asyncapi.com/definitions/1.1.0/asymmetricEncryption.json",
             "type": "object",
             "required": [
@@ -1022,21 +1022,21 @@
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/1.1.0/HTTPSecurityScheme.json": {
+        "HTTPSecurityScheme": {
             "id": "http://asyncapi.com/definitions/1.1.0/HTTPSecurityScheme.json",
             "oneOf": [
                 {
-                    "$ref": "http://asyncapi.com/definitions/1.1.0/NonBearerHTTPSecurityScheme.json"
+                    "$ref": "#/definitions/NonBearerHTTPSecurityScheme"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/1.1.0/BearerHTTPSecurityScheme.json"
+                    "$ref": "#/definitions/BearerHTTPSecurityScheme"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/1.1.0/APIKeyHTTPSecurityScheme.json"
+                    "$ref": "#/definitions/APIKeyHTTPSecurityScheme"
                 }
             ]
         },
-        "http://asyncapi.com/definitions/1.1.0/NonBearerHTTPSecurityScheme.json": {
+        "NonBearerHTTPSecurityScheme": {
             "id": "http://asyncapi.com/definitions/1.1.0/NonBearerHTTPSecurityScheme.json",
             "not": {
                 "type": "object",
@@ -1073,7 +1073,7 @@
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/1.1.0/BearerHTTPSecurityScheme.json": {
+        "BearerHTTPSecurityScheme": {
             "id": "http://asyncapi.com/definitions/1.1.0/BearerHTTPSecurityScheme.json",
             "type": "object",
             "required": [
@@ -1105,7 +1105,7 @@
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/1.1.0/APIKeyHTTPSecurityScheme.json": {
+        "APIKeyHTTPSecurityScheme": {
             "id": "http://asyncapi.com/definitions/1.1.0/APIKeyHTTPSecurityScheme.json",
             "type": "object",
             "required": [
@@ -1140,7 +1140,7 @@
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/1.1.0/SecurityRequirement.json": {
+        "SecurityRequirement": {
             "id": "http://asyncapi.com/definitions/1.1.0/SecurityRequirement.json",
             "type": "object",
             "additionalProperties": {

--- a/schemas/1.2.0.json
+++ b/schemas/1.2.0.json
@@ -27,7 +27,7 @@
     "additionalProperties": false,
     "patternProperties": {
         "^x-": {
-            "$ref": "http://asyncapi.com/definitions/1.2.0/vendorExtension.json"
+            "$ref": "#/definitions/vendorExtension"
         }
     },
     "properties": {
@@ -41,7 +41,7 @@
             "description": "The AsyncAPI specification version of this document."
         },
         "info": {
-            "$ref": "http://asyncapi.com/definitions/1.2.0/info.json"
+            "$ref": "#/definitions/info"
         },
         "baseTopic": {
             "type": "string",
@@ -52,49 +52,49 @@
         "servers": {
             "type": "array",
             "items": {
-                "$ref": "http://asyncapi.com/definitions/1.2.0/server.json"
+                "$ref": "#/definitions/server"
             },
             "uniqueItems": true
         },
         "topics": {
-            "$ref": "http://asyncapi.com/definitions/1.2.0/topics.json"
+            "$ref": "#/definitions/topics"
         },
         "stream": {
-            "$ref": "http://asyncapi.com/definitions/1.2.0/stream.json",
+            "$ref": "#/definitions/stream",
             "description": "The list of messages a consumer can read or write from/to a streaming API."
         },
         "events": {
-            "$ref": "http://asyncapi.com/definitions/1.2.0/events.json",
+            "$ref": "#/definitions/events",
             "description": "The list of messages an events API sends and/or receives."
         },
         "components": {
-            "$ref": "http://asyncapi.com/definitions/1.2.0/components.json"
+            "$ref": "#/definitions/components"
         },
         "tags": {
             "type": "array",
             "items": {
-                "$ref": "http://asyncapi.com/definitions/1.2.0/tag.json"
+                "$ref": "#/definitions/tag"
             },
             "uniqueItems": true
         },
         "security": {
             "type": "array",
             "items": {
-                "$ref": "http://asyncapi.com/definitions/1.2.0/SecurityRequirement.json"
+                "$ref": "#/definitions/SecurityRequirement"
             }
         },
         "externalDocs": {
-            "$ref": "http://asyncapi.com/definitions/1.2.0/externalDocs.json"
+            "$ref": "#/definitions/externalDocs"
         }
     },
     "definitions": {
-        "http://asyncapi.com/definitions/1.2.0/vendorExtension.json": {
+        "vendorExtension": {
             "id": "http://asyncapi.com/definitions/1.2.0/vendorExtension.json",
             "description": "Any property starting with x- is valid.",
             "additionalProperties": true,
             "additionalItems": true
         },
-        "http://asyncapi.com/definitions/1.2.0/info.json": {
+        "info": {
             "id": "http://asyncapi.com/definitions/1.2.0/info.json",
             "type": "object",
             "description": "General information about the API.",
@@ -105,7 +105,7 @@
             "additionalProperties": false,
             "patternProperties": {
                 "^x-": {
-                    "$ref": "http://asyncapi.com/definitions/1.2.0/vendorExtension.json"
+                    "$ref": "#/definitions/vendorExtension"
                 }
             },
             "properties": {
@@ -127,14 +127,14 @@
                     "format": "uri"
                 },
                 "contact": {
-                    "$ref": "http://asyncapi.com/definitions/1.2.0/contact.json"
+                    "$ref": "#/definitions/contact"
                 },
                 "license": {
-                    "$ref": "http://asyncapi.com/definitions/1.2.0/license.json"
+                    "$ref": "#/definitions/license"
                 }
             }
         },
-        "http://asyncapi.com/definitions/1.2.0/contact.json": {
+        "contact": {
             "id": "http://asyncapi.com/definitions/1.2.0/contact.json",
             "type": "object",
             "description": "Contact information for the owners of the API.",
@@ -157,11 +157,11 @@
             },
             "patternProperties": {
                 "^x-": {
-                    "$ref": "http://asyncapi.com/definitions/1.2.0/vendorExtension.json"
+                    "$ref": "#/definitions/vendorExtension"
                 }
             }
         },
-        "http://asyncapi.com/definitions/1.2.0/license.json": {
+        "license": {
             "id": "http://asyncapi.com/definitions/1.2.0/license.json",
             "type": "object",
             "required": [
@@ -181,11 +181,11 @@
             },
             "patternProperties": {
                 "^x-": {
-                    "$ref": "http://asyncapi.com/definitions/1.2.0/vendorExtension.json"
+                    "$ref": "#/definitions/vendorExtension"
                 }
             }
         },
-        "http://asyncapi.com/definitions/1.2.0/server.json": {
+        "server": {
             "id": "http://asyncapi.com/definitions/1.2.0/server.json",
             "type": "object",
             "description": "An object representing a Server.",
@@ -196,7 +196,7 @@
             "additionalProperties": false,
             "patternProperties": {
                 "^x-": {
-                    "$ref": "http://asyncapi.com/definitions/1.2.0/vendorExtension.json"
+                    "$ref": "#/definitions/vendorExtension"
                 }
             },
             "properties": {
@@ -230,18 +230,18 @@
                     "type": "string"
                 },
                 "variables": {
-                    "$ref": "http://asyncapi.com/definitions/1.2.0/serverVariables.json"
+                    "$ref": "#/definitions/serverVariables"
                 }
             }
         },
-        "http://asyncapi.com/definitions/1.2.0/serverVariables.json": {
+        "serverVariables": {
             "id": "http://asyncapi.com/definitions/1.2.0/serverVariables.json",
             "type": "object",
             "additionalProperties": {
-                "$ref": "http://asyncapi.com/definitions/1.2.0/serverVariable.json"
+                "$ref": "#/definitions/serverVariable"
             }
         },
-        "http://asyncapi.com/definitions/1.2.0/serverVariable.json": {
+        "serverVariable": {
             "id": "http://asyncapi.com/definitions/1.2.0/serverVariable.json",
             "type": "object",
             "description": "An object representing a Server Variable for server URL template substitution.",
@@ -249,7 +249,7 @@
             "additionalProperties": false,
             "patternProperties": {
                 "^x-": {
-                    "$ref": "http://asyncapi.com/definitions/1.2.0/vendorExtension.json"
+                    "$ref": "#/definitions/vendorExtension"
                 }
             },
             "properties": {
@@ -268,27 +268,27 @@
                 }
             }
         },
-        "http://asyncapi.com/definitions/1.2.0/topics.json": {
+        "topics": {
             "id": "http://asyncapi.com/definitions/1.2.0/topics.json",
             "type": "object",
             "description": "Relative paths to the individual topics. They must be relative to the 'baseTopic'.",
             "patternProperties": {
                 "^x-": {
-                    "$ref": "http://asyncapi.com/definitions/1.2.0/vendorExtension.json"
+                    "$ref": "#/definitions/vendorExtension"
                 },
                 "^[^.]": {
-                    "$ref": "http://asyncapi.com/definitions/1.2.0/topicItem.json"
+                    "$ref": "#/definitions/topicItem"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/1.2.0/topicItem.json": {
+        "topicItem": {
             "id": "http://asyncapi.com/definitions/1.2.0/topicItem.json",
             "type": "object",
             "additionalProperties": false,
             "patternProperties": {
                 "^x-": {
-                    "$ref": "http://asyncapi.com/definitions/1.2.0/vendorExtension.json"
+                    "$ref": "#/definitions/vendorExtension"
                 }
             },
             "minProperties": 1,
@@ -301,14 +301,14 @@
                     "uniqueItems": true,
                     "minItems": 1,
                     "items": {
-                        "$ref": "http://asyncapi.com/definitions/1.2.0/parameter.json"
+                        "$ref": "#/definitions/parameter"
                     }
                 },
                 "publish": {
-                    "$ref": "http://asyncapi.com/definitions/1.2.0/operation.json"
+                    "$ref": "#/definitions/operation"
                 },
                 "subscribe": {
-                    "$ref": "http://asyncapi.com/definitions/1.2.0/operation.json"
+                    "$ref": "#/definitions/operation"
                 },
                 "deprecated": {
                     "type": "boolean",
@@ -316,12 +316,12 @@
                 }
             }
         },
-        "http://asyncapi.com/definitions/1.2.0/parameter.json": {
+        "parameter": {
             "id": "http://asyncapi.com/definitions/1.2.0/parameter.json",
             "additionalProperties": false,
             "patternProperties": {
                 "^x-": {
-                    "$ref": "http://asyncapi.com/definitions/1.2.0/vendorExtension.json"
+                    "$ref": "#/definitions/vendorExtension"
                 }
             },
             "properties": {
@@ -334,20 +334,20 @@
                     "description": "The name of the parameter."
                 },
                 "schema": {
-                    "$ref": "http://asyncapi.com/definitions/1.2.0/schema.json"
+                    "$ref": "#/definitions/schema"
                 },
                 "$ref": {
                     "type": "string"
                 }
             }
         },
-        "http://asyncapi.com/definitions/1.2.0/schema.json": {
+        "schema": {
             "id": "http://asyncapi.com/definitions/1.2.0/schema.json",
             "type": "object",
             "description": "A deterministic version of a JSON Schema object.",
             "patternProperties": {
                 "^x-": {
-                    "$ref": "http://asyncapi.com/definitions/1.2.0/vendorExtension.json"
+                    "$ref": "#/definitions/vendorExtension"
                 }
             },
             "properties": {
@@ -358,63 +358,63 @@
                     "type": "string"
                 },
                 "title": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/properties/title"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "description": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/properties/description"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "default": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/properties/default"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "multipleOf": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/properties/multipleOf"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "maximum": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/properties/maximum"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "exclusiveMaximum": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/properties/exclusiveMaximum"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "minimum": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/properties/minimum"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "exclusiveMinimum": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/properties/exclusiveMinimum"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "maxLength": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "minLength": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "pattern": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/properties/pattern"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "maxItems": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "minItems": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "uniqueItems": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/properties/uniqueItems"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "maxProperties": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "minProperties": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "required": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/definitions/stringArray"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "enum": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/properties/enum"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "additionalProperties": {
                     "anyOf": [
                         {
-                            "$ref": "http://asyncapi.com/definitions/1.2.0/schema.json"
+                            "$ref": "#/definitions/schema"
                         },
                         {
                             "type": "boolean"
@@ -423,18 +423,18 @@
                     "default": {}
                 },
                 "type": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/properties/type"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "items": {
                     "anyOf": [
                         {
-                            "$ref": "http://asyncapi.com/definitions/1.2.0/schema.json"
+                            "$ref": "#/definitions/schema"
                         },
                         {
                             "type": "array",
                             "minItems": 1,
                             "items": {
-                                "$ref": "http://asyncapi.com/definitions/1.2.0/schema.json"
+                                "$ref": "#/definitions/schema"
                             }
                         }
                     ],
@@ -444,30 +444,30 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "http://asyncapi.com/definitions/1.2.0/schema.json"
+                        "$ref": "#/definitions/schema"
                     }
                 },
                 "oneOf": {
                     "type": "array",
                     "minItems": 2,
                     "items": {
-                        "$ref": "http://asyncapi.com/definitions/1.2.0/schema.json"
+                        "$ref": "#/definitions/schema"
                     }
                 },
                 "anyOf": {
                     "type": "array",
                     "minItems": 2,
                     "items": {
-                        "$ref": "http://asyncapi.com/definitions/1.2.0/schema.json"
+                        "$ref": "#/definitions/schema"
                     }
                 },
                 "not": {
-                    "$ref": "http://asyncapi.com/definitions/1.2.0/schema.json"
+                    "$ref": "#/definitions/schema"
                 },
                 "properties": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "http://asyncapi.com/definitions/1.2.0/schema.json"
+                        "$ref": "#/definitions/schema"
                     },
                     "default": {}
                 },
@@ -479,16 +479,16 @@
                     "default": false
                 },
                 "xml": {
-                    "$ref": "http://asyncapi.com/definitions/1.2.0/xml.json"
+                    "$ref": "#/definitions/xml"
                 },
                 "externalDocs": {
-                    "$ref": "http://asyncapi.com/definitions/1.2.0/externalDocs.json"
+                    "$ref": "#/definitions/externalDocs"
                 },
                 "example": {}
             },
             "additionalProperties": false
         },
-        "http://json-schema.org/draft-04/schema": {
+        "json-schema-draft-07-schema": {
             "id": "http://json-schema.org/draft-04/schema",
             "description": "Core schema meta-schema",
             "definitions": {
@@ -496,7 +496,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#"
+                        "$ref": "#/definitions/json-schema-draft-07-schema"
                     }
                 },
                 "positiveInteger": {
@@ -506,7 +506,7 @@
                 "positiveIntegerDefault0": {
                     "allOf": [
                         {
-                            "$ref": "#/definitions/positiveInteger"
+                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/positiveInteger"
                         },
                         {
                             "default": 0
@@ -568,10 +568,10 @@
                     "default": false
                 },
                 "maxLength": {
-                    "$ref": "#/definitions/positiveInteger"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/positiveInteger"
                 },
                 "minLength": {
-                    "$ref": "#/definitions/positiveIntegerDefault0"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/positiveIntegerDefault0"
                 },
                 "pattern": {
                     "type": "string",
@@ -583,7 +583,7 @@
                             "type": "boolean"
                         },
                         {
-                            "$ref": "#"
+                            "$ref": "#/definitions/json-schema-draft-07-schema"
                         }
                     ],
                     "default": {}
@@ -591,32 +591,32 @@
                 "items": {
                     "anyOf": [
                         {
-                            "$ref": "#"
+                            "$ref": "#/definitions/json-schema-draft-07-schema"
                         },
                         {
-                            "$ref": "#/definitions/schemaArray"
+                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/schemaArray"
                         }
                     ],
                     "default": {}
                 },
                 "maxItems": {
-                    "$ref": "#/definitions/positiveInteger"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/positiveInteger"
                 },
                 "minItems": {
-                    "$ref": "#/definitions/positiveIntegerDefault0"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/positiveIntegerDefault0"
                 },
                 "uniqueItems": {
                     "type": "boolean",
                     "default": false
                 },
                 "maxProperties": {
-                    "$ref": "#/definitions/positiveInteger"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/positiveInteger"
                 },
                 "minProperties": {
-                    "$ref": "#/definitions/positiveIntegerDefault0"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/positiveIntegerDefault0"
                 },
                 "required": {
-                    "$ref": "#/definitions/stringArray"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/stringArray"
                 },
                 "additionalProperties": {
                     "anyOf": [
@@ -624,7 +624,7 @@
                             "type": "boolean"
                         },
                         {
-                            "$ref": "#"
+                            "$ref": "#/definitions/json-schema-draft-07-schema"
                         }
                     ],
                     "default": {}
@@ -632,21 +632,21 @@
                 "definitions": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "#"
+                        "$ref": "#/definitions/json-schema-draft-07-schema"
                     },
                     "default": {}
                 },
                 "properties": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "#"
+                        "$ref": "#/definitions/json-schema-draft-07-schema"
                     },
                     "default": {}
                 },
                 "patternProperties": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "#"
+                        "$ref": "#/definitions/json-schema-draft-07-schema"
                     },
                     "default": {}
                 },
@@ -655,10 +655,10 @@
                     "additionalProperties": {
                         "anyOf": [
                             {
-                                "$ref": "#"
+                                "$ref": "#/definitions/json-schema-draft-07-schema"
                             },
                             {
-                                "$ref": "#/definitions/stringArray"
+                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/stringArray"
                             }
                         ]
                     }
@@ -671,12 +671,12 @@
                 "type": {
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/simpleTypes"
+                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/simpleTypes"
                         },
                         {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/simpleTypes"
+                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/simpleTypes"
                             },
                             "minItems": 1,
                             "uniqueItems": true
@@ -687,16 +687,16 @@
                     "type": "string"
                 },
                 "allOf": {
-                    "$ref": "#/definitions/schemaArray"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/schemaArray"
                 },
                 "anyOf": {
-                    "$ref": "#/definitions/schemaArray"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/schemaArray"
                 },
                 "oneOf": {
-                    "$ref": "#/definitions/schemaArray"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/schemaArray"
                 },
                 "not": {
-                    "$ref": "#"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 }
             },
             "dependencies": {
@@ -709,7 +709,7 @@
             },
             "default": {}
         },
-        "http://asyncapi.com/definitions/1.2.0/xml.json": {
+        "xml": {
             "id": "http://asyncapi.com/definitions/1.2.0/xml.json",
             "type": "object",
             "additionalProperties": false,
@@ -733,7 +733,7 @@
                 }
             }
         },
-        "http://asyncapi.com/definitions/1.2.0/externalDocs.json": {
+        "externalDocs": {
             "id": "http://asyncapi.com/definitions/1.2.0/externalDocs.json",
             "type": "object",
             "additionalProperties": false,
@@ -752,15 +752,15 @@
             },
             "patternProperties": {
                 "^x-": {
-                    "$ref": "http://asyncapi.com/definitions/1.2.0/vendorExtension.json"
+                    "$ref": "#/definitions/vendorExtension"
                 }
             }
         },
-        "http://asyncapi.com/definitions/1.2.0/operation.json": {
+        "operation": {
             "id": "http://asyncapi.com/definitions/1.2.0/operation.json",
             "oneOf": [
                 {
-                    "$ref": "http://asyncapi.com/definitions/1.2.0/message.json"
+                    "$ref": "#/definitions/message"
                 },
                 {
                     "type": "object",
@@ -770,7 +770,7 @@
                     "additionalProperties": false,
                     "patternProperties": {
                         "^x-": {
-                            "$ref": "http://asyncapi.com/definitions/1.2.0/vendorExtension.json"
+                            "$ref": "#/definitions/vendorExtension"
                         }
                     },
                     "properties": {
@@ -778,20 +778,20 @@
                             "type": "array",
                             "minItems": 2,
                             "items": {
-                                "$ref": "http://asyncapi.com/definitions/1.2.0/message.json"
+                                "$ref": "#/definitions/message"
                             }
                         }
                     }
                 }
             ]
         },
-        "http://asyncapi.com/definitions/1.2.0/message.json": {
+        "message": {
             "id": "http://asyncapi.com/definitions/1.2.0/message.json",
             "type": "object",
             "additionalProperties": false,
             "patternProperties": {
                 "^x-": {
-                    "$ref": "http://asyncapi.com/definitions/1.2.0/vendorExtension.json"
+                    "$ref": "#/definitions/vendorExtension"
                 }
             },
             "properties": {
@@ -799,15 +799,15 @@
                     "type": "string"
                 },
                 "headers": {
-                    "$ref": "http://asyncapi.com/definitions/1.2.0/schema.json"
+                    "$ref": "#/definitions/schema"
                 },
                 "payload": {
-                    "$ref": "http://asyncapi.com/definitions/1.2.0/schema.json"
+                    "$ref": "#/definitions/schema"
                 },
                 "tags": {
                     "type": "array",
                     "items": {
-                        "$ref": "http://asyncapi.com/definitions/1.2.0/tag.json"
+                        "$ref": "#/definitions/tag"
                     },
                     "uniqueItems": true
                 },
@@ -820,7 +820,7 @@
                     "description": "A longer description of the message. CommonMark is allowed."
                 },
                 "externalDocs": {
-                    "$ref": "http://asyncapi.com/definitions/1.2.0/externalDocs.json"
+                    "$ref": "#/definitions/externalDocs"
                 },
                 "deprecated": {
                     "type": "boolean",
@@ -829,7 +829,7 @@
                 "example": {}
             }
         },
-        "http://asyncapi.com/definitions/1.2.0/tag.json": {
+        "tag": {
             "id": "http://asyncapi.com/definitions/1.2.0/tag.json",
             "type": "object",
             "additionalProperties": false,
@@ -844,23 +844,23 @@
                     "type": "string"
                 },
                 "externalDocs": {
-                    "$ref": "http://asyncapi.com/definitions/1.2.0/externalDocs.json"
+                    "$ref": "#/definitions/externalDocs"
                 }
             },
             "patternProperties": {
                 "^x-": {
-                    "$ref": "http://asyncapi.com/definitions/1.2.0/vendorExtension.json"
+                    "$ref": "#/definitions/vendorExtension"
                 }
             }
         },
-        "http://asyncapi.com/definitions/1.2.0/stream.json": {
+        "stream": {
             "id": "http://asyncapi.com/definitions/1.2.0/stream.json",
             "title": "Stream Object",
             "type": "object",
             "additionalProperties": false,
             "patternProperties": {
                 "^x-": {
-                    "$ref": "http://asyncapi.com/definitions/1.2.0/vendorExtension.json"
+                    "$ref": "#/definitions/vendorExtension"
                 }
             },
             "minProperties": 1,
@@ -870,7 +870,7 @@
                     "type": "object",
                     "patternProperties": {
                         "^x-": {
-                            "$ref": "http://asyncapi.com/definitions/1.2.0/vendorExtension.json"
+                            "$ref": "#/definitions/vendorExtension"
                         }
                     },
                     "minProperties": 1,
@@ -920,7 +920,7 @@
                     "uniqueItems": true,
                     "minItems": 1,
                     "items": {
-                        "$ref": "http://asyncapi.com/definitions/1.2.0/message.json"
+                        "$ref": "#/definitions/message"
                     }
                 },
                 "write": {
@@ -929,19 +929,19 @@
                     "uniqueItems": true,
                     "minItems": 1,
                     "items": {
-                        "$ref": "http://asyncapi.com/definitions/1.2.0/message.json"
+                        "$ref": "#/definitions/message"
                     }
                 }
             }
         },
-        "http://asyncapi.com/definitions/1.2.0/events.json": {
+        "events": {
             "id": "http://asyncapi.com/definitions/1.2.0/events.json",
             "title": "Events Object",
             "type": "object",
             "additionalProperties": false,
             "patternProperties": {
                 "^x-": {
-                    "$ref": "http://asyncapi.com/definitions/1.2.0/vendorExtension.json"
+                    "$ref": "#/definitions/vendorExtension"
                 }
             },
             "minProperties": 1,
@@ -964,7 +964,7 @@
                     "uniqueItems": true,
                     "minItems": 1,
                     "items": {
-                        "$ref": "http://asyncapi.com/definitions/1.2.0/message.json"
+                        "$ref": "#/definitions/message"
                     }
                 },
                 "send": {
@@ -973,22 +973,22 @@
                     "uniqueItems": true,
                     "minItems": 1,
                     "items": {
-                        "$ref": "http://asyncapi.com/definitions/1.2.0/message.json"
+                        "$ref": "#/definitions/message"
                     }
                 }
             }
         },
-        "http://asyncapi.com/definitions/1.2.0/components.json": {
+        "components": {
             "id": "http://asyncapi.com/definitions/1.2.0/components.json",
             "type": "object",
             "description": "An object to hold a set of reusable objects for different aspects of the AsyncAPI Specification.",
             "additionalProperties": false,
             "properties": {
                 "schemas": {
-                    "$ref": "http://asyncapi.com/definitions/1.2.0/schemas.json"
+                    "$ref": "#/definitions/schemas"
                 },
                 "messages": {
-                    "$ref": "http://asyncapi.com/definitions/1.2.0/messages.json"
+                    "$ref": "#/definitions/messages"
                 },
                 "securitySchemes": {
                     "type": "object",
@@ -996,37 +996,37 @@
                         "^[a-zA-Z0-9\\.\\-_]+$": {
                             "oneOf": [
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/1.2.0/Reference.json"
+                                    "$ref": "#/definitions/Reference"
                                 },
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/1.2.0/SecurityScheme.json"
+                                    "$ref": "#/definitions/SecurityScheme"
                                 }
                             ]
                         }
                     }
                 },
                 "parameters": {
-                    "$ref": "http://asyncapi.com/definitions/1.2.0/parameters.json"
+                    "$ref": "#/definitions/parameters"
                 }
             }
         },
-        "http://asyncapi.com/definitions/1.2.0/schemas.json": {
+        "schemas": {
             "id": "http://asyncapi.com/definitions/1.2.0/schemas.json",
             "type": "object",
             "additionalProperties": {
-                "$ref": "http://asyncapi.com/definitions/1.2.0/schema.json"
+                "$ref": "#/definitions/schema"
             },
             "description": "JSON objects describing schemas the API uses."
         },
-        "http://asyncapi.com/definitions/1.2.0/messages.json": {
+        "messages": {
             "id": "http://asyncapi.com/definitions/1.2.0/messages.json",
             "type": "object",
             "additionalProperties": {
-                "$ref": "http://asyncapi.com/definitions/1.2.0/message.json"
+                "$ref": "#/definitions/message"
             },
             "description": "JSON objects describing the messages being consumed and produced by the API."
         },
-        "http://asyncapi.com/definitions/1.2.0/Reference.json": {
+        "Reference": {
             "id": "http://asyncapi.com/definitions/1.2.0/Reference.json",
             "type": "object",
             "required": [
@@ -1039,30 +1039,30 @@
                 }
             }
         },
-        "http://asyncapi.com/definitions/1.2.0/SecurityScheme.json": {
+        "SecurityScheme": {
             "id": "http://asyncapi.com/definitions/1.2.0/SecurityScheme.json",
             "oneOf": [
                 {
-                    "$ref": "http://asyncapi.com/definitions/1.2.0/userPassword.json"
+                    "$ref": "#/definitions/userPassword"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/1.2.0/apiKey.json"
+                    "$ref": "#/definitions/apiKey"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/1.2.0/X509.json"
+                    "$ref": "#/definitions/X509"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/1.2.0/symmetricEncryption.json"
+                    "$ref": "#/definitions/symmetricEncryption"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/1.2.0/asymmetricEncryption.json"
+                    "$ref": "#/definitions/asymmetricEncryption"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/1.2.0/HTTPSecurityScheme.json"
+                    "$ref": "#/definitions/HTTPSecurityScheme"
                 }
             ]
         },
-        "http://asyncapi.com/definitions/1.2.0/userPassword.json": {
+        "userPassword": {
             "id": "http://asyncapi.com/definitions/1.2.0/userPassword.json",
             "type": "object",
             "required": [
@@ -1084,7 +1084,7 @@
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/1.2.0/apiKey.json": {
+        "apiKey": {
             "id": "http://asyncapi.com/definitions/1.2.0/apiKey.json",
             "type": "object",
             "required": [
@@ -1114,7 +1114,7 @@
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/1.2.0/X509.json": {
+        "X509": {
             "id": "http://asyncapi.com/definitions/1.2.0/X509.json",
             "type": "object",
             "required": [
@@ -1136,7 +1136,7 @@
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/1.2.0/symmetricEncryption.json": {
+        "symmetricEncryption": {
             "id": "http://asyncapi.com/definitions/1.2.0/symmetricEncryption.json",
             "type": "object",
             "required": [
@@ -1158,7 +1158,7 @@
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/1.2.0/asymmetricEncryption.json": {
+        "asymmetricEncryption": {
             "id": "http://asyncapi.com/definitions/1.2.0/asymmetricEncryption.json",
             "type": "object",
             "required": [
@@ -1180,21 +1180,21 @@
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/1.2.0/HTTPSecurityScheme.json": {
+        "HTTPSecurityScheme": {
             "id": "http://asyncapi.com/definitions/1.2.0/HTTPSecurityScheme.json",
             "oneOf": [
                 {
-                    "$ref": "http://asyncapi.com/definitions/1.2.0/NonBearerHTTPSecurityScheme.json"
+                    "$ref": "#/definitions/NonBearerHTTPSecurityScheme"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/1.2.0/BearerHTTPSecurityScheme.json"
+                    "$ref": "#/definitions/BearerHTTPSecurityScheme"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/1.2.0/APIKeyHTTPSecurityScheme.json"
+                    "$ref": "#/definitions/APIKeyHTTPSecurityScheme"
                 }
             ]
         },
-        "http://asyncapi.com/definitions/1.2.0/NonBearerHTTPSecurityScheme.json": {
+        "NonBearerHTTPSecurityScheme": {
             "id": "http://asyncapi.com/definitions/1.2.0/NonBearerHTTPSecurityScheme.json",
             "not": {
                 "type": "object",
@@ -1231,7 +1231,7 @@
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/1.2.0/BearerHTTPSecurityScheme.json": {
+        "BearerHTTPSecurityScheme": {
             "id": "http://asyncapi.com/definitions/1.2.0/BearerHTTPSecurityScheme.json",
             "type": "object",
             "required": [
@@ -1263,7 +1263,7 @@
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/1.2.0/APIKeyHTTPSecurityScheme.json": {
+        "APIKeyHTTPSecurityScheme": {
             "id": "http://asyncapi.com/definitions/1.2.0/APIKeyHTTPSecurityScheme.json",
             "type": "object",
             "required": [
@@ -1298,15 +1298,15 @@
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/1.2.0/parameters.json": {
+        "parameters": {
             "id": "http://asyncapi.com/definitions/1.2.0/parameters.json",
             "type": "object",
             "additionalProperties": {
-                "$ref": "http://asyncapi.com/definitions/1.2.0/parameter.json"
+                "$ref": "#/definitions/parameter"
             },
             "description": "JSON objects describing re-usable topic parameters."
         },
-        "http://asyncapi.com/definitions/1.2.0/SecurityRequirement.json": {
+        "SecurityRequirement": {
             "id": "http://asyncapi.com/definitions/1.2.0/SecurityRequirement.json",
             "type": "object",
             "additionalProperties": {

--- a/schemas/2.0.0-rc1.json
+++ b/schemas/2.0.0-rc1.json
@@ -12,7 +12,7 @@
     "additionalProperties": false,
     "patternProperties": {
         "^x-[\\w\\d\\.\\x2d_]+$": {
-            "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/specificationExtension.json"
+            "$ref": "#/definitions/specificationExtension"
         }
     },
     "properties": {
@@ -29,12 +29,12 @@
             "format": "uri-reference"
         },
         "info": {
-            "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/info.json"
+            "$ref": "#/definitions/info"
         },
         "servers": {
             "type": "array",
             "items": {
-                "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/server.json"
+                "$ref": "#/definitions/server"
             },
             "uniqueItems": true
         },
@@ -42,30 +42,30 @@
             "type": "string"
         },
         "channels": {
-            "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/channels.json"
+            "$ref": "#/definitions/channels"
         },
         "components": {
-            "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/components.json"
+            "$ref": "#/definitions/components"
         },
         "tags": {
             "type": "array",
             "items": {
-                "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/tag.json"
+                "$ref": "#/definitions/tag"
             },
             "uniqueItems": true
         },
         "externalDocs": {
-            "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/externalDocs.json"
+            "$ref": "#/definitions/externalDocs"
         }
     },
     "definitions": {
-        "http://asyncapi.com/definitions/2.0.0-rc1/specificationExtension.json": {
+        "specificationExtension": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc1/specificationExtension.json",
             "description": "Any property starting with x- is valid.",
             "additionalProperties": true,
             "additionalItems": true
         },
-        "http://asyncapi.com/definitions/2.0.0-rc1/info.json": {
+        "info": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc1/info.json",
             "type": "object",
             "description": "General information about the API.",
@@ -76,7 +76,7 @@
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
@@ -98,14 +98,14 @@
                     "format": "uri"
                 },
                 "contact": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/contact.json"
+                    "$ref": "#/definitions/contact"
                 },
                 "license": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/license.json"
+                    "$ref": "#/definitions/license"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.0.0-rc1/contact.json": {
+        "contact": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc1/contact.json",
             "type": "object",
             "description": "Contact information for the owners of the API.",
@@ -128,11 +128,11 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.0.0-rc1/license.json": {
+        "license": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc1/license.json",
             "type": "object",
             "required": [
@@ -152,11 +152,11 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.0.0-rc1/server.json": {
+        "server": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc1/server.json",
             "type": "object",
             "description": "An object representing a Server.",
@@ -167,7 +167,7 @@
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
@@ -185,7 +185,7 @@
                     "type": "string"
                 },
                 "variables": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/serverVariables.json"
+                    "$ref": "#/definitions/serverVariables"
                 },
                 "baseChannel": {
                     "type": "string",
@@ -194,19 +194,19 @@
                 "security": {
                     "type": "array",
                     "items": {
-                        "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/SecurityRequirement.json"
+                        "$ref": "#/definitions/SecurityRequirement"
                     }
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.0.0-rc1/serverVariables.json": {
+        "serverVariables": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc1/serverVariables.json",
             "type": "object",
             "additionalProperties": {
-                "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/serverVariable.json"
+                "$ref": "#/definitions/serverVariable"
             }
         },
-        "http://asyncapi.com/definitions/2.0.0-rc1/serverVariable.json": {
+        "serverVariable": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc1/serverVariable.json",
             "type": "object",
             "description": "An object representing a Server Variable for server URL template substitution.",
@@ -214,7 +214,7 @@
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
@@ -239,7 +239,7 @@
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.0.0-rc1/SecurityRequirement.json": {
+        "SecurityRequirement": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc1/SecurityRequirement.json",
             "type": "object",
             "additionalProperties": {
@@ -250,7 +250,7 @@
                 "uniqueItems": true
             }
         },
-        "http://asyncapi.com/definitions/2.0.0-rc1/channels.json": {
+        "channels": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc1/channels.json",
             "type": "object",
             "propertyNames": {
@@ -259,36 +259,36 @@
                 "minLength": 1
             },
             "additionalProperties": {
-                "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/channelItem.json"
+                "$ref": "#/definitions/channelItem"
             }
         },
-        "http://asyncapi.com/definitions/2.0.0-rc1/channelItem.json": {
+        "channelItem": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc1/channelItem.json",
             "type": "object",
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "minProperties": 1,
             "properties": {
                 "$ref": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/ReferenceObject.json"
+                    "$ref": "#/definitions/ReferenceObject"
                 },
                 "parameters": {
                     "type": "array",
                     "uniqueItems": true,
                     "minItems": 1,
                     "items": {
-                        "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/parameter.json"
+                        "$ref": "#/definitions/parameter"
                     }
                 },
                 "publish": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/operation.json"
+                    "$ref": "#/definitions/operation"
                 },
                 "subscribe": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/operation.json"
+                    "$ref": "#/definitions/operation"
                 },
                 "deprecated": {
                     "type": "boolean",
@@ -302,17 +302,17 @@
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.0.0-rc1/ReferenceObject.json": {
+        "ReferenceObject": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc1/ReferenceObject.json",
             "type": "string",
             "format": "uri"
         },
-        "http://asyncapi.com/definitions/2.0.0-rc1/parameter.json": {
+        "parameter": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc1/parameter.json",
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
@@ -325,82 +325,82 @@
                     "description": "The name of the parameter."
                 },
                 "schema": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/schema.json"
+                    "$ref": "#/definitions/schema"
                 },
                 "$ref": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/ReferenceObject.json"
+                    "$ref": "#/definitions/ReferenceObject"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.0.0-rc1/schema.json": {
+        "schema": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc1/schema.json",
             "type": "object",
             "description": "A deterministic version of a JSON Schema object.",
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
                 "$ref": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/ReferenceObject.json"
+                    "$ref": "#/definitions/ReferenceObject"
                 },
                 "format": {
                     "type": "string"
                 },
                 "title": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/properties/title"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "description": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/properties/description"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "default": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/properties/default"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "multipleOf": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/properties/multipleOf"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "maximum": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/properties/maximum"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "exclusiveMaximum": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/properties/exclusiveMaximum"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "minimum": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/properties/minimum"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "exclusiveMinimum": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/properties/exclusiveMinimum"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "maxLength": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "minLength": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "pattern": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/properties/pattern"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "maxItems": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "minItems": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "uniqueItems": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/properties/uniqueItems"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "maxProperties": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "minProperties": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "required": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/definitions/stringArray"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "enum": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/properties/enum"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "deprecated": {
                     "type": "boolean",
@@ -409,7 +409,7 @@
                 "additionalProperties": {
                     "anyOf": [
                         {
-                            "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/schema.json"
+                            "$ref": "#/definitions/schema"
                         },
                         {
                             "type": "boolean"
@@ -418,18 +418,18 @@
                     "default": {}
                 },
                 "type": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/properties/type"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "items": {
                     "anyOf": [
                         {
-                            "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/schema.json"
+                            "$ref": "#/definitions/schema"
                         },
                         {
                             "type": "array",
                             "minItems": 1,
                             "items": {
-                                "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/schema.json"
+                                "$ref": "#/definitions/schema"
                             }
                         }
                     ],
@@ -439,30 +439,30 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/schema.json"
+                        "$ref": "#/definitions/schema"
                     }
                 },
                 "oneOf": {
                     "type": "array",
                     "minItems": 2,
                     "items": {
-                        "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/schema.json"
+                        "$ref": "#/definitions/schema"
                     }
                 },
                 "anyOf": {
                     "type": "array",
                     "minItems": 2,
                     "items": {
-                        "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/schema.json"
+                        "$ref": "#/definitions/schema"
                     }
                 },
                 "not": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/schema.json"
+                    "$ref": "#/definitions/schema"
                 },
                 "properties": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/schema.json"
+                        "$ref": "#/definitions/schema"
                     },
                     "default": {}
                 },
@@ -474,10 +474,10 @@
                     "default": false
                 },
                 "xml": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/xml.json"
+                    "$ref": "#/definitions/xml"
                 },
                 "externalDocs": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/externalDocs.json"
+                    "$ref": "#/definitions/externalDocs"
                 },
                 "example": {},
                 "examples": {
@@ -487,7 +487,7 @@
             },
             "additionalProperties": false
         },
-        "http://json-schema.org/draft-04/schema": {
+        "json-schema-draft-07-schema": {
             "id": "http://json-schema.org/draft-04/schema",
             "$schema": "http://json-schema.org/draft-04/schema",
             "description": "Core schema meta-schema",
@@ -496,7 +496,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#"
+                        "$ref": "#/definitions/json-schema-draft-07-schema"
                     }
                 },
                 "positiveInteger": {
@@ -506,7 +506,7 @@
                 "positiveIntegerDefault0": {
                     "allOf": [
                         {
-                            "$ref": "#/definitions/positiveInteger"
+                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/positiveInteger"
                         },
                         {
                             "default": 0
@@ -568,10 +568,10 @@
                     "default": false
                 },
                 "maxLength": {
-                    "$ref": "#/definitions/positiveInteger"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/positiveInteger"
                 },
                 "minLength": {
-                    "$ref": "#/definitions/positiveIntegerDefault0"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/positiveIntegerDefault0"
                 },
                 "pattern": {
                     "type": "string",
@@ -583,7 +583,7 @@
                             "type": "boolean"
                         },
                         {
-                            "$ref": "#"
+                            "$ref": "#/definitions/json-schema-draft-07-schema"
                         }
                     ],
                     "default": {}
@@ -591,32 +591,32 @@
                 "items": {
                     "anyOf": [
                         {
-                            "$ref": "#"
+                            "$ref": "#/definitions/json-schema-draft-07-schema"
                         },
                         {
-                            "$ref": "#/definitions/schemaArray"
+                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/schemaArray"
                         }
                     ],
                     "default": {}
                 },
                 "maxItems": {
-                    "$ref": "#/definitions/positiveInteger"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/positiveInteger"
                 },
                 "minItems": {
-                    "$ref": "#/definitions/positiveIntegerDefault0"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/positiveIntegerDefault0"
                 },
                 "uniqueItems": {
                     "type": "boolean",
                     "default": false
                 },
                 "maxProperties": {
-                    "$ref": "#/definitions/positiveInteger"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/positiveInteger"
                 },
                 "minProperties": {
-                    "$ref": "#/definitions/positiveIntegerDefault0"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/positiveIntegerDefault0"
                 },
                 "required": {
-                    "$ref": "#/definitions/stringArray"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/stringArray"
                 },
                 "additionalProperties": {
                     "anyOf": [
@@ -624,7 +624,7 @@
                             "type": "boolean"
                         },
                         {
-                            "$ref": "#"
+                            "$ref": "#/definitions/json-schema-draft-07-schema"
                         }
                     ],
                     "default": {}
@@ -632,21 +632,21 @@
                 "definitions": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "#"
+                        "$ref": "#/definitions/json-schema-draft-07-schema"
                     },
                     "default": {}
                 },
                 "properties": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "#"
+                        "$ref": "#/definitions/json-schema-draft-07-schema"
                     },
                     "default": {}
                 },
                 "patternProperties": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "#"
+                        "$ref": "#/definitions/json-schema-draft-07-schema"
                     },
                     "default": {}
                 },
@@ -655,10 +655,10 @@
                     "additionalProperties": {
                         "anyOf": [
                             {
-                                "$ref": "#"
+                                "$ref": "#/definitions/json-schema-draft-07-schema"
                             },
                             {
-                                "$ref": "#/definitions/stringArray"
+                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/stringArray"
                             }
                         ]
                     }
@@ -671,12 +671,12 @@
                 "type": {
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/simpleTypes"
+                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/simpleTypes"
                         },
                         {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/simpleTypes"
+                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/simpleTypes"
                             },
                             "minItems": 1,
                             "uniqueItems": true
@@ -687,16 +687,16 @@
                     "type": "string"
                 },
                 "allOf": {
-                    "$ref": "#/definitions/schemaArray"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/schemaArray"
                 },
                 "anyOf": {
-                    "$ref": "#/definitions/schemaArray"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/schemaArray"
                 },
                 "oneOf": {
-                    "$ref": "#/definitions/schemaArray"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/schemaArray"
                 },
                 "not": {
-                    "$ref": "#"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 }
             },
             "dependencies": {
@@ -709,7 +709,7 @@
             },
             "default": {}
         },
-        "http://asyncapi.com/definitions/2.0.0-rc1/xml.json": {
+        "xml": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc1/xml.json",
             "type": "object",
             "additionalProperties": false,
@@ -733,7 +733,7 @@
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.0.0-rc1/externalDocs.json": {
+        "externalDocs": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc1/externalDocs.json",
             "type": "object",
             "additionalProperties": false,
@@ -752,17 +752,17 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.0.0-rc1/operation.json": {
+        "operation": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc1/operation.json",
             "type": "object",
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
@@ -771,10 +771,10 @@
                     "items": {
                         "oneOf": [
                             {
-                                "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/Reference.json"
+                                "$ref": "#/definitions/Reference"
                             },
                             {
-                                "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/operationTrait.json"
+                                "$ref": "#/definitions/operationTrait"
                             },
                             {
                                 "type": "array",
@@ -782,10 +782,10 @@
                                     {
                                         "oneOf": [
                                             {
-                                                "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/Reference.json"
+                                                "$ref": "#/definitions/Reference"
                                             },
                                             {
-                                                "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/operationTrait.json"
+                                                "$ref": "#/definitions/operationTrait"
                                             }
                                         ]
                                     },
@@ -807,12 +807,12 @@
                 "tags": {
                     "type": "array",
                     "items": {
-                        "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/tag.json"
+                        "$ref": "#/definitions/tag"
                     },
                     "uniqueItems": true
                 },
                 "externalDocs": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/externalDocs.json"
+                    "$ref": "#/definitions/externalDocs"
                 },
                 "operationId": {
                     "type": "string"
@@ -826,7 +826,7 @@
                 "message": {
                     "oneOf": [
                         {
-                            "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/message.json"
+                            "$ref": "#/definitions/message"
                         },
                         {
                             "type": "object",
@@ -836,7 +836,7 @@
                             "additionalProperties": false,
                             "patternProperties": {
                                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/specificationExtension.json"
+                                    "$ref": "#/definitions/specificationExtension"
                                 }
                             },
                             "properties": {
@@ -844,7 +844,7 @@
                                     "type": "array",
                                     "minItems": 2,
                                     "items": {
-                                        "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/message.json"
+                                        "$ref": "#/definitions/message"
                                     }
                                 }
                             }
@@ -853,7 +853,7 @@
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.0.0-rc1/Reference.json": {
+        "Reference": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc1/Reference.json",
             "type": "object",
             "required": [
@@ -861,17 +861,17 @@
             ],
             "properties": {
                 "$ref": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/ReferenceObject.json"
+                    "$ref": "#/definitions/ReferenceObject"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.0.0-rc1/operationTrait.json": {
+        "operationTrait": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc1/operationTrait.json",
             "type": "object",
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
@@ -884,12 +884,12 @@
                 "tags": {
                     "type": "array",
                     "items": {
-                        "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/tag.json"
+                        "$ref": "#/definitions/tag"
                     },
                     "uniqueItems": true
                 },
                 "externalDocs": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/externalDocs.json"
+                    "$ref": "#/definitions/externalDocs"
                 },
                 "operationId": {
                     "type": "string"
@@ -902,7 +902,7 @@
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.0.0-rc1/tag.json": {
+        "tag": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc1/tag.json",
             "type": "object",
             "additionalProperties": false,
@@ -917,22 +917,22 @@
                     "type": "string"
                 },
                 "externalDocs": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/externalDocs.json"
+                    "$ref": "#/definitions/externalDocs"
                 }
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.0.0-rc1/message.json": {
+        "message": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc1/message.json",
             "type": "object",
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
@@ -947,10 +947,10 @@
                     "additionalProperties": {
                         "oneOf": [
                             {
-                                "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/Reference.json"
+                                "$ref": "#/definitions/Reference"
                             },
                             {
-                                "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/schema.json"
+                                "$ref": "#/definitions/schema"
                             }
                         ]
                     }
@@ -959,17 +959,17 @@
                 "correlationId": {
                     "oneOf": [
                         {
-                            "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/Reference.json"
+                            "$ref": "#/definitions/Reference"
                         },
                         {
-                            "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/correlationId.json"
+                            "$ref": "#/definitions/correlationId"
                         }
                     ]
                 },
                 "tags": {
                     "type": "array",
                     "items": {
-                        "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/tag.json"
+                        "$ref": "#/definitions/tag"
                     },
                     "uniqueItems": true
                 },
@@ -990,7 +990,7 @@
                     "description": "A longer description of the message. CommonMark is allowed."
                 },
                 "externalDocs": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/externalDocs.json"
+                    "$ref": "#/definitions/externalDocs"
                 },
                 "deprecated": {
                     "type": "boolean",
@@ -1013,10 +1013,10 @@
                     "items": {
                         "oneOf": [
                             {
-                                "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/Reference.json"
+                                "$ref": "#/definitions/Reference"
                             },
                             {
-                                "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/messageTrait.json"
+                                "$ref": "#/definitions/messageTrait"
                             },
                             {
                                 "type": "array",
@@ -1024,10 +1024,10 @@
                                     {
                                         "oneOf": [
                                             {
-                                                "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/Reference.json"
+                                                "$ref": "#/definitions/Reference"
                                             },
                                             {
-                                                "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/messageTrait.json"
+                                                "$ref": "#/definitions/messageTrait"
                                             }
                                         ]
                                     },
@@ -1042,7 +1042,7 @@
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.0.0-rc1/correlationId.json": {
+        "correlationId": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc1/correlationId.json",
             "type": "object",
             "required": [
@@ -1051,7 +1051,7 @@
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
@@ -1066,13 +1066,13 @@
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.0.0-rc1/messageTrait.json": {
+        "messageTrait": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc1/messageTrait.json",
             "type": "object",
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
@@ -1087,10 +1087,10 @@
                     "additionalProperties": {
                         "oneOf": [
                             {
-                                "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/Reference.json"
+                                "$ref": "#/definitions/Reference"
                             },
                             {
-                                "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/schema.json"
+                                "$ref": "#/definitions/schema"
                             }
                         ]
                     }
@@ -1098,17 +1098,17 @@
                 "correlationId": {
                     "oneOf": [
                         {
-                            "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/Reference.json"
+                            "$ref": "#/definitions/Reference"
                         },
                         {
-                            "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/correlationId.json"
+                            "$ref": "#/definitions/correlationId"
                         }
                     ]
                 },
                 "tags": {
                     "type": "array",
                     "items": {
-                        "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/tag.json"
+                        "$ref": "#/definitions/tag"
                     },
                     "uniqueItems": true
                 },
@@ -1129,7 +1129,7 @@
                     "description": "A longer description of the message. CommonMark is allowed."
                 },
                 "externalDocs": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/externalDocs.json"
+                    "$ref": "#/definitions/externalDocs"
                 },
                 "deprecated": {
                     "type": "boolean",
@@ -1149,17 +1149,17 @@
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.0.0-rc1/components.json": {
+        "components": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc1/components.json",
             "type": "object",
             "description": "An object to hold a set of reusable objects for different aspects of the AsyncAPI Specification.",
             "additionalProperties": false,
             "properties": {
                 "schemas": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/schemas.json"
+                    "$ref": "#/definitions/schemas"
                 },
                 "messages": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/messages.json"
+                    "$ref": "#/definitions/messages"
                 },
                 "securitySchemes": {
                     "type": "object",
@@ -1167,17 +1167,17 @@
                         "^[\\w\\d\\.\\-_]+$": {
                             "oneOf": [
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/Reference.json"
+                                    "$ref": "#/definitions/Reference"
                                 },
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/SecurityScheme.json"
+                                    "$ref": "#/definitions/SecurityScheme"
                                 }
                             ]
                         }
                     }
                 },
                 "parameters": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/parameters.json"
+                    "$ref": "#/definitions/parameters"
                 },
                 "correlationIds": {
                     "type": "object",
@@ -1185,66 +1185,66 @@
                         "^[\\w\\d\\.\\-_]+$": {
                             "oneOf": [
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/Reference.json"
+                                    "$ref": "#/definitions/Reference"
                                 },
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/correlationId.json"
+                                    "$ref": "#/definitions/correlationId"
                                 }
                             ]
                         }
                     }
                 },
                 "traits": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/traits.json"
+                    "$ref": "#/definitions/traits"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.0.0-rc1/schemas.json": {
+        "schemas": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc1/schemas.json",
             "type": "object",
             "additionalProperties": {
-                "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/schema.json"
+                "$ref": "#/definitions/schema"
             },
             "description": "JSON objects describing schemas the API uses."
         },
-        "http://asyncapi.com/definitions/2.0.0-rc1/messages.json": {
+        "messages": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc1/messages.json",
             "type": "object",
             "additionalProperties": {
-                "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/message.json"
+                "$ref": "#/definitions/message"
             },
             "description": "JSON objects describing the messages being consumed and produced by the API."
         },
-        "http://asyncapi.com/definitions/2.0.0-rc1/SecurityScheme.json": {
+        "SecurityScheme": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc1/SecurityScheme.json",
             "oneOf": [
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/userPassword.json"
+                    "$ref": "#/definitions/userPassword"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/apiKey.json"
+                    "$ref": "#/definitions/apiKey"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/X509.json"
+                    "$ref": "#/definitions/X509"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/symmetricEncryption.json"
+                    "$ref": "#/definitions/symmetricEncryption"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/asymmetricEncryption.json"
+                    "$ref": "#/definitions/asymmetricEncryption"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/HTTPSecurityScheme.json"
+                    "$ref": "#/definitions/HTTPSecurityScheme"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/oauth2Flows.json"
+                    "$ref": "#/definitions/oauth2Flows"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/openIdConnect.json"
+                    "$ref": "#/definitions/openIdConnect"
                 }
             ]
         },
-        "http://asyncapi.com/definitions/2.0.0-rc1/userPassword.json": {
+        "userPassword": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc1/userPassword.json",
             "type": "object",
             "required": [
@@ -1263,12 +1263,12 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.0.0-rc1/apiKey.json": {
+        "apiKey": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc1/apiKey.json",
             "type": "object",
             "required": [
@@ -1295,12 +1295,12 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.0.0-rc1/X509.json": {
+        "X509": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc1/X509.json",
             "type": "object",
             "required": [
@@ -1319,12 +1319,12 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.0.0-rc1/symmetricEncryption.json": {
+        "symmetricEncryption": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc1/symmetricEncryption.json",
             "type": "object",
             "required": [
@@ -1343,12 +1343,12 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.0.0-rc1/asymmetricEncryption.json": {
+        "asymmetricEncryption": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc1/asymmetricEncryption.json",
             "type": "object",
             "required": [
@@ -1367,26 +1367,26 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.0.0-rc1/HTTPSecurityScheme.json": {
+        "HTTPSecurityScheme": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc1/HTTPSecurityScheme.json",
             "oneOf": [
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/NonBearerHTTPSecurityScheme.json"
+                    "$ref": "#/definitions/NonBearerHTTPSecurityScheme"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/BearerHTTPSecurityScheme.json"
+                    "$ref": "#/definitions/BearerHTTPSecurityScheme"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/APIKeyHTTPSecurityScheme.json"
+                    "$ref": "#/definitions/APIKeyHTTPSecurityScheme"
                 }
             ]
         },
-        "http://asyncapi.com/definitions/2.0.0-rc1/NonBearerHTTPSecurityScheme.json": {
+        "NonBearerHTTPSecurityScheme": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc1/NonBearerHTTPSecurityScheme.json",
             "not": {
                 "type": "object",
@@ -1420,12 +1420,12 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.0.0-rc1/BearerHTTPSecurityScheme.json": {
+        "BearerHTTPSecurityScheme": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc1/BearerHTTPSecurityScheme.json",
             "type": "object",
             "required": [
@@ -1454,12 +1454,12 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.0.0-rc1/APIKeyHTTPSecurityScheme.json": {
+        "APIKeyHTTPSecurityScheme": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc1/APIKeyHTTPSecurityScheme.json",
             "type": "object",
             "required": [
@@ -1491,12 +1491,12 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.0.0-rc1/oauth2Flows.json": {
+        "oauth2Flows": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc1/oauth2Flows.json",
             "type": "object",
             "required": [
@@ -1519,7 +1519,7 @@
                         "implicit": {
                             "allOf": [
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/oauth2Flow.json"
+                                    "$ref": "#/definitions/oauth2Flow"
                                 },
                                 {
                                     "required": [
@@ -1539,7 +1539,7 @@
                         "password": {
                             "allOf": [
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/oauth2Flow.json"
+                                    "$ref": "#/definitions/oauth2Flow"
                                 },
                                 {
                                     "required": [
@@ -1559,7 +1559,7 @@
                         "clientCredentials": {
                             "allOf": [
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/oauth2Flow.json"
+                                    "$ref": "#/definitions/oauth2Flow"
                                 },
                                 {
                                     "required": [
@@ -1579,7 +1579,7 @@
                         "authorizationCode": {
                             "allOf": [
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/oauth2Flow.json"
+                                    "$ref": "#/definitions/oauth2Flow"
                                 },
                                 {
                                     "required": [
@@ -1597,11 +1597,11 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.0.0-rc1/oauth2Flow.json": {
+        "oauth2Flow": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc1/oauth2Flow.json",
             "type": "object",
             "properties": {
@@ -1618,24 +1618,24 @@
                     "format": "uri"
                 },
                 "scopes": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/oauth2Scopes.json"
+                    "$ref": "#/definitions/oauth2Scopes"
                 }
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.0.0-rc1/oauth2Scopes.json": {
+        "oauth2Scopes": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc1/oauth2Scopes.json",
             "type": "object",
             "additionalProperties": {
                 "type": "string"
             }
         },
-        "http://asyncapi.com/definitions/2.0.0-rc1/openIdConnect.json": {
+        "openIdConnect": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc1/openIdConnect.json",
             "type": "object",
             "required": [
@@ -1659,29 +1659,29 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.0.0-rc1/parameters.json": {
+        "parameters": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc1/parameters.json",
             "type": "object",
             "additionalProperties": {
-                "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/parameter.json"
+                "$ref": "#/definitions/parameter"
             },
             "description": "JSON objects describing re-usable channel parameters."
         },
-        "http://asyncapi.com/definitions/2.0.0-rc1/traits.json": {
+        "traits": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc1/traits.json",
             "type": "object",
             "additionalProperties": {
                 "anyOf": [
                     {
-                        "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/operationTrait.json"
+                        "$ref": "#/definitions/operationTrait"
                     },
                     {
-                        "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/messageTrait.json"
+                        "$ref": "#/definitions/messageTrait"
                     }
                 ]
             }

--- a/schemas/2.0.0-rc2.json
+++ b/schemas/2.0.0-rc2.json
@@ -11,7 +11,7 @@
     "additionalProperties": false,
     "patternProperties": {
         "^x-[\\w\\d\\.\\x2d_]+$": {
-            "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/specificationExtension.json"
+            "$ref": "#/definitions/specificationExtension"
         }
     },
     "properties": {
@@ -28,42 +28,42 @@
             "format": "uri"
         },
         "info": {
-            "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/info.json"
+            "$ref": "#/definitions/info"
         },
         "servers": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/server.json"
+                "$ref": "#/definitions/server"
             }
         },
         "defaultContentType": {
             "type": "string"
         },
         "channels": {
-            "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/channels.json"
+            "$ref": "#/definitions/channels"
         },
         "components": {
-            "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/components.json"
+            "$ref": "#/definitions/components"
         },
         "tags": {
             "type": "array",
             "items": {
-                "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/tag.json"
+                "$ref": "#/definitions/tag"
             },
             "uniqueItems": true
         },
         "externalDocs": {
-            "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/externalDocs.json"
+            "$ref": "#/definitions/externalDocs"
         }
     },
     "definitions": {
-        "http://asyncapi.com/definitions/2.0.0-rc2/specificationExtension.json": {
+        "specificationExtension": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc2/specificationExtension.json",
             "description": "Any property starting with x- is valid.",
             "additionalProperties": true,
             "additionalItems": true
         },
-        "http://asyncapi.com/definitions/2.0.0-rc2/info.json": {
+        "info": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc2/info.json",
             "type": "object",
             "description": "General information about the API.",
@@ -74,7 +74,7 @@
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
@@ -96,14 +96,14 @@
                     "format": "uri"
                 },
                 "contact": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/contact.json"
+                    "$ref": "#/definitions/contact"
                 },
                 "license": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/license.json"
+                    "$ref": "#/definitions/license"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.0.0-rc2/contact.json": {
+        "contact": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc2/contact.json",
             "type": "object",
             "description": "Contact information for the owners of the API.",
@@ -126,11 +126,11 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.0.0-rc2/license.json": {
+        "license": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc2/license.json",
             "type": "object",
             "required": [
@@ -150,11 +150,11 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.0.0-rc2/server.json": {
+        "server": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc2/server.json",
             "type": "object",
             "description": "An object representing a Server.",
@@ -165,7 +165,7 @@
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
@@ -183,27 +183,27 @@
                     "type": "string"
                 },
                 "variables": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/serverVariables.json"
+                    "$ref": "#/definitions/serverVariables"
                 },
                 "security": {
                     "type": "array",
                     "items": {
-                        "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/SecurityRequirement.json"
+                        "$ref": "#/definitions/SecurityRequirement"
                     }
                 },
                 "bindings": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/bindingsObject.json"
+                    "$ref": "#/definitions/bindingsObject"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.0.0-rc2/serverVariables.json": {
+        "serverVariables": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc2/serverVariables.json",
             "type": "object",
             "additionalProperties": {
-                "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/serverVariable.json"
+                "$ref": "#/definitions/serverVariable"
             }
         },
-        "http://asyncapi.com/definitions/2.0.0-rc2/serverVariable.json": {
+        "serverVariable": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc2/serverVariable.json",
             "type": "object",
             "description": "An object representing a Server Variable for server URL template substitution.",
@@ -211,7 +211,7 @@
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
@@ -236,7 +236,7 @@
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.0.0-rc2/SecurityRequirement.json": {
+        "SecurityRequirement": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc2/SecurityRequirement.json",
             "type": "object",
             "additionalProperties": {
@@ -247,7 +247,7 @@
                 "uniqueItems": true
             }
         },
-        "http://asyncapi.com/definitions/2.0.0-rc2/bindingsObject.json": {
+        "bindingsObject": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc2/bindingsObject.json",
             "type": "object",
             "additionalProperties": true,
@@ -267,7 +267,7 @@
                 "redis": {}
             }
         },
-        "http://asyncapi.com/definitions/2.0.0-rc2/channels.json": {
+        "channels": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc2/channels.json",
             "type": "object",
             "propertyNames": {
@@ -276,27 +276,27 @@
                 "minLength": 1
             },
             "additionalProperties": {
-                "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/channelItem.json"
+                "$ref": "#/definitions/channelItem"
             }
         },
-        "http://asyncapi.com/definitions/2.0.0-rc2/channelItem.json": {
+        "channelItem": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc2/channelItem.json",
             "type": "object",
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "minProperties": 1,
             "properties": {
                 "$ref": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/ReferenceObject.json"
+                    "$ref": "#/definitions/ReferenceObject"
                 },
                 "parameters": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/parameter.json"
+                        "$ref": "#/definitions/parameter"
                     }
                 },
                 "description": {
@@ -304,31 +304,31 @@
                     "description": "A description of the channel."
                 },
                 "publish": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/operation.json"
+                    "$ref": "#/definitions/operation"
                 },
                 "subscribe": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/operation.json"
+                    "$ref": "#/definitions/operation"
                 },
                 "deprecated": {
                     "type": "boolean",
                     "default": false
                 },
                 "bindings": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/bindingsObject.json"
+                    "$ref": "#/definitions/bindingsObject"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.0.0-rc2/ReferenceObject.json": {
+        "ReferenceObject": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc2/ReferenceObject.json",
             "type": "string",
             "format": "uri-reference"
         },
-        "http://asyncapi.com/definitions/2.0.0-rc2/parameter.json": {
+        "parameter": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc2/parameter.json",
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
@@ -337,7 +337,7 @@
                     "description": "A brief description of the parameter. This could contain examples of use. GitHub Flavored Markdown is allowed."
                 },
                 "schema": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/schema.json"
+                    "$ref": "#/definitions/schema"
                 },
                 "location": {
                     "type": "string",
@@ -345,37 +345,37 @@
                     "pattern": "^\\$message\\.(header|payload)#(\\/(([^\\/~])|(~[01]))*)*"
                 },
                 "$ref": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/ReferenceObject.json"
+                    "$ref": "#/definitions/ReferenceObject"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.0.0-rc2/schema.json": {
+        "schema": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc2/schema.json",
             "allOf": [
                 {
-                    "$ref": "http://json-schema.org/draft-07/schema#"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 {
                     "type": "object",
                     "patternProperties": {
                         "^x-[\\w\\d\\.\\x2d_]+$": {
-                            "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/specificationExtension.json"
+                            "$ref": "#/definitions/specificationExtension"
                         }
                     },
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/schema.json"
+                            "$ref": "#/definitions/schema"
                         },
                         "items": {
                             "anyOf": [
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/schema.json"
+                                    "$ref": "#/definitions/schema"
                                 },
                                 {
                                     "type": "array",
                                     "minItems": 1,
                                     "items": {
-                                        "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/schema.json"
+                                        "$ref": "#/definitions/schema"
                                     }
                                 }
                             ],
@@ -385,51 +385,51 @@
                             "type": "array",
                             "minItems": 1,
                             "items": {
-                                "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/schema.json"
+                                "$ref": "#/definitions/schema"
                             }
                         },
                         "oneOf": {
                             "type": "array",
                             "minItems": 2,
                             "items": {
-                                "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/schema.json"
+                                "$ref": "#/definitions/schema"
                             }
                         },
                         "anyOf": {
                             "type": "array",
                             "minItems": 2,
                             "items": {
-                                "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/schema.json"
+                                "$ref": "#/definitions/schema"
                             }
                         },
                         "not": {
-                            "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/schema.json"
+                            "$ref": "#/definitions/schema"
                         },
                         "properties": {
                             "type": "object",
                             "additionalProperties": {
-                                "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/schema.json"
+                                "$ref": "#/definitions/schema"
                             },
                             "default": {}
                         },
                         "patternProperties": {
                             "type": "object",
                             "additionalProperties": {
-                                "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/schema.json"
+                                "$ref": "#/definitions/schema"
                             },
                             "default": {}
                         },
                         "propertyNames": {
-                            "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/schema.json"
+                            "$ref": "#/definitions/schema"
                         },
                         "contains": {
-                            "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/schema.json"
+                            "$ref": "#/definitions/schema"
                         },
                         "discriminator": {
                             "type": "string"
                         },
                         "externalDocs": {
-                            "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/externalDocs.json"
+                            "$ref": "#/definitions/externalDocs"
                         },
                         "deprecated": {
                             "type": "boolean",
@@ -439,7 +439,7 @@
                 }
             ]
         },
-        "http://json-schema.org/draft-07/schema": {
+        "json-schema-draft-07-schema": {
             "$id": "http://json-schema.org/draft-07/schema",
             "title": "Core schema meta-schema",
             "definitions": {
@@ -447,7 +447,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#"
+                        "$ref": "#/definitions/json-schema-draft-07-schema"
                     }
                 },
                 "nonNegativeInteger": {
@@ -457,7 +457,7 @@
                 "nonNegativeIntegerDefault0": {
                     "allOf": [
                         {
-                            "$ref": "#/definitions/nonNegativeInteger"
+                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/nonNegativeInteger"
                         },
                         {
                             "default": 0
@@ -540,72 +540,72 @@
                     "type": "number"
                 },
                 "maxLength": {
-                    "$ref": "#/definitions/nonNegativeInteger"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/nonNegativeInteger"
                 },
                 "minLength": {
-                    "$ref": "#/definitions/nonNegativeIntegerDefault0"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/nonNegativeIntegerDefault0"
                 },
                 "pattern": {
                     "type": "string",
                     "format": "regex"
                 },
                 "additionalItems": {
-                    "$ref": "#"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "items": {
                     "anyOf": [
                         {
-                            "$ref": "#"
+                            "$ref": "#/definitions/json-schema-draft-07-schema"
                         },
                         {
-                            "$ref": "#/definitions/schemaArray"
+                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/schemaArray"
                         }
                     ],
                     "default": true
                 },
                 "maxItems": {
-                    "$ref": "#/definitions/nonNegativeInteger"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/nonNegativeInteger"
                 },
                 "minItems": {
-                    "$ref": "#/definitions/nonNegativeIntegerDefault0"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/nonNegativeIntegerDefault0"
                 },
                 "uniqueItems": {
                     "type": "boolean",
                     "default": false
                 },
                 "contains": {
-                    "$ref": "#"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "maxProperties": {
-                    "$ref": "#/definitions/nonNegativeInteger"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/nonNegativeInteger"
                 },
                 "minProperties": {
-                    "$ref": "#/definitions/nonNegativeIntegerDefault0"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/nonNegativeIntegerDefault0"
                 },
                 "required": {
-                    "$ref": "#/definitions/stringArray"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/stringArray"
                 },
                 "additionalProperties": {
-                    "$ref": "#"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "definitions": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "#"
+                        "$ref": "#/definitions/json-schema-draft-07-schema"
                     },
                     "default": {}
                 },
                 "properties": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "#"
+                        "$ref": "#/definitions/json-schema-draft-07-schema"
                     },
                     "default": {}
                 },
                 "patternProperties": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "#"
+                        "$ref": "#/definitions/json-schema-draft-07-schema"
                     },
                     "propertyNames": {
                         "format": "regex"
@@ -617,16 +617,16 @@
                     "additionalProperties": {
                         "anyOf": [
                             {
-                                "$ref": "#"
+                                "$ref": "#/definitions/json-schema-draft-07-schema"
                             },
                             {
-                                "$ref": "#/definitions/stringArray"
+                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/stringArray"
                             }
                         ]
                     }
                 },
                 "propertyNames": {
-                    "$ref": "#"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "const": true,
                 "enum": {
@@ -638,12 +638,12 @@
                 "type": {
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/simpleTypes"
+                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/simpleTypes"
                         },
                         {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/simpleTypes"
+                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/simpleTypes"
                             },
                             "minItems": 1,
                             "uniqueItems": true
@@ -660,30 +660,30 @@
                     "type": "string"
                 },
                 "if": {
-                    "$ref": "#"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "then": {
-                    "$ref": "#"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "else": {
-                    "$ref": "#"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "allOf": {
-                    "$ref": "#/definitions/schemaArray"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/schemaArray"
                 },
                 "anyOf": {
-                    "$ref": "#/definitions/schemaArray"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/schemaArray"
                 },
                 "oneOf": {
-                    "$ref": "#/definitions/schemaArray"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/schemaArray"
                 },
                 "not": {
-                    "$ref": "#"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 }
             },
             "default": true
         },
-        "http://asyncapi.com/definitions/2.0.0-rc2/externalDocs.json": {
+        "externalDocs": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc2/externalDocs.json",
             "type": "object",
             "additionalProperties": false,
@@ -702,17 +702,17 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.0.0-rc2/operation.json": {
+        "operation": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc2/operation.json",
             "type": "object",
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
@@ -721,10 +721,10 @@
                     "items": {
                         "oneOf": [
                             {
-                                "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/Reference.json"
+                                "$ref": "#/definitions/Reference"
                             },
                             {
-                                "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/operationTrait.json"
+                                "$ref": "#/definitions/operationTrait"
                             },
                             {
                                 "type": "array",
@@ -732,10 +732,10 @@
                                     {
                                         "oneOf": [
                                             {
-                                                "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/Reference.json"
+                                                "$ref": "#/definitions/Reference"
                                             },
                                             {
-                                                "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/operationTrait.json"
+                                                "$ref": "#/definitions/operationTrait"
                                             }
                                         ]
                                     },
@@ -757,25 +757,25 @@
                 "tags": {
                     "type": "array",
                     "items": {
-                        "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/tag.json"
+                        "$ref": "#/definitions/tag"
                     },
                     "uniqueItems": true
                 },
                 "externalDocs": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/externalDocs.json"
+                    "$ref": "#/definitions/externalDocs"
                 },
                 "operationId": {
                     "type": "string"
                 },
                 "bindings": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/bindingsObject.json"
+                    "$ref": "#/definitions/bindingsObject"
                 },
                 "message": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/message.json"
+                    "$ref": "#/definitions/message"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.0.0-rc2/Reference.json": {
+        "Reference": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc2/Reference.json",
             "type": "object",
             "required": [
@@ -783,17 +783,17 @@
             ],
             "properties": {
                 "$ref": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/ReferenceObject.json"
+                    "$ref": "#/definitions/ReferenceObject"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.0.0-rc2/operationTrait.json": {
+        "operationTrait": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc2/operationTrait.json",
             "type": "object",
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
@@ -806,22 +806,22 @@
                 "tags": {
                     "type": "array",
                     "items": {
-                        "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/tag.json"
+                        "$ref": "#/definitions/tag"
                     },
                     "uniqueItems": true
                 },
                 "externalDocs": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/externalDocs.json"
+                    "$ref": "#/definitions/externalDocs"
                 },
                 "operationId": {
                     "type": "string"
                 },
                 "bindings": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/bindingsObject.json"
+                    "$ref": "#/definitions/bindingsObject"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.0.0-rc2/tag.json": {
+        "tag": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc2/tag.json",
             "type": "object",
             "additionalProperties": false,
@@ -836,20 +836,20 @@
                     "type": "string"
                 },
                 "externalDocs": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/externalDocs.json"
+                    "$ref": "#/definitions/externalDocs"
                 }
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.0.0-rc2/message.json": {
+        "message": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc2/message.json",
             "oneOf": [
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/Reference.json"
+                    "$ref": "#/definitions/Reference"
                 },
                 {
                     "oneOf": [
@@ -863,7 +863,7 @@
                                 "oneOf": {
                                     "type": "array",
                                     "items": {
-                                        "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/message.json"
+                                        "$ref": "#/definitions/message"
                                     }
                                 }
                             }
@@ -873,7 +873,7 @@
                             "additionalProperties": false,
                             "patternProperties": {
                                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/specificationExtension.json"
+                                    "$ref": "#/definitions/specificationExtension"
                                 }
                             },
                             "properties": {
@@ -884,23 +884,23 @@
                                     "type": "string"
                                 },
                                 "headers": {
-                                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/schema.json"
+                                    "$ref": "#/definitions/schema"
                                 },
                                 "payload": {},
                                 "correlationId": {
                                     "oneOf": [
                                         {
-                                            "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/Reference.json"
+                                            "$ref": "#/definitions/Reference"
                                         },
                                         {
-                                            "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/correlationId.json"
+                                            "$ref": "#/definitions/correlationId"
                                         }
                                     ]
                                 },
                                 "tags": {
                                     "type": "array",
                                     "items": {
-                                        "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/tag.json"
+                                        "$ref": "#/definitions/tag"
                                     },
                                     "uniqueItems": true
                                 },
@@ -921,7 +921,7 @@
                                     "description": "A longer description of the message. CommonMark is allowed."
                                 },
                                 "externalDocs": {
-                                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/externalDocs.json"
+                                    "$ref": "#/definitions/externalDocs"
                                 },
                                 "deprecated": {
                                     "type": "boolean",
@@ -934,17 +934,17 @@
                                     }
                                 },
                                 "bindings": {
-                                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/bindingsObject.json"
+                                    "$ref": "#/definitions/bindingsObject"
                                 },
                                 "traits": {
                                     "type": "array",
                                     "items": {
                                         "oneOf": [
                                             {
-                                                "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/Reference.json"
+                                                "$ref": "#/definitions/Reference"
                                             },
                                             {
-                                                "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/messageTrait.json"
+                                                "$ref": "#/definitions/messageTrait"
                                             },
                                             {
                                                 "type": "array",
@@ -952,10 +952,10 @@
                                                     {
                                                         "oneOf": [
                                                             {
-                                                                "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/Reference.json"
+                                                                "$ref": "#/definitions/Reference"
                                                             },
                                                             {
-                                                                "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/messageTrait.json"
+                                                                "$ref": "#/definitions/messageTrait"
                                                             }
                                                         ]
                                                     },
@@ -974,7 +974,7 @@
                 }
             ]
         },
-        "http://asyncapi.com/definitions/2.0.0-rc2/correlationId.json": {
+        "correlationId": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc2/correlationId.json",
             "type": "object",
             "required": [
@@ -983,7 +983,7 @@
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
@@ -998,13 +998,13 @@
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.0.0-rc2/messageTrait.json": {
+        "messageTrait": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc2/messageTrait.json",
             "type": "object",
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
@@ -1017,27 +1017,27 @@
                 "headers": {
                     "oneOf": [
                         {
-                            "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/Reference.json"
+                            "$ref": "#/definitions/Reference"
                         },
                         {
-                            "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/schema.json"
+                            "$ref": "#/definitions/schema"
                         }
                     ]
                 },
                 "correlationId": {
                     "oneOf": [
                         {
-                            "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/Reference.json"
+                            "$ref": "#/definitions/Reference"
                         },
                         {
-                            "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/correlationId.json"
+                            "$ref": "#/definitions/correlationId"
                         }
                     ]
                 },
                 "tags": {
                     "type": "array",
                     "items": {
-                        "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/tag.json"
+                        "$ref": "#/definitions/tag"
                     },
                     "uniqueItems": true
                 },
@@ -1058,7 +1058,7 @@
                     "description": "A longer description of the message. CommonMark is allowed."
                 },
                 "externalDocs": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/externalDocs.json"
+                    "$ref": "#/definitions/externalDocs"
                 },
                 "deprecated": {
                     "type": "boolean",
@@ -1071,21 +1071,21 @@
                     }
                 },
                 "bindings": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/bindingsObject.json"
+                    "$ref": "#/definitions/bindingsObject"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.0.0-rc2/components.json": {
+        "components": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc2/components.json",
             "type": "object",
             "description": "An object to hold a set of reusable objects for different aspects of the AsyncAPI Specification.",
             "additionalProperties": false,
             "properties": {
                 "schemas": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/schemas.json"
+                    "$ref": "#/definitions/schemas"
                 },
                 "messages": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/messages.json"
+                    "$ref": "#/definitions/messages"
                 },
                 "securitySchemes": {
                     "type": "object",
@@ -1093,17 +1093,17 @@
                         "^[\\w\\d\\.\\-_]+$": {
                             "oneOf": [
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/Reference.json"
+                                    "$ref": "#/definitions/Reference"
                                 },
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/SecurityScheme.json"
+                                    "$ref": "#/definitions/SecurityScheme"
                                 }
                             ]
                         }
                     }
                 },
                 "parameters": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/parameters.json"
+                    "$ref": "#/definitions/parameters"
                 },
                 "correlationIds": {
                     "type": "object",
@@ -1111,10 +1111,10 @@
                         "^[\\w\\d\\.\\-_]+$": {
                             "oneOf": [
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/Reference.json"
+                                    "$ref": "#/definitions/Reference"
                                 },
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/correlationId.json"
+                                    "$ref": "#/definitions/correlationId"
                                 }
                             ]
                         }
@@ -1123,87 +1123,87 @@
                 "operationTraits": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/operationTrait.json"
+                        "$ref": "#/definitions/operationTrait"
                     }
                 },
                 "messageTraits": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/messageTrait.json"
+                        "$ref": "#/definitions/messageTrait"
                     }
                 },
                 "serverBindings": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/bindingsObject.json"
+                        "$ref": "#/definitions/bindingsObject"
                     }
                 },
                 "channelBindings": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/bindingsObject.json"
+                        "$ref": "#/definitions/bindingsObject"
                     }
                 },
                 "operationBindings": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/bindingsObject.json"
+                        "$ref": "#/definitions/bindingsObject"
                     }
                 },
                 "messageBindings": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/bindingsObject.json"
+                        "$ref": "#/definitions/bindingsObject"
                     }
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.0.0-rc2/schemas.json": {
+        "schemas": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc2/schemas.json",
             "type": "object",
             "additionalProperties": {
-                "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/schema.json"
+                "$ref": "#/definitions/schema"
             },
             "description": "JSON objects describing schemas the API uses."
         },
-        "http://asyncapi.com/definitions/2.0.0-rc2/messages.json": {
+        "messages": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc2/messages.json",
             "type": "object",
             "additionalProperties": {
-                "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/message.json"
+                "$ref": "#/definitions/message"
             },
             "description": "JSON objects describing the messages being consumed and produced by the API."
         },
-        "http://asyncapi.com/definitions/2.0.0-rc2/SecurityScheme.json": {
+        "SecurityScheme": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc2/SecurityScheme.json",
             "oneOf": [
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/userPassword.json"
+                    "$ref": "#/definitions/userPassword"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/apiKey.json"
+                    "$ref": "#/definitions/apiKey"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/X509.json"
+                    "$ref": "#/definitions/X509"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/symmetricEncryption.json"
+                    "$ref": "#/definitions/symmetricEncryption"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/asymmetricEncryption.json"
+                    "$ref": "#/definitions/asymmetricEncryption"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/HTTPSecurityScheme.json"
+                    "$ref": "#/definitions/HTTPSecurityScheme"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/oauth2Flows.json"
+                    "$ref": "#/definitions/oauth2Flows"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/openIdConnect.json"
+                    "$ref": "#/definitions/openIdConnect"
                 }
             ]
         },
-        "http://asyncapi.com/definitions/2.0.0-rc2/userPassword.json": {
+        "userPassword": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc2/userPassword.json",
             "type": "object",
             "required": [
@@ -1222,12 +1222,12 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.0.0-rc2/apiKey.json": {
+        "apiKey": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc2/apiKey.json",
             "type": "object",
             "required": [
@@ -1254,12 +1254,12 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.0.0-rc2/X509.json": {
+        "X509": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc2/X509.json",
             "type": "object",
             "required": [
@@ -1278,12 +1278,12 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.0.0-rc2/symmetricEncryption.json": {
+        "symmetricEncryption": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc2/symmetricEncryption.json",
             "type": "object",
             "required": [
@@ -1302,12 +1302,12 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.0.0-rc2/asymmetricEncryption.json": {
+        "asymmetricEncryption": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc2/asymmetricEncryption.json",
             "type": "object",
             "required": [
@@ -1326,26 +1326,26 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.0.0-rc2/HTTPSecurityScheme.json": {
+        "HTTPSecurityScheme": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc2/HTTPSecurityScheme.json",
             "oneOf": [
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/NonBearerHTTPSecurityScheme.json"
+                    "$ref": "#/definitions/NonBearerHTTPSecurityScheme"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/BearerHTTPSecurityScheme.json"
+                    "$ref": "#/definitions/BearerHTTPSecurityScheme"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/APIKeyHTTPSecurityScheme.json"
+                    "$ref": "#/definitions/APIKeyHTTPSecurityScheme"
                 }
             ]
         },
-        "http://asyncapi.com/definitions/2.0.0-rc2/NonBearerHTTPSecurityScheme.json": {
+        "NonBearerHTTPSecurityScheme": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc2/NonBearerHTTPSecurityScheme.json",
             "not": {
                 "type": "object",
@@ -1379,12 +1379,12 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.0.0-rc2/BearerHTTPSecurityScheme.json": {
+        "BearerHTTPSecurityScheme": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc2/BearerHTTPSecurityScheme.json",
             "type": "object",
             "required": [
@@ -1413,12 +1413,12 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.0.0-rc2/APIKeyHTTPSecurityScheme.json": {
+        "APIKeyHTTPSecurityScheme": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc2/APIKeyHTTPSecurityScheme.json",
             "type": "object",
             "required": [
@@ -1450,12 +1450,12 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.0.0-rc2/oauth2Flows.json": {
+        "oauth2Flows": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc2/oauth2Flows.json",
             "type": "object",
             "required": [
@@ -1478,7 +1478,7 @@
                         "implicit": {
                             "allOf": [
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/oauth2Flow.json"
+                                    "$ref": "#/definitions/oauth2Flow"
                                 },
                                 {
                                     "required": [
@@ -1498,7 +1498,7 @@
                         "password": {
                             "allOf": [
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/oauth2Flow.json"
+                                    "$ref": "#/definitions/oauth2Flow"
                                 },
                                 {
                                     "required": [
@@ -1518,7 +1518,7 @@
                         "clientCredentials": {
                             "allOf": [
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/oauth2Flow.json"
+                                    "$ref": "#/definitions/oauth2Flow"
                                 },
                                 {
                                     "required": [
@@ -1538,7 +1538,7 @@
                         "authorizationCode": {
                             "allOf": [
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/oauth2Flow.json"
+                                    "$ref": "#/definitions/oauth2Flow"
                                 },
                                 {
                                     "required": [
@@ -1556,11 +1556,11 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.0.0-rc2/oauth2Flow.json": {
+        "oauth2Flow": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc2/oauth2Flow.json",
             "type": "object",
             "properties": {
@@ -1577,24 +1577,24 @@
                     "format": "uri"
                 },
                 "scopes": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/oauth2Scopes.json"
+                    "$ref": "#/definitions/oauth2Scopes"
                 }
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.0.0-rc2/oauth2Scopes.json": {
+        "oauth2Scopes": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc2/oauth2Scopes.json",
             "type": "object",
             "additionalProperties": {
                 "type": "string"
             }
         },
-        "http://asyncapi.com/definitions/2.0.0-rc2/openIdConnect.json": {
+        "openIdConnect": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc2/openIdConnect.json",
             "type": "object",
             "required": [
@@ -1618,16 +1618,16 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.0.0-rc2/parameters.json": {
+        "parameters": {
             "$id": "http://asyncapi.com/definitions/2.0.0-rc2/parameters.json",
             "type": "object",
             "additionalProperties": {
-                "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/parameter.json"
+                "$ref": "#/definitions/parameter"
             },
             "description": "JSON objects describing re-usable channel parameters."
         }

--- a/schemas/2.0.0.json
+++ b/schemas/2.0.0.json
@@ -11,7 +11,7 @@
     "additionalProperties": false,
     "patternProperties": {
         "^x-[\\w\\d\\.\\x2d_]+$": {
-            "$ref": "http://asyncapi.com/definitions/2.0.0/specificationExtension.json"
+            "$ref": "#/definitions/specificationExtension"
         }
     },
     "properties": {
@@ -28,42 +28,42 @@
             "format": "uri"
         },
         "info": {
-            "$ref": "http://asyncapi.com/definitions/2.0.0/info.json"
+            "$ref": "#/definitions/info"
         },
         "servers": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "http://asyncapi.com/definitions/2.0.0/server.json"
+                "$ref": "#/definitions/server"
             }
         },
         "defaultContentType": {
             "type": "string"
         },
         "channels": {
-            "$ref": "http://asyncapi.com/definitions/2.0.0/channels.json"
+            "$ref": "#/definitions/channels"
         },
         "components": {
-            "$ref": "http://asyncapi.com/definitions/2.0.0/components.json"
+            "$ref": "#/definitions/components"
         },
         "tags": {
             "type": "array",
             "items": {
-                "$ref": "http://asyncapi.com/definitions/2.0.0/tag.json"
+                "$ref": "#/definitions/tag"
             },
             "uniqueItems": true
         },
         "externalDocs": {
-            "$ref": "http://asyncapi.com/definitions/2.0.0/externalDocs.json"
+            "$ref": "#/definitions/externalDocs"
         }
     },
     "definitions": {
-        "http://asyncapi.com/definitions/2.0.0/specificationExtension.json": {
+        "specificationExtension": {
             "$id": "http://asyncapi.com/definitions/2.0.0/specificationExtension.json",
             "description": "Any property starting with x- is valid.",
             "additionalProperties": true,
             "additionalItems": true
         },
-        "http://asyncapi.com/definitions/2.0.0/info.json": {
+        "info": {
             "$id": "http://asyncapi.com/definitions/2.0.0/info.json",
             "type": "object",
             "description": "General information about the API.",
@@ -74,7 +74,7 @@
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
@@ -96,14 +96,14 @@
                     "format": "uri"
                 },
                 "contact": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0/contact.json"
+                    "$ref": "#/definitions/contact"
                 },
                 "license": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0/license.json"
+                    "$ref": "#/definitions/license"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.0.0/contact.json": {
+        "contact": {
             "$id": "http://asyncapi.com/definitions/2.0.0/contact.json",
             "type": "object",
             "description": "Contact information for the owners of the API.",
@@ -126,11 +126,11 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.0.0/license.json": {
+        "license": {
             "$id": "http://asyncapi.com/definitions/2.0.0/license.json",
             "type": "object",
             "required": [
@@ -150,11 +150,11 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.0.0/server.json": {
+        "server": {
             "$id": "http://asyncapi.com/definitions/2.0.0/server.json",
             "type": "object",
             "description": "An object representing a Server.",
@@ -165,7 +165,7 @@
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
@@ -183,34 +183,34 @@
                     "type": "string"
                 },
                 "variables": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0/serverVariables.json"
+                    "$ref": "#/definitions/serverVariables"
                 },
                 "security": {
                     "type": "array",
                     "items": {
-                        "$ref": "http://asyncapi.com/definitions/2.0.0/SecurityRequirement.json"
+                        "$ref": "#/definitions/SecurityRequirement"
                     }
                 },
                 "bindings": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0/bindingsObject.json"
+                    "$ref": "#/definitions/bindingsObject"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.0.0/serverVariables.json": {
+        "serverVariables": {
             "$id": "http://asyncapi.com/definitions/2.0.0/serverVariables.json",
             "type": "object",
             "additionalProperties": {
-                "$ref": "http://asyncapi.com/definitions/2.0.0/serverVariable.json"
+                "$ref": "#/definitions/serverVariable"
             }
         },
-        "http://asyncapi.com/definitions/2.0.0/serverVariable.json": {
+        "serverVariable": {
             "$id": "http://asyncapi.com/definitions/2.0.0/serverVariable.json",
             "type": "object",
             "description": "An object representing a Server Variable for server URL template substitution.",
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
@@ -235,7 +235,7 @@
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.0.0/SecurityRequirement.json": {
+        "SecurityRequirement": {
             "$id": "http://asyncapi.com/definitions/2.0.0/SecurityRequirement.json",
             "type": "object",
             "additionalProperties": {
@@ -246,7 +246,7 @@
                 "uniqueItems": true
             }
         },
-        "http://asyncapi.com/definitions/2.0.0/bindingsObject.json": {
+        "bindingsObject": {
             "$id": "http://asyncapi.com/definitions/2.0.0/bindingsObject.json",
             "type": "object",
             "additionalProperties": true,
@@ -266,7 +266,7 @@
                 "redis": {}
             }
         },
-        "http://asyncapi.com/definitions/2.0.0/channels.json": {
+        "channels": {
             "$id": "http://asyncapi.com/definitions/2.0.0/channels.json",
             "type": "object",
             "propertyNames": {
@@ -275,26 +275,26 @@
                 "minLength": 1
             },
             "additionalProperties": {
-                "$ref": "http://asyncapi.com/definitions/2.0.0/channelItem.json"
+                "$ref": "#/definitions/channelItem"
             }
         },
-        "http://asyncapi.com/definitions/2.0.0/channelItem.json": {
+        "channelItem": {
             "$id": "http://asyncapi.com/definitions/2.0.0/channelItem.json",
             "type": "object",
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
                 "$ref": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0/ReferenceObject.json"
+                    "$ref": "#/definitions/ReferenceObject"
                 },
                 "parameters": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "http://asyncapi.com/definitions/2.0.0/parameter.json"
+                        "$ref": "#/definitions/parameter"
                     }
                 },
                 "description": {
@@ -302,31 +302,31 @@
                     "description": "A description of the channel."
                 },
                 "publish": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0/operation.json"
+                    "$ref": "#/definitions/operation"
                 },
                 "subscribe": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0/operation.json"
+                    "$ref": "#/definitions/operation"
                 },
                 "deprecated": {
                     "type": "boolean",
                     "default": false
                 },
                 "bindings": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0/bindingsObject.json"
+                    "$ref": "#/definitions/bindingsObject"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.0.0/ReferenceObject.json": {
+        "ReferenceObject": {
             "$id": "http://asyncapi.com/definitions/2.0.0/ReferenceObject.json",
             "type": "string",
             "format": "uri-reference"
         },
-        "http://asyncapi.com/definitions/2.0.0/parameter.json": {
+        "parameter": {
             "$id": "http://asyncapi.com/definitions/2.0.0/parameter.json",
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
@@ -335,7 +335,7 @@
                     "description": "A brief description of the parameter. This could contain examples of use. GitHub Flavored Markdown is allowed."
                 },
                 "schema": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0/schema.json"
+                    "$ref": "#/definitions/schema"
                 },
                 "location": {
                     "type": "string",
@@ -343,27 +343,27 @@
                     "pattern": "^\\$message\\.(header|payload)#(\\/(([^\\/~])|(~[01]))*)*"
                 },
                 "$ref": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0/ReferenceObject.json"
+                    "$ref": "#/definitions/ReferenceObject"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.0.0/schema.json": {
+        "schema": {
             "$id": "http://asyncapi.com/definitions/2.0.0/schema.json",
             "allOf": [
                 {
-                    "$ref": "http://json-schema.org/draft-07/schema#"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 {
                     "patternProperties": {
                         "^x-[\\w\\d\\.\\x2d_]+$": {
-                            "$ref": "http://asyncapi.com/definitions/2.0.0/specificationExtension.json"
+                            "$ref": "#/definitions/specificationExtension"
                         }
                     },
                     "properties": {
                         "additionalProperties": {
                             "anyOf": [
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.0.0/schema.json"
+                                    "$ref": "#/definitions/schema"
                                 },
                                 {
                                     "type": "boolean"
@@ -374,13 +374,13 @@
                         "items": {
                             "anyOf": [
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.0.0/schema.json"
+                                    "$ref": "#/definitions/schema"
                                 },
                                 {
                                     "type": "array",
                                     "minItems": 1,
                                     "items": {
-                                        "$ref": "http://asyncapi.com/definitions/2.0.0/schema.json"
+                                        "$ref": "#/definitions/schema"
                                     }
                                 }
                             ],
@@ -390,51 +390,51 @@
                             "type": "array",
                             "minItems": 1,
                             "items": {
-                                "$ref": "http://asyncapi.com/definitions/2.0.0/schema.json"
+                                "$ref": "#/definitions/schema"
                             }
                         },
                         "oneOf": {
                             "type": "array",
                             "minItems": 1,
                             "items": {
-                                "$ref": "http://asyncapi.com/definitions/2.0.0/schema.json"
+                                "$ref": "#/definitions/schema"
                             }
                         },
                         "anyOf": {
                             "type": "array",
                             "minItems": 1,
                             "items": {
-                                "$ref": "http://asyncapi.com/definitions/2.0.0/schema.json"
+                                "$ref": "#/definitions/schema"
                             }
                         },
                         "not": {
-                            "$ref": "http://asyncapi.com/definitions/2.0.0/schema.json"
+                            "$ref": "#/definitions/schema"
                         },
                         "properties": {
                             "type": "object",
                             "additionalProperties": {
-                                "$ref": "http://asyncapi.com/definitions/2.0.0/schema.json"
+                                "$ref": "#/definitions/schema"
                             },
                             "default": {}
                         },
                         "patternProperties": {
                             "type": "object",
                             "additionalProperties": {
-                                "$ref": "http://asyncapi.com/definitions/2.0.0/schema.json"
+                                "$ref": "#/definitions/schema"
                             },
                             "default": {}
                         },
                         "propertyNames": {
-                            "$ref": "http://asyncapi.com/definitions/2.0.0/schema.json"
+                            "$ref": "#/definitions/schema"
                         },
                         "contains": {
-                            "$ref": "http://asyncapi.com/definitions/2.0.0/schema.json"
+                            "$ref": "#/definitions/schema"
                         },
                         "discriminator": {
                             "type": "string"
                         },
                         "externalDocs": {
-                            "$ref": "http://asyncapi.com/definitions/2.0.0/externalDocs.json"
+                            "$ref": "#/definitions/externalDocs"
                         },
                         "deprecated": {
                             "type": "boolean",
@@ -444,7 +444,7 @@
                 }
             ]
         },
-        "http://json-schema.org/draft-07/schema": {
+        "json-schema-draft-07-schema": {
             "$id": "http://json-schema.org/draft-07/schema",
             "title": "Core schema meta-schema",
             "definitions": {
@@ -452,7 +452,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#"
+                        "$ref": "#/definitions/json-schema-draft-07-schema"
                     }
                 },
                 "nonNegativeInteger": {
@@ -462,7 +462,7 @@
                 "nonNegativeIntegerDefault0": {
                     "allOf": [
                         {
-                            "$ref": "#/definitions/nonNegativeInteger"
+                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/nonNegativeInteger"
                         },
                         {
                             "default": 0
@@ -545,72 +545,72 @@
                     "type": "number"
                 },
                 "maxLength": {
-                    "$ref": "#/definitions/nonNegativeInteger"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/nonNegativeInteger"
                 },
                 "minLength": {
-                    "$ref": "#/definitions/nonNegativeIntegerDefault0"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/nonNegativeIntegerDefault0"
                 },
                 "pattern": {
                     "type": "string",
                     "format": "regex"
                 },
                 "additionalItems": {
-                    "$ref": "#"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "items": {
                     "anyOf": [
                         {
-                            "$ref": "#"
+                            "$ref": "#/definitions/json-schema-draft-07-schema"
                         },
                         {
-                            "$ref": "#/definitions/schemaArray"
+                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/schemaArray"
                         }
                     ],
                     "default": true
                 },
                 "maxItems": {
-                    "$ref": "#/definitions/nonNegativeInteger"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/nonNegativeInteger"
                 },
                 "minItems": {
-                    "$ref": "#/definitions/nonNegativeIntegerDefault0"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/nonNegativeIntegerDefault0"
                 },
                 "uniqueItems": {
                     "type": "boolean",
                     "default": false
                 },
                 "contains": {
-                    "$ref": "#"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "maxProperties": {
-                    "$ref": "#/definitions/nonNegativeInteger"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/nonNegativeInteger"
                 },
                 "minProperties": {
-                    "$ref": "#/definitions/nonNegativeIntegerDefault0"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/nonNegativeIntegerDefault0"
                 },
                 "required": {
-                    "$ref": "#/definitions/stringArray"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/stringArray"
                 },
                 "additionalProperties": {
-                    "$ref": "#"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "definitions": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "#"
+                        "$ref": "#/definitions/json-schema-draft-07-schema"
                     },
                     "default": {}
                 },
                 "properties": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "#"
+                        "$ref": "#/definitions/json-schema-draft-07-schema"
                     },
                     "default": {}
                 },
                 "patternProperties": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "#"
+                        "$ref": "#/definitions/json-schema-draft-07-schema"
                     },
                     "propertyNames": {
                         "format": "regex"
@@ -622,16 +622,16 @@
                     "additionalProperties": {
                         "anyOf": [
                             {
-                                "$ref": "#"
+                                "$ref": "#/definitions/json-schema-draft-07-schema"
                             },
                             {
-                                "$ref": "#/definitions/stringArray"
+                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/stringArray"
                             }
                         ]
                     }
                 },
                 "propertyNames": {
-                    "$ref": "#"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "const": true,
                 "enum": {
@@ -643,12 +643,12 @@
                 "type": {
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/simpleTypes"
+                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/simpleTypes"
                         },
                         {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/simpleTypes"
+                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/simpleTypes"
                             },
                             "minItems": 1,
                             "uniqueItems": true
@@ -665,30 +665,30 @@
                     "type": "string"
                 },
                 "if": {
-                    "$ref": "#"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "then": {
-                    "$ref": "#"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "else": {
-                    "$ref": "#"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "allOf": {
-                    "$ref": "#/definitions/schemaArray"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/schemaArray"
                 },
                 "anyOf": {
-                    "$ref": "#/definitions/schemaArray"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/schemaArray"
                 },
                 "oneOf": {
-                    "$ref": "#/definitions/schemaArray"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/schemaArray"
                 },
                 "not": {
-                    "$ref": "#"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 }
             },
             "default": true
         },
-        "http://asyncapi.com/definitions/2.0.0/externalDocs.json": {
+        "externalDocs": {
             "$id": "http://asyncapi.com/definitions/2.0.0/externalDocs.json",
             "type": "object",
             "additionalProperties": false,
@@ -707,17 +707,17 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.0.0/operation.json": {
+        "operation": {
             "$id": "http://asyncapi.com/definitions/2.0.0/operation.json",
             "type": "object",
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
@@ -726,10 +726,10 @@
                     "items": {
                         "oneOf": [
                             {
-                                "$ref": "http://asyncapi.com/definitions/2.0.0/Reference.json"
+                                "$ref": "#/definitions/Reference"
                             },
                             {
-                                "$ref": "http://asyncapi.com/definitions/2.0.0/operationTrait.json"
+                                "$ref": "#/definitions/operationTrait"
                             },
                             {
                                 "type": "array",
@@ -737,10 +737,10 @@
                                     {
                                         "oneOf": [
                                             {
-                                                "$ref": "http://asyncapi.com/definitions/2.0.0/Reference.json"
+                                                "$ref": "#/definitions/Reference"
                                             },
                                             {
-                                                "$ref": "http://asyncapi.com/definitions/2.0.0/operationTrait.json"
+                                                "$ref": "#/definitions/operationTrait"
                                             }
                                         ]
                                     },
@@ -762,25 +762,25 @@
                 "tags": {
                     "type": "array",
                     "items": {
-                        "$ref": "http://asyncapi.com/definitions/2.0.0/tag.json"
+                        "$ref": "#/definitions/tag"
                     },
                     "uniqueItems": true
                 },
                 "externalDocs": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0/externalDocs.json"
+                    "$ref": "#/definitions/externalDocs"
                 },
                 "operationId": {
                     "type": "string"
                 },
                 "bindings": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0/bindingsObject.json"
+                    "$ref": "#/definitions/bindingsObject"
                 },
                 "message": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0/message.json"
+                    "$ref": "#/definitions/message"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.0.0/Reference.json": {
+        "Reference": {
             "$id": "http://asyncapi.com/definitions/2.0.0/Reference.json",
             "type": "object",
             "required": [
@@ -788,17 +788,17 @@
             ],
             "properties": {
                 "$ref": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0/ReferenceObject.json"
+                    "$ref": "#/definitions/ReferenceObject"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.0.0/operationTrait.json": {
+        "operationTrait": {
             "$id": "http://asyncapi.com/definitions/2.0.0/operationTrait.json",
             "type": "object",
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
@@ -811,22 +811,22 @@
                 "tags": {
                     "type": "array",
                     "items": {
-                        "$ref": "http://asyncapi.com/definitions/2.0.0/tag.json"
+                        "$ref": "#/definitions/tag"
                     },
                     "uniqueItems": true
                 },
                 "externalDocs": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0/externalDocs.json"
+                    "$ref": "#/definitions/externalDocs"
                 },
                 "operationId": {
                     "type": "string"
                 },
                 "bindings": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0/bindingsObject.json"
+                    "$ref": "#/definitions/bindingsObject"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.0.0/tag.json": {
+        "tag": {
             "$id": "http://asyncapi.com/definitions/2.0.0/tag.json",
             "type": "object",
             "additionalProperties": false,
@@ -841,20 +841,20 @@
                     "type": "string"
                 },
                 "externalDocs": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0/externalDocs.json"
+                    "$ref": "#/definitions/externalDocs"
                 }
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.0.0/message.json": {
+        "message": {
             "$id": "http://asyncapi.com/definitions/2.0.0/message.json",
             "oneOf": [
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0/Reference.json"
+                    "$ref": "#/definitions/Reference"
                 },
                 {
                     "oneOf": [
@@ -868,7 +868,7 @@
                                 "oneOf": {
                                     "type": "array",
                                     "items": {
-                                        "$ref": "http://asyncapi.com/definitions/2.0.0/message.json"
+                                        "$ref": "#/definitions/message"
                                     }
                                 }
                             }
@@ -878,7 +878,7 @@
                             "additionalProperties": false,
                             "patternProperties": {
                                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                                    "$ref": "http://asyncapi.com/definitions/2.0.0/specificationExtension.json"
+                                    "$ref": "#/definitions/specificationExtension"
                                 }
                             },
                             "properties": {
@@ -891,7 +891,7 @@
                                 "headers": {
                                     "allOf": [
                                         {
-                                            "$ref": "http://asyncapi.com/definitions/2.0.0/schema.json"
+                                            "$ref": "#/definitions/schema"
                                         },
                                         {
                                             "properties": {
@@ -906,17 +906,17 @@
                                 "correlationId": {
                                     "oneOf": [
                                         {
-                                            "$ref": "http://asyncapi.com/definitions/2.0.0/Reference.json"
+                                            "$ref": "#/definitions/Reference"
                                         },
                                         {
-                                            "$ref": "http://asyncapi.com/definitions/2.0.0/correlationId.json"
+                                            "$ref": "#/definitions/correlationId"
                                         }
                                     ]
                                 },
                                 "tags": {
                                     "type": "array",
                                     "items": {
-                                        "$ref": "http://asyncapi.com/definitions/2.0.0/tag.json"
+                                        "$ref": "#/definitions/tag"
                                     },
                                     "uniqueItems": true
                                 },
@@ -937,7 +937,7 @@
                                     "description": "A longer description of the message. CommonMark is allowed."
                                 },
                                 "externalDocs": {
-                                    "$ref": "http://asyncapi.com/definitions/2.0.0/externalDocs.json"
+                                    "$ref": "#/definitions/externalDocs"
                                 },
                                 "deprecated": {
                                     "type": "boolean",
@@ -957,17 +957,17 @@
                                     }
                                 },
                                 "bindings": {
-                                    "$ref": "http://asyncapi.com/definitions/2.0.0/bindingsObject.json"
+                                    "$ref": "#/definitions/bindingsObject"
                                 },
                                 "traits": {
                                     "type": "array",
                                     "items": {
                                         "oneOf": [
                                             {
-                                                "$ref": "http://asyncapi.com/definitions/2.0.0/Reference.json"
+                                                "$ref": "#/definitions/Reference"
                                             },
                                             {
-                                                "$ref": "http://asyncapi.com/definitions/2.0.0/messageTrait.json"
+                                                "$ref": "#/definitions/messageTrait"
                                             },
                                             {
                                                 "type": "array",
@@ -975,10 +975,10 @@
                                                     {
                                                         "oneOf": [
                                                             {
-                                                                "$ref": "http://asyncapi.com/definitions/2.0.0/Reference.json"
+                                                                "$ref": "#/definitions/Reference"
                                                             },
                                                             {
-                                                                "$ref": "http://asyncapi.com/definitions/2.0.0/messageTrait.json"
+                                                                "$ref": "#/definitions/messageTrait"
                                                             }
                                                         ]
                                                     },
@@ -997,7 +997,7 @@
                 }
             ]
         },
-        "http://asyncapi.com/definitions/2.0.0/correlationId.json": {
+        "correlationId": {
             "$id": "http://asyncapi.com/definitions/2.0.0/correlationId.json",
             "type": "object",
             "required": [
@@ -1006,7 +1006,7 @@
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
@@ -1021,13 +1021,13 @@
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.0.0/messageTrait.json": {
+        "messageTrait": {
             "$id": "http://asyncapi.com/definitions/2.0.0/messageTrait.json",
             "type": "object",
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
@@ -1040,7 +1040,7 @@
                 "headers": {
                     "allOf": [
                         {
-                            "$ref": "http://asyncapi.com/definitions/2.0.0/schema.json"
+                            "$ref": "#/definitions/schema"
                         },
                         {
                             "properties": {
@@ -1054,17 +1054,17 @@
                 "correlationId": {
                     "oneOf": [
                         {
-                            "$ref": "http://asyncapi.com/definitions/2.0.0/Reference.json"
+                            "$ref": "#/definitions/Reference"
                         },
                         {
-                            "$ref": "http://asyncapi.com/definitions/2.0.0/correlationId.json"
+                            "$ref": "#/definitions/correlationId"
                         }
                     ]
                 },
                 "tags": {
                     "type": "array",
                     "items": {
-                        "$ref": "http://asyncapi.com/definitions/2.0.0/tag.json"
+                        "$ref": "#/definitions/tag"
                     },
                     "uniqueItems": true
                 },
@@ -1085,7 +1085,7 @@
                     "description": "A longer description of the message. CommonMark is allowed."
                 },
                 "externalDocs": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0/externalDocs.json"
+                    "$ref": "#/definitions/externalDocs"
                 },
                 "deprecated": {
                     "type": "boolean",
@@ -1098,26 +1098,26 @@
                     }
                 },
                 "bindings": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0/bindingsObject.json"
+                    "$ref": "#/definitions/bindingsObject"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.0.0/components.json": {
+        "components": {
             "$id": "http://asyncapi.com/definitions/2.0.0/components.json",
             "type": "object",
             "description": "An object to hold a set of reusable objects for different aspects of the AsyncAPI Specification.",
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
                 "schemas": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0/schemas.json"
+                    "$ref": "#/definitions/schemas"
                 },
                 "messages": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0/messages.json"
+                    "$ref": "#/definitions/messages"
                 },
                 "securitySchemes": {
                     "type": "object",
@@ -1125,17 +1125,17 @@
                         "^[\\w\\d\\.\\-_]+$": {
                             "oneOf": [
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.0.0/Reference.json"
+                                    "$ref": "#/definitions/Reference"
                                 },
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.0.0/SecurityScheme.json"
+                                    "$ref": "#/definitions/SecurityScheme"
                                 }
                             ]
                         }
                     }
                 },
                 "parameters": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0/parameters.json"
+                    "$ref": "#/definitions/parameters"
                 },
                 "correlationIds": {
                     "type": "object",
@@ -1143,10 +1143,10 @@
                         "^[\\w\\d\\.\\-_]+$": {
                             "oneOf": [
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.0.0/Reference.json"
+                                    "$ref": "#/definitions/Reference"
                                 },
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.0.0/correlationId.json"
+                                    "$ref": "#/definitions/correlationId"
                                 }
                             ]
                         }
@@ -1155,87 +1155,87 @@
                 "operationTraits": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "http://asyncapi.com/definitions/2.0.0/operationTrait.json"
+                        "$ref": "#/definitions/operationTrait"
                     }
                 },
                 "messageTraits": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "http://asyncapi.com/definitions/2.0.0/messageTrait.json"
+                        "$ref": "#/definitions/messageTrait"
                     }
                 },
                 "serverBindings": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "http://asyncapi.com/definitions/2.0.0/bindingsObject.json"
+                        "$ref": "#/definitions/bindingsObject"
                     }
                 },
                 "channelBindings": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "http://asyncapi.com/definitions/2.0.0/bindingsObject.json"
+                        "$ref": "#/definitions/bindingsObject"
                     }
                 },
                 "operationBindings": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "http://asyncapi.com/definitions/2.0.0/bindingsObject.json"
+                        "$ref": "#/definitions/bindingsObject"
                     }
                 },
                 "messageBindings": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "http://asyncapi.com/definitions/2.0.0/bindingsObject.json"
+                        "$ref": "#/definitions/bindingsObject"
                     }
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.0.0/schemas.json": {
+        "schemas": {
             "$id": "http://asyncapi.com/definitions/2.0.0/schemas.json",
             "type": "object",
             "additionalProperties": {
-                "$ref": "http://asyncapi.com/definitions/2.0.0/schema.json"
+                "$ref": "#/definitions/schema"
             },
             "description": "JSON objects describing schemas the API uses."
         },
-        "http://asyncapi.com/definitions/2.0.0/messages.json": {
+        "messages": {
             "$id": "http://asyncapi.com/definitions/2.0.0/messages.json",
             "type": "object",
             "additionalProperties": {
-                "$ref": "http://asyncapi.com/definitions/2.0.0/message.json"
+                "$ref": "#/definitions/message"
             },
             "description": "JSON objects describing the messages being consumed and produced by the API."
         },
-        "http://asyncapi.com/definitions/2.0.0/SecurityScheme.json": {
+        "SecurityScheme": {
             "$id": "http://asyncapi.com/definitions/2.0.0/SecurityScheme.json",
             "oneOf": [
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0/userPassword.json"
+                    "$ref": "#/definitions/userPassword"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0/apiKey.json"
+                    "$ref": "#/definitions/apiKey"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0/X509.json"
+                    "$ref": "#/definitions/X509"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0/symmetricEncryption.json"
+                    "$ref": "#/definitions/symmetricEncryption"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0/asymmetricEncryption.json"
+                    "$ref": "#/definitions/asymmetricEncryption"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0/HTTPSecurityScheme.json"
+                    "$ref": "#/definitions/HTTPSecurityScheme"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0/oauth2Flows.json"
+                    "$ref": "#/definitions/oauth2Flows"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0/openIdConnect.json"
+                    "$ref": "#/definitions/openIdConnect"
                 }
             ]
         },
-        "http://asyncapi.com/definitions/2.0.0/userPassword.json": {
+        "userPassword": {
             "$id": "http://asyncapi.com/definitions/2.0.0/userPassword.json",
             "type": "object",
             "required": [
@@ -1254,12 +1254,12 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.0.0/apiKey.json": {
+        "apiKey": {
             "$id": "http://asyncapi.com/definitions/2.0.0/apiKey.json",
             "type": "object",
             "required": [
@@ -1286,12 +1286,12 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.0.0/X509.json": {
+        "X509": {
             "$id": "http://asyncapi.com/definitions/2.0.0/X509.json",
             "type": "object",
             "required": [
@@ -1310,12 +1310,12 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.0.0/symmetricEncryption.json": {
+        "symmetricEncryption": {
             "$id": "http://asyncapi.com/definitions/2.0.0/symmetricEncryption.json",
             "type": "object",
             "required": [
@@ -1334,12 +1334,12 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.0.0/asymmetricEncryption.json": {
+        "asymmetricEncryption": {
             "$id": "http://asyncapi.com/definitions/2.0.0/asymmetricEncryption.json",
             "type": "object",
             "required": [
@@ -1358,26 +1358,26 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.0.0/HTTPSecurityScheme.json": {
+        "HTTPSecurityScheme": {
             "$id": "http://asyncapi.com/definitions/2.0.0/HTTPSecurityScheme.json",
             "oneOf": [
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0/NonBearerHTTPSecurityScheme.json"
+                    "$ref": "#/definitions/NonBearerHTTPSecurityScheme"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0/BearerHTTPSecurityScheme.json"
+                    "$ref": "#/definitions/BearerHTTPSecurityScheme"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0/APIKeyHTTPSecurityScheme.json"
+                    "$ref": "#/definitions/APIKeyHTTPSecurityScheme"
                 }
             ]
         },
-        "http://asyncapi.com/definitions/2.0.0/NonBearerHTTPSecurityScheme.json": {
+        "NonBearerHTTPSecurityScheme": {
             "$id": "http://asyncapi.com/definitions/2.0.0/NonBearerHTTPSecurityScheme.json",
             "not": {
                 "type": "object",
@@ -1411,12 +1411,12 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.0.0/BearerHTTPSecurityScheme.json": {
+        "BearerHTTPSecurityScheme": {
             "$id": "http://asyncapi.com/definitions/2.0.0/BearerHTTPSecurityScheme.json",
             "type": "object",
             "required": [
@@ -1445,12 +1445,12 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.0.0/APIKeyHTTPSecurityScheme.json": {
+        "APIKeyHTTPSecurityScheme": {
             "$id": "http://asyncapi.com/definitions/2.0.0/APIKeyHTTPSecurityScheme.json",
             "type": "object",
             "required": [
@@ -1482,12 +1482,12 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.0.0/oauth2Flows.json": {
+        "oauth2Flows": {
             "$id": "http://asyncapi.com/definitions/2.0.0/oauth2Flows.json",
             "type": "object",
             "required": [
@@ -1510,7 +1510,7 @@
                         "implicit": {
                             "allOf": [
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.0.0/oauth2Flow.json"
+                                    "$ref": "#/definitions/oauth2Flow"
                                 },
                                 {
                                     "required": [
@@ -1530,7 +1530,7 @@
                         "password": {
                             "allOf": [
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.0.0/oauth2Flow.json"
+                                    "$ref": "#/definitions/oauth2Flow"
                                 },
                                 {
                                     "required": [
@@ -1550,7 +1550,7 @@
                         "clientCredentials": {
                             "allOf": [
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.0.0/oauth2Flow.json"
+                                    "$ref": "#/definitions/oauth2Flow"
                                 },
                                 {
                                     "required": [
@@ -1570,7 +1570,7 @@
                         "authorizationCode": {
                             "allOf": [
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.0.0/oauth2Flow.json"
+                                    "$ref": "#/definitions/oauth2Flow"
                                 },
                                 {
                                     "required": [
@@ -1587,11 +1587,11 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.0.0/oauth2Flow.json": {
+        "oauth2Flow": {
             "$id": "http://asyncapi.com/definitions/2.0.0/oauth2Flow.json",
             "type": "object",
             "properties": {
@@ -1608,24 +1608,24 @@
                     "format": "uri"
                 },
                 "scopes": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0/oauth2Scopes.json"
+                    "$ref": "#/definitions/oauth2Scopes"
                 }
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.0.0/oauth2Scopes.json": {
+        "oauth2Scopes": {
             "$id": "http://asyncapi.com/definitions/2.0.0/oauth2Scopes.json",
             "type": "object",
             "additionalProperties": {
                 "type": "string"
             }
         },
-        "http://asyncapi.com/definitions/2.0.0/openIdConnect.json": {
+        "openIdConnect": {
             "$id": "http://asyncapi.com/definitions/2.0.0/openIdConnect.json",
             "type": "object",
             "required": [
@@ -1649,16 +1649,16 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.0.0/parameters.json": {
+        "parameters": {
             "$id": "http://asyncapi.com/definitions/2.0.0/parameters.json",
             "type": "object",
             "additionalProperties": {
-                "$ref": "http://asyncapi.com/definitions/2.0.0/parameter.json"
+                "$ref": "#/definitions/parameter"
             },
             "description": "JSON objects describing re-usable channel parameters."
         }

--- a/schemas/2.1.0.json
+++ b/schemas/2.1.0.json
@@ -11,7 +11,7 @@
     "additionalProperties": false,
     "patternProperties": {
         "^x-[\\w\\d\\.\\x2d_]+$": {
-            "$ref": "http://asyncapi.com/definitions/2.1.0/specificationExtension.json"
+            "$ref": "#/definitions/specificationExtension"
         }
     },
     "properties": {
@@ -28,42 +28,42 @@
             "format": "uri"
         },
         "info": {
-            "$ref": "http://asyncapi.com/definitions/2.1.0/info.json"
+            "$ref": "#/definitions/info"
         },
         "servers": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "http://asyncapi.com/definitions/2.1.0/server.json"
+                "$ref": "#/definitions/server"
             }
         },
         "defaultContentType": {
             "type": "string"
         },
         "channels": {
-            "$ref": "http://asyncapi.com/definitions/2.1.0/channels.json"
+            "$ref": "#/definitions/channels"
         },
         "components": {
-            "$ref": "http://asyncapi.com/definitions/2.1.0/components.json"
+            "$ref": "#/definitions/components"
         },
         "tags": {
             "type": "array",
             "items": {
-                "$ref": "http://asyncapi.com/definitions/2.1.0/tag.json"
+                "$ref": "#/definitions/tag"
             },
             "uniqueItems": true
         },
         "externalDocs": {
-            "$ref": "http://asyncapi.com/definitions/2.1.0/externalDocs.json"
+            "$ref": "#/definitions/externalDocs"
         }
     },
     "definitions": {
-        "http://asyncapi.com/definitions/2.1.0/specificationExtension.json": {
+        "specificationExtension": {
             "$id": "http://asyncapi.com/definitions/2.1.0/specificationExtension.json",
             "description": "Any property starting with x- is valid.",
             "additionalProperties": true,
             "additionalItems": true
         },
-        "http://asyncapi.com/definitions/2.1.0/info.json": {
+        "info": {
             "$id": "http://asyncapi.com/definitions/2.1.0/info.json",
             "type": "object",
             "description": "General information about the API.",
@@ -74,7 +74,7 @@
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
@@ -96,14 +96,14 @@
                     "format": "uri"
                 },
                 "contact": {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/contact.json"
+                    "$ref": "#/definitions/contact"
                 },
                 "license": {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/license.json"
+                    "$ref": "#/definitions/license"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.1.0/contact.json": {
+        "contact": {
             "$id": "http://asyncapi.com/definitions/2.1.0/contact.json",
             "type": "object",
             "description": "Contact information for the owners of the API.",
@@ -126,11 +126,11 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.1.0/license.json": {
+        "license": {
             "$id": "http://asyncapi.com/definitions/2.1.0/license.json",
             "type": "object",
             "required": [
@@ -150,11 +150,11 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.1.0/server.json": {
+        "server": {
             "$id": "http://asyncapi.com/definitions/2.1.0/server.json",
             "type": "object",
             "description": "An object representing a Server.",
@@ -165,7 +165,7 @@
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
@@ -183,34 +183,34 @@
                     "type": "string"
                 },
                 "variables": {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/serverVariables.json"
+                    "$ref": "#/definitions/serverVariables"
                 },
                 "security": {
                     "type": "array",
                     "items": {
-                        "$ref": "http://asyncapi.com/definitions/2.1.0/SecurityRequirement.json"
+                        "$ref": "#/definitions/SecurityRequirement"
                     }
                 },
                 "bindings": {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/bindingsObject.json"
+                    "$ref": "#/definitions/bindingsObject"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.1.0/serverVariables.json": {
+        "serverVariables": {
             "$id": "http://asyncapi.com/definitions/2.1.0/serverVariables.json",
             "type": "object",
             "additionalProperties": {
-                "$ref": "http://asyncapi.com/definitions/2.1.0/serverVariable.json"
+                "$ref": "#/definitions/serverVariable"
             }
         },
-        "http://asyncapi.com/definitions/2.1.0/serverVariable.json": {
+        "serverVariable": {
             "$id": "http://asyncapi.com/definitions/2.1.0/serverVariable.json",
             "type": "object",
             "description": "An object representing a Server Variable for server URL template substitution.",
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
@@ -235,7 +235,7 @@
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.1.0/SecurityRequirement.json": {
+        "SecurityRequirement": {
             "$id": "http://asyncapi.com/definitions/2.1.0/SecurityRequirement.json",
             "type": "object",
             "additionalProperties": {
@@ -246,7 +246,7 @@
                 "uniqueItems": true
             }
         },
-        "http://asyncapi.com/definitions/2.1.0/bindingsObject.json": {
+        "bindingsObject": {
             "$id": "http://asyncapi.com/definitions/2.1.0/bindingsObject.json",
             "type": "object",
             "additionalProperties": true,
@@ -267,7 +267,7 @@
                 "ibmmq": {}
             }
         },
-        "http://asyncapi.com/definitions/2.1.0/channels.json": {
+        "channels": {
             "$id": "http://asyncapi.com/definitions/2.1.0/channels.json",
             "type": "object",
             "propertyNames": {
@@ -276,26 +276,26 @@
                 "minLength": 1
             },
             "additionalProperties": {
-                "$ref": "http://asyncapi.com/definitions/2.1.0/channelItem.json"
+                "$ref": "#/definitions/channelItem"
             }
         },
-        "http://asyncapi.com/definitions/2.1.0/channelItem.json": {
+        "channelItem": {
             "$id": "http://asyncapi.com/definitions/2.1.0/channelItem.json",
             "type": "object",
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
                 "$ref": {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/ReferenceObject.json"
+                    "$ref": "#/definitions/ReferenceObject"
                 },
                 "parameters": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "http://asyncapi.com/definitions/2.1.0/parameter.json"
+                        "$ref": "#/definitions/parameter"
                     }
                 },
                 "description": {
@@ -303,31 +303,31 @@
                     "description": "A description of the channel."
                 },
                 "publish": {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/operation.json"
+                    "$ref": "#/definitions/operation"
                 },
                 "subscribe": {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/operation.json"
+                    "$ref": "#/definitions/operation"
                 },
                 "deprecated": {
                     "type": "boolean",
                     "default": false
                 },
                 "bindings": {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/bindingsObject.json"
+                    "$ref": "#/definitions/bindingsObject"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.1.0/ReferenceObject.json": {
+        "ReferenceObject": {
             "$id": "http://asyncapi.com/definitions/2.1.0/ReferenceObject.json",
             "type": "string",
             "format": "uri-reference"
         },
-        "http://asyncapi.com/definitions/2.1.0/parameter.json": {
+        "parameter": {
             "$id": "http://asyncapi.com/definitions/2.1.0/parameter.json",
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
@@ -336,7 +336,7 @@
                     "description": "A brief description of the parameter. This could contain examples of use. GitHub Flavored Markdown is allowed."
                 },
                 "schema": {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/schema.json"
+                    "$ref": "#/definitions/schema"
                 },
                 "location": {
                     "type": "string",
@@ -344,27 +344,27 @@
                     "pattern": "^\\$message\\.(header|payload)#(\\/(([^\\/~])|(~[01]))*)*"
                 },
                 "$ref": {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/ReferenceObject.json"
+                    "$ref": "#/definitions/ReferenceObject"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.1.0/schema.json": {
+        "schema": {
             "$id": "http://asyncapi.com/definitions/2.1.0/schema.json",
             "allOf": [
                 {
-                    "$ref": "http://json-schema.org/draft-07/schema#"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 {
                     "patternProperties": {
                         "^x-[\\w\\d\\.\\x2d_]+$": {
-                            "$ref": "http://asyncapi.com/definitions/2.1.0/specificationExtension.json"
+                            "$ref": "#/definitions/specificationExtension"
                         }
                     },
                     "properties": {
                         "additionalProperties": {
                             "anyOf": [
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.1.0/schema.json"
+                                    "$ref": "#/definitions/schema"
                                 },
                                 {
                                     "type": "boolean"
@@ -375,13 +375,13 @@
                         "items": {
                             "anyOf": [
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.1.0/schema.json"
+                                    "$ref": "#/definitions/schema"
                                 },
                                 {
                                     "type": "array",
                                     "minItems": 1,
                                     "items": {
-                                        "$ref": "http://asyncapi.com/definitions/2.1.0/schema.json"
+                                        "$ref": "#/definitions/schema"
                                     }
                                 }
                             ],
@@ -391,51 +391,51 @@
                             "type": "array",
                             "minItems": 1,
                             "items": {
-                                "$ref": "http://asyncapi.com/definitions/2.1.0/schema.json"
+                                "$ref": "#/definitions/schema"
                             }
                         },
                         "oneOf": {
                             "type": "array",
                             "minItems": 1,
                             "items": {
-                                "$ref": "http://asyncapi.com/definitions/2.1.0/schema.json"
+                                "$ref": "#/definitions/schema"
                             }
                         },
                         "anyOf": {
                             "type": "array",
                             "minItems": 1,
                             "items": {
-                                "$ref": "http://asyncapi.com/definitions/2.1.0/schema.json"
+                                "$ref": "#/definitions/schema"
                             }
                         },
                         "not": {
-                            "$ref": "http://asyncapi.com/definitions/2.1.0/schema.json"
+                            "$ref": "#/definitions/schema"
                         },
                         "properties": {
                             "type": "object",
                             "additionalProperties": {
-                                "$ref": "http://asyncapi.com/definitions/2.1.0/schema.json"
+                                "$ref": "#/definitions/schema"
                             },
                             "default": {}
                         },
                         "patternProperties": {
                             "type": "object",
                             "additionalProperties": {
-                                "$ref": "http://asyncapi.com/definitions/2.1.0/schema.json"
+                                "$ref": "#/definitions/schema"
                             },
                             "default": {}
                         },
                         "propertyNames": {
-                            "$ref": "http://asyncapi.com/definitions/2.1.0/schema.json"
+                            "$ref": "#/definitions/schema"
                         },
                         "contains": {
-                            "$ref": "http://asyncapi.com/definitions/2.1.0/schema.json"
+                            "$ref": "#/definitions/schema"
                         },
                         "discriminator": {
                             "type": "string"
                         },
                         "externalDocs": {
-                            "$ref": "http://asyncapi.com/definitions/2.1.0/externalDocs.json"
+                            "$ref": "#/definitions/externalDocs"
                         },
                         "deprecated": {
                             "type": "boolean",
@@ -445,7 +445,7 @@
                 }
             ]
         },
-        "http://json-schema.org/draft-07/schema": {
+        "json-schema-draft-07-schema": {
             "$id": "http://json-schema.org/draft-07/schema",
             "title": "Core schema meta-schema",
             "definitions": {
@@ -453,7 +453,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#"
+                        "$ref": "#/definitions/json-schema-draft-07-schema"
                     }
                 },
                 "nonNegativeInteger": {
@@ -463,7 +463,7 @@
                 "nonNegativeIntegerDefault0": {
                     "allOf": [
                         {
-                            "$ref": "#/definitions/nonNegativeInteger"
+                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/nonNegativeInteger"
                         },
                         {
                             "default": 0
@@ -546,72 +546,72 @@
                     "type": "number"
                 },
                 "maxLength": {
-                    "$ref": "#/definitions/nonNegativeInteger"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/nonNegativeInteger"
                 },
                 "minLength": {
-                    "$ref": "#/definitions/nonNegativeIntegerDefault0"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/nonNegativeIntegerDefault0"
                 },
                 "pattern": {
                     "type": "string",
                     "format": "regex"
                 },
                 "additionalItems": {
-                    "$ref": "#"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "items": {
                     "anyOf": [
                         {
-                            "$ref": "#"
+                            "$ref": "#/definitions/json-schema-draft-07-schema"
                         },
                         {
-                            "$ref": "#/definitions/schemaArray"
+                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/schemaArray"
                         }
                     ],
                     "default": true
                 },
                 "maxItems": {
-                    "$ref": "#/definitions/nonNegativeInteger"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/nonNegativeInteger"
                 },
                 "minItems": {
-                    "$ref": "#/definitions/nonNegativeIntegerDefault0"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/nonNegativeIntegerDefault0"
                 },
                 "uniqueItems": {
                     "type": "boolean",
                     "default": false
                 },
                 "contains": {
-                    "$ref": "#"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "maxProperties": {
-                    "$ref": "#/definitions/nonNegativeInteger"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/nonNegativeInteger"
                 },
                 "minProperties": {
-                    "$ref": "#/definitions/nonNegativeIntegerDefault0"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/nonNegativeIntegerDefault0"
                 },
                 "required": {
-                    "$ref": "#/definitions/stringArray"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/stringArray"
                 },
                 "additionalProperties": {
-                    "$ref": "#"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "definitions": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "#"
+                        "$ref": "#/definitions/json-schema-draft-07-schema"
                     },
                     "default": {}
                 },
                 "properties": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "#"
+                        "$ref": "#/definitions/json-schema-draft-07-schema"
                     },
                     "default": {}
                 },
                 "patternProperties": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "#"
+                        "$ref": "#/definitions/json-schema-draft-07-schema"
                     },
                     "propertyNames": {
                         "format": "regex"
@@ -623,16 +623,16 @@
                     "additionalProperties": {
                         "anyOf": [
                             {
-                                "$ref": "#"
+                                "$ref": "#/definitions/json-schema-draft-07-schema"
                             },
                             {
-                                "$ref": "#/definitions/stringArray"
+                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/stringArray"
                             }
                         ]
                     }
                 },
                 "propertyNames": {
-                    "$ref": "#"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "const": true,
                 "enum": {
@@ -644,12 +644,12 @@
                 "type": {
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/simpleTypes"
+                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/simpleTypes"
                         },
                         {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/simpleTypes"
+                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/simpleTypes"
                             },
                             "minItems": 1,
                             "uniqueItems": true
@@ -666,30 +666,30 @@
                     "type": "string"
                 },
                 "if": {
-                    "$ref": "#"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "then": {
-                    "$ref": "#"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "else": {
-                    "$ref": "#"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "allOf": {
-                    "$ref": "#/definitions/schemaArray"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/schemaArray"
                 },
                 "anyOf": {
-                    "$ref": "#/definitions/schemaArray"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/schemaArray"
                 },
                 "oneOf": {
-                    "$ref": "#/definitions/schemaArray"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/schemaArray"
                 },
                 "not": {
-                    "$ref": "#"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 }
             },
             "default": true
         },
-        "http://asyncapi.com/definitions/2.1.0/externalDocs.json": {
+        "externalDocs": {
             "$id": "http://asyncapi.com/definitions/2.1.0/externalDocs.json",
             "type": "object",
             "additionalProperties": false,
@@ -708,17 +708,17 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.1.0/operation.json": {
+        "operation": {
             "$id": "http://asyncapi.com/definitions/2.1.0/operation.json",
             "type": "object",
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
@@ -727,10 +727,10 @@
                     "items": {
                         "oneOf": [
                             {
-                                "$ref": "http://asyncapi.com/definitions/2.1.0/Reference.json"
+                                "$ref": "#/definitions/Reference"
                             },
                             {
-                                "$ref": "http://asyncapi.com/definitions/2.1.0/operationTrait.json"
+                                "$ref": "#/definitions/operationTrait"
                             },
                             {
                                 "type": "array",
@@ -738,10 +738,10 @@
                                     {
                                         "oneOf": [
                                             {
-                                                "$ref": "http://asyncapi.com/definitions/2.1.0/Reference.json"
+                                                "$ref": "#/definitions/Reference"
                                             },
                                             {
-                                                "$ref": "http://asyncapi.com/definitions/2.1.0/operationTrait.json"
+                                                "$ref": "#/definitions/operationTrait"
                                             }
                                         ]
                                     },
@@ -763,25 +763,25 @@
                 "tags": {
                     "type": "array",
                     "items": {
-                        "$ref": "http://asyncapi.com/definitions/2.1.0/tag.json"
+                        "$ref": "#/definitions/tag"
                     },
                     "uniqueItems": true
                 },
                 "externalDocs": {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/externalDocs.json"
+                    "$ref": "#/definitions/externalDocs"
                 },
                 "operationId": {
                     "type": "string"
                 },
                 "bindings": {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/bindingsObject.json"
+                    "$ref": "#/definitions/bindingsObject"
                 },
                 "message": {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/message.json"
+                    "$ref": "#/definitions/message"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.1.0/Reference.json": {
+        "Reference": {
             "$id": "http://asyncapi.com/definitions/2.1.0/Reference.json",
             "type": "object",
             "required": [
@@ -789,17 +789,17 @@
             ],
             "properties": {
                 "$ref": {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/ReferenceObject.json"
+                    "$ref": "#/definitions/ReferenceObject"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.1.0/operationTrait.json": {
+        "operationTrait": {
             "$id": "http://asyncapi.com/definitions/2.1.0/operationTrait.json",
             "type": "object",
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
@@ -812,22 +812,22 @@
                 "tags": {
                     "type": "array",
                     "items": {
-                        "$ref": "http://asyncapi.com/definitions/2.1.0/tag.json"
+                        "$ref": "#/definitions/tag"
                     },
                     "uniqueItems": true
                 },
                 "externalDocs": {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/externalDocs.json"
+                    "$ref": "#/definitions/externalDocs"
                 },
                 "operationId": {
                     "type": "string"
                 },
                 "bindings": {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/bindingsObject.json"
+                    "$ref": "#/definitions/bindingsObject"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.1.0/tag.json": {
+        "tag": {
             "$id": "http://asyncapi.com/definitions/2.1.0/tag.json",
             "type": "object",
             "additionalProperties": false,
@@ -842,20 +842,20 @@
                     "type": "string"
                 },
                 "externalDocs": {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/externalDocs.json"
+                    "$ref": "#/definitions/externalDocs"
                 }
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.1.0/message.json": {
+        "message": {
             "$id": "http://asyncapi.com/definitions/2.1.0/message.json",
             "oneOf": [
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/Reference.json"
+                    "$ref": "#/definitions/Reference"
                 },
                 {
                     "oneOf": [
@@ -869,7 +869,7 @@
                                 "oneOf": {
                                     "type": "array",
                                     "items": {
-                                        "$ref": "http://asyncapi.com/definitions/2.1.0/message.json"
+                                        "$ref": "#/definitions/message"
                                     }
                                 }
                             }
@@ -879,7 +879,7 @@
                             "additionalProperties": false,
                             "patternProperties": {
                                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                                    "$ref": "http://asyncapi.com/definitions/2.1.0/specificationExtension.json"
+                                    "$ref": "#/definitions/specificationExtension"
                                 }
                             },
                             "properties": {
@@ -892,7 +892,7 @@
                                 "headers": {
                                     "allOf": [
                                         {
-                                            "$ref": "http://asyncapi.com/definitions/2.1.0/schema.json"
+                                            "$ref": "#/definitions/schema"
                                         },
                                         {
                                             "properties": {
@@ -907,17 +907,17 @@
                                 "correlationId": {
                                     "oneOf": [
                                         {
-                                            "$ref": "http://asyncapi.com/definitions/2.1.0/Reference.json"
+                                            "$ref": "#/definitions/Reference"
                                         },
                                         {
-                                            "$ref": "http://asyncapi.com/definitions/2.1.0/correlationId.json"
+                                            "$ref": "#/definitions/correlationId"
                                         }
                                     ]
                                 },
                                 "tags": {
                                     "type": "array",
                                     "items": {
-                                        "$ref": "http://asyncapi.com/definitions/2.1.0/tag.json"
+                                        "$ref": "#/definitions/tag"
                                     },
                                     "uniqueItems": true
                                 },
@@ -938,7 +938,7 @@
                                     "description": "A longer description of the message. CommonMark is allowed."
                                 },
                                 "externalDocs": {
-                                    "$ref": "http://asyncapi.com/definitions/2.1.0/externalDocs.json"
+                                    "$ref": "#/definitions/externalDocs"
                                 },
                                 "deprecated": {
                                     "type": "boolean",
@@ -978,17 +978,17 @@
                                     }
                                 },
                                 "bindings": {
-                                    "$ref": "http://asyncapi.com/definitions/2.1.0/bindingsObject.json"
+                                    "$ref": "#/definitions/bindingsObject"
                                 },
                                 "traits": {
                                     "type": "array",
                                     "items": {
                                         "oneOf": [
                                             {
-                                                "$ref": "http://asyncapi.com/definitions/2.1.0/Reference.json"
+                                                "$ref": "#/definitions/Reference"
                                             },
                                             {
-                                                "$ref": "http://asyncapi.com/definitions/2.1.0/messageTrait.json"
+                                                "$ref": "#/definitions/messageTrait"
                                             },
                                             {
                                                 "type": "array",
@@ -996,10 +996,10 @@
                                                     {
                                                         "oneOf": [
                                                             {
-                                                                "$ref": "http://asyncapi.com/definitions/2.1.0/Reference.json"
+                                                                "$ref": "#/definitions/Reference"
                                                             },
                                                             {
-                                                                "$ref": "http://asyncapi.com/definitions/2.1.0/messageTrait.json"
+                                                                "$ref": "#/definitions/messageTrait"
                                                             }
                                                         ]
                                                     },
@@ -1018,7 +1018,7 @@
                 }
             ]
         },
-        "http://asyncapi.com/definitions/2.1.0/correlationId.json": {
+        "correlationId": {
             "$id": "http://asyncapi.com/definitions/2.1.0/correlationId.json",
             "type": "object",
             "required": [
@@ -1027,7 +1027,7 @@
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
@@ -1042,13 +1042,13 @@
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.1.0/messageTrait.json": {
+        "messageTrait": {
             "$id": "http://asyncapi.com/definitions/2.1.0/messageTrait.json",
             "type": "object",
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
@@ -1061,7 +1061,7 @@
                 "headers": {
                     "allOf": [
                         {
-                            "$ref": "http://asyncapi.com/definitions/2.1.0/schema.json"
+                            "$ref": "#/definitions/schema"
                         },
                         {
                             "properties": {
@@ -1075,17 +1075,17 @@
                 "correlationId": {
                     "oneOf": [
                         {
-                            "$ref": "http://asyncapi.com/definitions/2.1.0/Reference.json"
+                            "$ref": "#/definitions/Reference"
                         },
                         {
-                            "$ref": "http://asyncapi.com/definitions/2.1.0/correlationId.json"
+                            "$ref": "#/definitions/correlationId"
                         }
                     ]
                 },
                 "tags": {
                     "type": "array",
                     "items": {
-                        "$ref": "http://asyncapi.com/definitions/2.1.0/tag.json"
+                        "$ref": "#/definitions/tag"
                     },
                     "uniqueItems": true
                 },
@@ -1106,7 +1106,7 @@
                     "description": "A longer description of the message. CommonMark is allowed."
                 },
                 "externalDocs": {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/externalDocs.json"
+                    "$ref": "#/definitions/externalDocs"
                 },
                 "deprecated": {
                     "type": "boolean",
@@ -1146,26 +1146,26 @@
                     }
                 },
                 "bindings": {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/bindingsObject.json"
+                    "$ref": "#/definitions/bindingsObject"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.1.0/components.json": {
+        "components": {
             "$id": "http://asyncapi.com/definitions/2.1.0/components.json",
             "type": "object",
             "description": "An object to hold a set of reusable objects for different aspects of the AsyncAPI Specification.",
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
                 "schemas": {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/schemas.json"
+                    "$ref": "#/definitions/schemas"
                 },
                 "messages": {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/messages.json"
+                    "$ref": "#/definitions/messages"
                 },
                 "securitySchemes": {
                     "type": "object",
@@ -1173,17 +1173,17 @@
                         "^[\\w\\d\\.\\-_]+$": {
                             "oneOf": [
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.1.0/Reference.json"
+                                    "$ref": "#/definitions/Reference"
                                 },
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.1.0/SecurityScheme.json"
+                                    "$ref": "#/definitions/SecurityScheme"
                                 }
                             ]
                         }
                     }
                 },
                 "parameters": {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/parameters.json"
+                    "$ref": "#/definitions/parameters"
                 },
                 "correlationIds": {
                     "type": "object",
@@ -1191,10 +1191,10 @@
                         "^[\\w\\d\\.\\-_]+$": {
                             "oneOf": [
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.1.0/Reference.json"
+                                    "$ref": "#/definitions/Reference"
                                 },
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.1.0/correlationId.json"
+                                    "$ref": "#/definitions/correlationId"
                                 }
                             ]
                         }
@@ -1203,90 +1203,90 @@
                 "operationTraits": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "http://asyncapi.com/definitions/2.1.0/operationTrait.json"
+                        "$ref": "#/definitions/operationTrait"
                     }
                 },
                 "messageTraits": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "http://asyncapi.com/definitions/2.1.0/messageTrait.json"
+                        "$ref": "#/definitions/messageTrait"
                     }
                 },
                 "serverBindings": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "http://asyncapi.com/definitions/2.1.0/bindingsObject.json"
+                        "$ref": "#/definitions/bindingsObject"
                     }
                 },
                 "channelBindings": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "http://asyncapi.com/definitions/2.1.0/bindingsObject.json"
+                        "$ref": "#/definitions/bindingsObject"
                     }
                 },
                 "operationBindings": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "http://asyncapi.com/definitions/2.1.0/bindingsObject.json"
+                        "$ref": "#/definitions/bindingsObject"
                     }
                 },
                 "messageBindings": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "http://asyncapi.com/definitions/2.1.0/bindingsObject.json"
+                        "$ref": "#/definitions/bindingsObject"
                     }
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.1.0/schemas.json": {
+        "schemas": {
             "$id": "http://asyncapi.com/definitions/2.1.0/schemas.json",
             "type": "object",
             "additionalProperties": {
-                "$ref": "http://asyncapi.com/definitions/2.1.0/schema.json"
+                "$ref": "#/definitions/schema"
             },
             "description": "JSON objects describing schemas the API uses."
         },
-        "http://asyncapi.com/definitions/2.1.0/messages.json": {
+        "messages": {
             "$id": "http://asyncapi.com/definitions/2.1.0/messages.json",
             "type": "object",
             "additionalProperties": {
-                "$ref": "http://asyncapi.com/definitions/2.1.0/message.json"
+                "$ref": "#/definitions/message"
             },
             "description": "JSON objects describing the messages being consumed and produced by the API."
         },
-        "http://asyncapi.com/definitions/2.1.0/SecurityScheme.json": {
+        "SecurityScheme": {
             "$id": "http://asyncapi.com/definitions/2.1.0/SecurityScheme.json",
             "oneOf": [
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/userPassword.json"
+                    "$ref": "#/definitions/userPassword"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/apiKey.json"
+                    "$ref": "#/definitions/apiKey"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/X509.json"
+                    "$ref": "#/definitions/X509"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/symmetricEncryption.json"
+                    "$ref": "#/definitions/symmetricEncryption"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/asymmetricEncryption.json"
+                    "$ref": "#/definitions/asymmetricEncryption"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/HTTPSecurityScheme.json"
+                    "$ref": "#/definitions/HTTPSecurityScheme"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/oauth2Flows.json"
+                    "$ref": "#/definitions/oauth2Flows"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/openIdConnect.json"
+                    "$ref": "#/definitions/openIdConnect"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/SaslSecurityScheme.json"
+                    "$ref": "#/definitions/SaslSecurityScheme"
                 }
             ]
         },
-        "http://asyncapi.com/definitions/2.1.0/userPassword.json": {
+        "userPassword": {
             "$id": "http://asyncapi.com/definitions/2.1.0/userPassword.json",
             "type": "object",
             "required": [
@@ -1305,12 +1305,12 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.1.0/apiKey.json": {
+        "apiKey": {
             "$id": "http://asyncapi.com/definitions/2.1.0/apiKey.json",
             "type": "object",
             "required": [
@@ -1337,12 +1337,12 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.1.0/X509.json": {
+        "X509": {
             "$id": "http://asyncapi.com/definitions/2.1.0/X509.json",
             "type": "object",
             "required": [
@@ -1361,12 +1361,12 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.1.0/symmetricEncryption.json": {
+        "symmetricEncryption": {
             "$id": "http://asyncapi.com/definitions/2.1.0/symmetricEncryption.json",
             "type": "object",
             "required": [
@@ -1385,12 +1385,12 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.1.0/asymmetricEncryption.json": {
+        "asymmetricEncryption": {
             "$id": "http://asyncapi.com/definitions/2.1.0/asymmetricEncryption.json",
             "type": "object",
             "required": [
@@ -1409,26 +1409,26 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.1.0/HTTPSecurityScheme.json": {
+        "HTTPSecurityScheme": {
             "$id": "http://asyncapi.com/definitions/2.1.0/HTTPSecurityScheme.json",
             "oneOf": [
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/NonBearerHTTPSecurityScheme.json"
+                    "$ref": "#/definitions/NonBearerHTTPSecurityScheme"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/BearerHTTPSecurityScheme.json"
+                    "$ref": "#/definitions/BearerHTTPSecurityScheme"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/APIKeyHTTPSecurityScheme.json"
+                    "$ref": "#/definitions/APIKeyHTTPSecurityScheme"
                 }
             ]
         },
-        "http://asyncapi.com/definitions/2.1.0/NonBearerHTTPSecurityScheme.json": {
+        "NonBearerHTTPSecurityScheme": {
             "$id": "http://asyncapi.com/definitions/2.1.0/NonBearerHTTPSecurityScheme.json",
             "not": {
                 "type": "object",
@@ -1462,12 +1462,12 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.1.0/BearerHTTPSecurityScheme.json": {
+        "BearerHTTPSecurityScheme": {
             "$id": "http://asyncapi.com/definitions/2.1.0/BearerHTTPSecurityScheme.json",
             "type": "object",
             "required": [
@@ -1496,12 +1496,12 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.1.0/APIKeyHTTPSecurityScheme.json": {
+        "APIKeyHTTPSecurityScheme": {
             "$id": "http://asyncapi.com/definitions/2.1.0/APIKeyHTTPSecurityScheme.json",
             "type": "object",
             "required": [
@@ -1533,12 +1533,12 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.1.0/oauth2Flows.json": {
+        "oauth2Flows": {
             "$id": "http://asyncapi.com/definitions/2.1.0/oauth2Flows.json",
             "type": "object",
             "required": [
@@ -1561,7 +1561,7 @@
                         "implicit": {
                             "allOf": [
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.1.0/oauth2Flow.json"
+                                    "$ref": "#/definitions/oauth2Flow"
                                 },
                                 {
                                     "required": [
@@ -1581,7 +1581,7 @@
                         "password": {
                             "allOf": [
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.1.0/oauth2Flow.json"
+                                    "$ref": "#/definitions/oauth2Flow"
                                 },
                                 {
                                     "required": [
@@ -1601,7 +1601,7 @@
                         "clientCredentials": {
                             "allOf": [
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.1.0/oauth2Flow.json"
+                                    "$ref": "#/definitions/oauth2Flow"
                                 },
                                 {
                                     "required": [
@@ -1621,7 +1621,7 @@
                         "authorizationCode": {
                             "allOf": [
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.1.0/oauth2Flow.json"
+                                    "$ref": "#/definitions/oauth2Flow"
                                 },
                                 {
                                     "required": [
@@ -1638,11 +1638,11 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.1.0/oauth2Flow.json": {
+        "oauth2Flow": {
             "$id": "http://asyncapi.com/definitions/2.1.0/oauth2Flow.json",
             "type": "object",
             "properties": {
@@ -1659,24 +1659,24 @@
                     "format": "uri"
                 },
                 "scopes": {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/oauth2Scopes.json"
+                    "$ref": "#/definitions/oauth2Scopes"
                 }
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.1.0/oauth2Scopes.json": {
+        "oauth2Scopes": {
             "$id": "http://asyncapi.com/definitions/2.1.0/oauth2Scopes.json",
             "type": "object",
             "additionalProperties": {
                 "type": "string"
             }
         },
-        "http://asyncapi.com/definitions/2.1.0/openIdConnect.json": {
+        "openIdConnect": {
             "$id": "http://asyncapi.com/definitions/2.1.0/openIdConnect.json",
             "type": "object",
             "required": [
@@ -1700,26 +1700,26 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.1.0/SaslSecurityScheme.json": {
+        "SaslSecurityScheme": {
             "$id": "http://asyncapi.com/definitions/2.1.0/SaslSecurityScheme.json",
             "oneOf": [
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/SaslPlainSecurityScheme.json"
+                    "$ref": "#/definitions/SaslPlainSecurityScheme"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/SaslScramSecurityScheme.json"
+                    "$ref": "#/definitions/SaslScramSecurityScheme"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/SaslGssapiSecurityScheme.json"
+                    "$ref": "#/definitions/SaslGssapiSecurityScheme"
                 }
             ]
         },
-        "http://asyncapi.com/definitions/2.1.0/SaslPlainSecurityScheme.json": {
+        "SaslPlainSecurityScheme": {
             "$id": "http://asyncapi.com/definitions/2.1.0/SaslPlainSecurityScheme.json",
             "type": "object",
             "required": [
@@ -1738,12 +1738,12 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.1.0/SaslScramSecurityScheme.json": {
+        "SaslScramSecurityScheme": {
             "$id": "http://asyncapi.com/definitions/2.1.0/SaslScramSecurityScheme.json",
             "type": "object",
             "required": [
@@ -1763,12 +1763,12 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.1.0/SaslGssapiSecurityScheme.json": {
+        "SaslGssapiSecurityScheme": {
             "$id": "http://asyncapi.com/definitions/2.1.0/SaslGssapiSecurityScheme.json",
             "type": "object",
             "required": [
@@ -1787,16 +1787,16 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.1.0/parameters.json": {
+        "parameters": {
             "$id": "http://asyncapi.com/definitions/2.1.0/parameters.json",
             "type": "object",
             "additionalProperties": {
-                "$ref": "http://asyncapi.com/definitions/2.1.0/parameter.json"
+                "$ref": "#/definitions/parameter"
             },
             "description": "JSON objects describing re-usable channel parameters."
         }

--- a/schemas/2.2.0.json
+++ b/schemas/2.2.0.json
@@ -11,7 +11,7 @@
     "additionalProperties": false,
     "patternProperties": {
         "^x-[\\w\\d\\.\\x2d_]+$": {
-            "$ref": "http://asyncapi.com/definitions/2.2.0/specificationExtension.json"
+            "$ref": "#/definitions/specificationExtension"
         }
     },
     "properties": {
@@ -28,42 +28,42 @@
             "format": "uri"
         },
         "info": {
-            "$ref": "http://asyncapi.com/definitions/2.2.0/info.json"
+            "$ref": "#/definitions/info"
         },
         "servers": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "http://asyncapi.com/definitions/2.2.0/server.json"
+                "$ref": "#/definitions/server"
             }
         },
         "defaultContentType": {
             "type": "string"
         },
         "channels": {
-            "$ref": "http://asyncapi.com/definitions/2.2.0/channels.json"
+            "$ref": "#/definitions/channels"
         },
         "components": {
-            "$ref": "http://asyncapi.com/definitions/2.2.0/components.json"
+            "$ref": "#/definitions/components"
         },
         "tags": {
             "type": "array",
             "items": {
-                "$ref": "http://asyncapi.com/definitions/2.2.0/tag.json"
+                "$ref": "#/definitions/tag"
             },
             "uniqueItems": true
         },
         "externalDocs": {
-            "$ref": "http://asyncapi.com/definitions/2.2.0/externalDocs.json"
+            "$ref": "#/definitions/externalDocs"
         }
     },
     "definitions": {
-        "http://asyncapi.com/definitions/2.2.0/specificationExtension.json": {
+        "specificationExtension": {
             "$id": "http://asyncapi.com/definitions/2.2.0/specificationExtension.json",
             "description": "Any property starting with x- is valid.",
             "additionalProperties": true,
             "additionalItems": true
         },
-        "http://asyncapi.com/definitions/2.2.0/info.json": {
+        "info": {
             "$id": "http://asyncapi.com/definitions/2.2.0/info.json",
             "type": "object",
             "description": "General information about the API.",
@@ -74,7 +74,7 @@
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
@@ -96,14 +96,14 @@
                     "format": "uri"
                 },
                 "contact": {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/contact.json"
+                    "$ref": "#/definitions/contact"
                 },
                 "license": {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/license.json"
+                    "$ref": "#/definitions/license"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.2.0/contact.json": {
+        "contact": {
             "$id": "http://asyncapi.com/definitions/2.2.0/contact.json",
             "type": "object",
             "description": "Contact information for the owners of the API.",
@@ -126,11 +126,11 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.2.0/license.json": {
+        "license": {
             "$id": "http://asyncapi.com/definitions/2.2.0/license.json",
             "type": "object",
             "required": [
@@ -150,11 +150,11 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.2.0/server.json": {
+        "server": {
             "$id": "http://asyncapi.com/definitions/2.2.0/server.json",
             "type": "object",
             "description": "An object representing a Server.",
@@ -165,7 +165,7 @@
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
@@ -183,34 +183,34 @@
                     "type": "string"
                 },
                 "variables": {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/serverVariables.json"
+                    "$ref": "#/definitions/serverVariables"
                 },
                 "security": {
                     "type": "array",
                     "items": {
-                        "$ref": "http://asyncapi.com/definitions/2.2.0/SecurityRequirement.json"
+                        "$ref": "#/definitions/SecurityRequirement"
                     }
                 },
                 "bindings": {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/bindingsObject.json"
+                    "$ref": "#/definitions/bindingsObject"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.2.0/serverVariables.json": {
+        "serverVariables": {
             "$id": "http://asyncapi.com/definitions/2.2.0/serverVariables.json",
             "type": "object",
             "additionalProperties": {
-                "$ref": "http://asyncapi.com/definitions/2.2.0/serverVariable.json"
+                "$ref": "#/definitions/serverVariable"
             }
         },
-        "http://asyncapi.com/definitions/2.2.0/serverVariable.json": {
+        "serverVariable": {
             "$id": "http://asyncapi.com/definitions/2.2.0/serverVariable.json",
             "type": "object",
             "description": "An object representing a Server Variable for server URL template substitution.",
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
@@ -235,7 +235,7 @@
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.2.0/SecurityRequirement.json": {
+        "SecurityRequirement": {
             "$id": "http://asyncapi.com/definitions/2.2.0/SecurityRequirement.json",
             "type": "object",
             "additionalProperties": {
@@ -246,7 +246,7 @@
                 "uniqueItems": true
             }
         },
-        "http://asyncapi.com/definitions/2.2.0/bindingsObject.json": {
+        "bindingsObject": {
             "$id": "http://asyncapi.com/definitions/2.2.0/bindingsObject.json",
             "type": "object",
             "additionalProperties": true,
@@ -268,7 +268,7 @@
                 "ibmmq": {}
             }
         },
-        "http://asyncapi.com/definitions/2.2.0/channels.json": {
+        "channels": {
             "$id": "http://asyncapi.com/definitions/2.2.0/channels.json",
             "type": "object",
             "propertyNames": {
@@ -277,26 +277,26 @@
                 "minLength": 1
             },
             "additionalProperties": {
-                "$ref": "http://asyncapi.com/definitions/2.2.0/channelItem.json"
+                "$ref": "#/definitions/channelItem"
             }
         },
-        "http://asyncapi.com/definitions/2.2.0/channelItem.json": {
+        "channelItem": {
             "$id": "http://asyncapi.com/definitions/2.2.0/channelItem.json",
             "type": "object",
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
                 "$ref": {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/ReferenceObject.json"
+                    "$ref": "#/definitions/ReferenceObject"
                 },
                 "parameters": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "http://asyncapi.com/definitions/2.2.0/parameter.json"
+                        "$ref": "#/definitions/parameter"
                     }
                 },
                 "description": {
@@ -312,31 +312,31 @@
                     "uniqueItems": true
                 },
                 "publish": {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/operation.json"
+                    "$ref": "#/definitions/operation"
                 },
                 "subscribe": {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/operation.json"
+                    "$ref": "#/definitions/operation"
                 },
                 "deprecated": {
                     "type": "boolean",
                     "default": false
                 },
                 "bindings": {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/bindingsObject.json"
+                    "$ref": "#/definitions/bindingsObject"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.2.0/ReferenceObject.json": {
+        "ReferenceObject": {
             "$id": "http://asyncapi.com/definitions/2.2.0/ReferenceObject.json",
             "type": "string",
             "format": "uri-reference"
         },
-        "http://asyncapi.com/definitions/2.2.0/parameter.json": {
+        "parameter": {
             "$id": "http://asyncapi.com/definitions/2.2.0/parameter.json",
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
@@ -345,7 +345,7 @@
                     "description": "A brief description of the parameter. This could contain examples of use. GitHub Flavored Markdown is allowed."
                 },
                 "schema": {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/schema.json"
+                    "$ref": "#/definitions/schema"
                 },
                 "location": {
                     "type": "string",
@@ -353,27 +353,27 @@
                     "pattern": "^\\$message\\.(header|payload)#(\\/(([^\\/~])|(~[01]))*)*"
                 },
                 "$ref": {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/ReferenceObject.json"
+                    "$ref": "#/definitions/ReferenceObject"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.2.0/schema.json": {
+        "schema": {
             "$id": "http://asyncapi.com/definitions/2.2.0/schema.json",
             "allOf": [
                 {
-                    "$ref": "http://json-schema.org/draft-07/schema#"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 {
                     "patternProperties": {
                         "^x-[\\w\\d\\.\\x2d_]+$": {
-                            "$ref": "http://asyncapi.com/definitions/2.2.0/specificationExtension.json"
+                            "$ref": "#/definitions/specificationExtension"
                         }
                     },
                     "properties": {
                         "additionalProperties": {
                             "anyOf": [
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.2.0/schema.json"
+                                    "$ref": "#/definitions/schema"
                                 },
                                 {
                                     "type": "boolean"
@@ -384,13 +384,13 @@
                         "items": {
                             "anyOf": [
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.2.0/schema.json"
+                                    "$ref": "#/definitions/schema"
                                 },
                                 {
                                     "type": "array",
                                     "minItems": 1,
                                     "items": {
-                                        "$ref": "http://asyncapi.com/definitions/2.2.0/schema.json"
+                                        "$ref": "#/definitions/schema"
                                     }
                                 }
                             ],
@@ -400,51 +400,51 @@
                             "type": "array",
                             "minItems": 1,
                             "items": {
-                                "$ref": "http://asyncapi.com/definitions/2.2.0/schema.json"
+                                "$ref": "#/definitions/schema"
                             }
                         },
                         "oneOf": {
                             "type": "array",
                             "minItems": 1,
                             "items": {
-                                "$ref": "http://asyncapi.com/definitions/2.2.0/schema.json"
+                                "$ref": "#/definitions/schema"
                             }
                         },
                         "anyOf": {
                             "type": "array",
                             "minItems": 1,
                             "items": {
-                                "$ref": "http://asyncapi.com/definitions/2.2.0/schema.json"
+                                "$ref": "#/definitions/schema"
                             }
                         },
                         "not": {
-                            "$ref": "http://asyncapi.com/definitions/2.2.0/schema.json"
+                            "$ref": "#/definitions/schema"
                         },
                         "properties": {
                             "type": "object",
                             "additionalProperties": {
-                                "$ref": "http://asyncapi.com/definitions/2.2.0/schema.json"
+                                "$ref": "#/definitions/schema"
                             },
                             "default": {}
                         },
                         "patternProperties": {
                             "type": "object",
                             "additionalProperties": {
-                                "$ref": "http://asyncapi.com/definitions/2.2.0/schema.json"
+                                "$ref": "#/definitions/schema"
                             },
                             "default": {}
                         },
                         "propertyNames": {
-                            "$ref": "http://asyncapi.com/definitions/2.2.0/schema.json"
+                            "$ref": "#/definitions/schema"
                         },
                         "contains": {
-                            "$ref": "http://asyncapi.com/definitions/2.2.0/schema.json"
+                            "$ref": "#/definitions/schema"
                         },
                         "discriminator": {
                             "type": "string"
                         },
                         "externalDocs": {
-                            "$ref": "http://asyncapi.com/definitions/2.2.0/externalDocs.json"
+                            "$ref": "#/definitions/externalDocs"
                         },
                         "deprecated": {
                             "type": "boolean",
@@ -454,7 +454,7 @@
                 }
             ]
         },
-        "http://json-schema.org/draft-07/schema": {
+        "json-schema-draft-07-schema": {
             "$id": "http://json-schema.org/draft-07/schema",
             "title": "Core schema meta-schema",
             "definitions": {
@@ -462,7 +462,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#"
+                        "$ref": "#/definitions/json-schema-draft-07-schema"
                     }
                 },
                 "nonNegativeInteger": {
@@ -472,7 +472,7 @@
                 "nonNegativeIntegerDefault0": {
                     "allOf": [
                         {
-                            "$ref": "#/definitions/nonNegativeInteger"
+                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/nonNegativeInteger"
                         },
                         {
                             "default": 0
@@ -555,72 +555,72 @@
                     "type": "number"
                 },
                 "maxLength": {
-                    "$ref": "#/definitions/nonNegativeInteger"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/nonNegativeInteger"
                 },
                 "minLength": {
-                    "$ref": "#/definitions/nonNegativeIntegerDefault0"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/nonNegativeIntegerDefault0"
                 },
                 "pattern": {
                     "type": "string",
                     "format": "regex"
                 },
                 "additionalItems": {
-                    "$ref": "#"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "items": {
                     "anyOf": [
                         {
-                            "$ref": "#"
+                            "$ref": "#/definitions/json-schema-draft-07-schema"
                         },
                         {
-                            "$ref": "#/definitions/schemaArray"
+                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/schemaArray"
                         }
                     ],
                     "default": true
                 },
                 "maxItems": {
-                    "$ref": "#/definitions/nonNegativeInteger"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/nonNegativeInteger"
                 },
                 "minItems": {
-                    "$ref": "#/definitions/nonNegativeIntegerDefault0"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/nonNegativeIntegerDefault0"
                 },
                 "uniqueItems": {
                     "type": "boolean",
                     "default": false
                 },
                 "contains": {
-                    "$ref": "#"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "maxProperties": {
-                    "$ref": "#/definitions/nonNegativeInteger"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/nonNegativeInteger"
                 },
                 "minProperties": {
-                    "$ref": "#/definitions/nonNegativeIntegerDefault0"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/nonNegativeIntegerDefault0"
                 },
                 "required": {
-                    "$ref": "#/definitions/stringArray"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/stringArray"
                 },
                 "additionalProperties": {
-                    "$ref": "#"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "definitions": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "#"
+                        "$ref": "#/definitions/json-schema-draft-07-schema"
                     },
                     "default": {}
                 },
                 "properties": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "#"
+                        "$ref": "#/definitions/json-schema-draft-07-schema"
                     },
                     "default": {}
                 },
                 "patternProperties": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "#"
+                        "$ref": "#/definitions/json-schema-draft-07-schema"
                     },
                     "propertyNames": {
                         "format": "regex"
@@ -632,16 +632,16 @@
                     "additionalProperties": {
                         "anyOf": [
                             {
-                                "$ref": "#"
+                                "$ref": "#/definitions/json-schema-draft-07-schema"
                             },
                             {
-                                "$ref": "#/definitions/stringArray"
+                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/stringArray"
                             }
                         ]
                     }
                 },
                 "propertyNames": {
-                    "$ref": "#"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "const": true,
                 "enum": {
@@ -653,12 +653,12 @@
                 "type": {
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/simpleTypes"
+                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/simpleTypes"
                         },
                         {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/simpleTypes"
+                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/simpleTypes"
                             },
                             "minItems": 1,
                             "uniqueItems": true
@@ -675,30 +675,30 @@
                     "type": "string"
                 },
                 "if": {
-                    "$ref": "#"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "then": {
-                    "$ref": "#"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "else": {
-                    "$ref": "#"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "allOf": {
-                    "$ref": "#/definitions/schemaArray"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/schemaArray"
                 },
                 "anyOf": {
-                    "$ref": "#/definitions/schemaArray"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/schemaArray"
                 },
                 "oneOf": {
-                    "$ref": "#/definitions/schemaArray"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/schemaArray"
                 },
                 "not": {
-                    "$ref": "#"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 }
             },
             "default": true
         },
-        "http://asyncapi.com/definitions/2.2.0/externalDocs.json": {
+        "externalDocs": {
             "$id": "http://asyncapi.com/definitions/2.2.0/externalDocs.json",
             "type": "object",
             "additionalProperties": false,
@@ -717,17 +717,17 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.2.0/operation.json": {
+        "operation": {
             "$id": "http://asyncapi.com/definitions/2.2.0/operation.json",
             "type": "object",
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
@@ -736,10 +736,10 @@
                     "items": {
                         "oneOf": [
                             {
-                                "$ref": "http://asyncapi.com/definitions/2.2.0/Reference.json"
+                                "$ref": "#/definitions/Reference"
                             },
                             {
-                                "$ref": "http://asyncapi.com/definitions/2.2.0/operationTrait.json"
+                                "$ref": "#/definitions/operationTrait"
                             },
                             {
                                 "type": "array",
@@ -747,10 +747,10 @@
                                     {
                                         "oneOf": [
                                             {
-                                                "$ref": "http://asyncapi.com/definitions/2.2.0/Reference.json"
+                                                "$ref": "#/definitions/Reference"
                                             },
                                             {
-                                                "$ref": "http://asyncapi.com/definitions/2.2.0/operationTrait.json"
+                                                "$ref": "#/definitions/operationTrait"
                                             }
                                         ]
                                     },
@@ -772,25 +772,25 @@
                 "tags": {
                     "type": "array",
                     "items": {
-                        "$ref": "http://asyncapi.com/definitions/2.2.0/tag.json"
+                        "$ref": "#/definitions/tag"
                     },
                     "uniqueItems": true
                 },
                 "externalDocs": {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/externalDocs.json"
+                    "$ref": "#/definitions/externalDocs"
                 },
                 "operationId": {
                     "type": "string"
                 },
                 "bindings": {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/bindingsObject.json"
+                    "$ref": "#/definitions/bindingsObject"
                 },
                 "message": {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/message.json"
+                    "$ref": "#/definitions/message"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.2.0/Reference.json": {
+        "Reference": {
             "$id": "http://asyncapi.com/definitions/2.2.0/Reference.json",
             "type": "object",
             "required": [
@@ -798,17 +798,17 @@
             ],
             "properties": {
                 "$ref": {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/ReferenceObject.json"
+                    "$ref": "#/definitions/ReferenceObject"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.2.0/operationTrait.json": {
+        "operationTrait": {
             "$id": "http://asyncapi.com/definitions/2.2.0/operationTrait.json",
             "type": "object",
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
@@ -821,22 +821,22 @@
                 "tags": {
                     "type": "array",
                     "items": {
-                        "$ref": "http://asyncapi.com/definitions/2.2.0/tag.json"
+                        "$ref": "#/definitions/tag"
                     },
                     "uniqueItems": true
                 },
                 "externalDocs": {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/externalDocs.json"
+                    "$ref": "#/definitions/externalDocs"
                 },
                 "operationId": {
                     "type": "string"
                 },
                 "bindings": {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/bindingsObject.json"
+                    "$ref": "#/definitions/bindingsObject"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.2.0/tag.json": {
+        "tag": {
             "$id": "http://asyncapi.com/definitions/2.2.0/tag.json",
             "type": "object",
             "additionalProperties": false,
@@ -851,20 +851,20 @@
                     "type": "string"
                 },
                 "externalDocs": {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/externalDocs.json"
+                    "$ref": "#/definitions/externalDocs"
                 }
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.2.0/message.json": {
+        "message": {
             "$id": "http://asyncapi.com/definitions/2.2.0/message.json",
             "oneOf": [
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/Reference.json"
+                    "$ref": "#/definitions/Reference"
                 },
                 {
                     "oneOf": [
@@ -878,7 +878,7 @@
                                 "oneOf": {
                                     "type": "array",
                                     "items": {
-                                        "$ref": "http://asyncapi.com/definitions/2.2.0/message.json"
+                                        "$ref": "#/definitions/message"
                                     }
                                 }
                             }
@@ -888,7 +888,7 @@
                             "additionalProperties": false,
                             "patternProperties": {
                                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                                    "$ref": "http://asyncapi.com/definitions/2.2.0/specificationExtension.json"
+                                    "$ref": "#/definitions/specificationExtension"
                                 }
                             },
                             "properties": {
@@ -901,7 +901,7 @@
                                 "headers": {
                                     "allOf": [
                                         {
-                                            "$ref": "http://asyncapi.com/definitions/2.2.0/schema.json"
+                                            "$ref": "#/definitions/schema"
                                         },
                                         {
                                             "properties": {
@@ -916,17 +916,17 @@
                                 "correlationId": {
                                     "oneOf": [
                                         {
-                                            "$ref": "http://asyncapi.com/definitions/2.2.0/Reference.json"
+                                            "$ref": "#/definitions/Reference"
                                         },
                                         {
-                                            "$ref": "http://asyncapi.com/definitions/2.2.0/correlationId.json"
+                                            "$ref": "#/definitions/correlationId"
                                         }
                                     ]
                                 },
                                 "tags": {
                                     "type": "array",
                                     "items": {
-                                        "$ref": "http://asyncapi.com/definitions/2.2.0/tag.json"
+                                        "$ref": "#/definitions/tag"
                                     },
                                     "uniqueItems": true
                                 },
@@ -947,7 +947,7 @@
                                     "description": "A longer description of the message. CommonMark is allowed."
                                 },
                                 "externalDocs": {
-                                    "$ref": "http://asyncapi.com/definitions/2.2.0/externalDocs.json"
+                                    "$ref": "#/definitions/externalDocs"
                                 },
                                 "deprecated": {
                                     "type": "boolean",
@@ -987,17 +987,17 @@
                                     }
                                 },
                                 "bindings": {
-                                    "$ref": "http://asyncapi.com/definitions/2.2.0/bindingsObject.json"
+                                    "$ref": "#/definitions/bindingsObject"
                                 },
                                 "traits": {
                                     "type": "array",
                                     "items": {
                                         "oneOf": [
                                             {
-                                                "$ref": "http://asyncapi.com/definitions/2.2.0/Reference.json"
+                                                "$ref": "#/definitions/Reference"
                                             },
                                             {
-                                                "$ref": "http://asyncapi.com/definitions/2.2.0/messageTrait.json"
+                                                "$ref": "#/definitions/messageTrait"
                                             },
                                             {
                                                 "type": "array",
@@ -1005,10 +1005,10 @@
                                                     {
                                                         "oneOf": [
                                                             {
-                                                                "$ref": "http://asyncapi.com/definitions/2.2.0/Reference.json"
+                                                                "$ref": "#/definitions/Reference"
                                                             },
                                                             {
-                                                                "$ref": "http://asyncapi.com/definitions/2.2.0/messageTrait.json"
+                                                                "$ref": "#/definitions/messageTrait"
                                                             }
                                                         ]
                                                     },
@@ -1027,7 +1027,7 @@
                 }
             ]
         },
-        "http://asyncapi.com/definitions/2.2.0/correlationId.json": {
+        "correlationId": {
             "$id": "http://asyncapi.com/definitions/2.2.0/correlationId.json",
             "type": "object",
             "required": [
@@ -1036,7 +1036,7 @@
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
@@ -1051,13 +1051,13 @@
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.2.0/messageTrait.json": {
+        "messageTrait": {
             "$id": "http://asyncapi.com/definitions/2.2.0/messageTrait.json",
             "type": "object",
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
@@ -1070,7 +1070,7 @@
                 "headers": {
                     "allOf": [
                         {
-                            "$ref": "http://asyncapi.com/definitions/2.2.0/schema.json"
+                            "$ref": "#/definitions/schema"
                         },
                         {
                             "properties": {
@@ -1084,17 +1084,17 @@
                 "correlationId": {
                     "oneOf": [
                         {
-                            "$ref": "http://asyncapi.com/definitions/2.2.0/Reference.json"
+                            "$ref": "#/definitions/Reference"
                         },
                         {
-                            "$ref": "http://asyncapi.com/definitions/2.2.0/correlationId.json"
+                            "$ref": "#/definitions/correlationId"
                         }
                     ]
                 },
                 "tags": {
                     "type": "array",
                     "items": {
-                        "$ref": "http://asyncapi.com/definitions/2.2.0/tag.json"
+                        "$ref": "#/definitions/tag"
                     },
                     "uniqueItems": true
                 },
@@ -1115,7 +1115,7 @@
                     "description": "A longer description of the message. CommonMark is allowed."
                 },
                 "externalDocs": {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/externalDocs.json"
+                    "$ref": "#/definitions/externalDocs"
                 },
                 "deprecated": {
                     "type": "boolean",
@@ -1128,26 +1128,26 @@
                     }
                 },
                 "bindings": {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/bindingsObject.json"
+                    "$ref": "#/definitions/bindingsObject"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.2.0/components.json": {
+        "components": {
             "$id": "http://asyncapi.com/definitions/2.2.0/components.json",
             "type": "object",
             "description": "An object to hold a set of reusable objects for different aspects of the AsyncAPI Specification.",
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
                 "schemas": {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/schemas.json"
+                    "$ref": "#/definitions/schemas"
                 },
                 "messages": {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/messages.json"
+                    "$ref": "#/definitions/messages"
                 },
                 "securitySchemes": {
                     "type": "object",
@@ -1155,17 +1155,17 @@
                         "^[\\w\\d\\.\\-_]+$": {
                             "oneOf": [
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.2.0/Reference.json"
+                                    "$ref": "#/definitions/Reference"
                                 },
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.2.0/SecurityScheme.json"
+                                    "$ref": "#/definitions/SecurityScheme"
                                 }
                             ]
                         }
                     }
                 },
                 "parameters": {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/parameters.json"
+                    "$ref": "#/definitions/parameters"
                 },
                 "correlationIds": {
                     "type": "object",
@@ -1173,10 +1173,10 @@
                         "^[\\w\\d\\.\\-_]+$": {
                             "oneOf": [
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.2.0/Reference.json"
+                                    "$ref": "#/definitions/Reference"
                                 },
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.2.0/correlationId.json"
+                                    "$ref": "#/definitions/correlationId"
                                 }
                             ]
                         }
@@ -1185,90 +1185,90 @@
                 "operationTraits": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "http://asyncapi.com/definitions/2.2.0/operationTrait.json"
+                        "$ref": "#/definitions/operationTrait"
                     }
                 },
                 "messageTraits": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "http://asyncapi.com/definitions/2.2.0/messageTrait.json"
+                        "$ref": "#/definitions/messageTrait"
                     }
                 },
                 "serverBindings": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "http://asyncapi.com/definitions/2.2.0/bindingsObject.json"
+                        "$ref": "#/definitions/bindingsObject"
                     }
                 },
                 "channelBindings": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "http://asyncapi.com/definitions/2.2.0/bindingsObject.json"
+                        "$ref": "#/definitions/bindingsObject"
                     }
                 },
                 "operationBindings": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "http://asyncapi.com/definitions/2.2.0/bindingsObject.json"
+                        "$ref": "#/definitions/bindingsObject"
                     }
                 },
                 "messageBindings": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "http://asyncapi.com/definitions/2.2.0/bindingsObject.json"
+                        "$ref": "#/definitions/bindingsObject"
                     }
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.2.0/schemas.json": {
+        "schemas": {
             "$id": "http://asyncapi.com/definitions/2.2.0/schemas.json",
             "type": "object",
             "additionalProperties": {
-                "$ref": "http://asyncapi.com/definitions/2.2.0/schema.json"
+                "$ref": "#/definitions/schema"
             },
             "description": "JSON objects describing schemas the API uses."
         },
-        "http://asyncapi.com/definitions/2.2.0/messages.json": {
+        "messages": {
             "$id": "http://asyncapi.com/definitions/2.2.0/messages.json",
             "type": "object",
             "additionalProperties": {
-                "$ref": "http://asyncapi.com/definitions/2.2.0/message.json"
+                "$ref": "#/definitions/message"
             },
             "description": "JSON objects describing the messages being consumed and produced by the API."
         },
-        "http://asyncapi.com/definitions/2.2.0/SecurityScheme.json": {
+        "SecurityScheme": {
             "$id": "http://asyncapi.com/definitions/2.2.0/SecurityScheme.json",
             "oneOf": [
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/userPassword.json"
+                    "$ref": "#/definitions/userPassword"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/apiKey.json"
+                    "$ref": "#/definitions/apiKey"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/X509.json"
+                    "$ref": "#/definitions/X509"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/symmetricEncryption.json"
+                    "$ref": "#/definitions/symmetricEncryption"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/asymmetricEncryption.json"
+                    "$ref": "#/definitions/asymmetricEncryption"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/HTTPSecurityScheme.json"
+                    "$ref": "#/definitions/HTTPSecurityScheme"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/oauth2Flows.json"
+                    "$ref": "#/definitions/oauth2Flows"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/openIdConnect.json"
+                    "$ref": "#/definitions/openIdConnect"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/SaslSecurityScheme.json"
+                    "$ref": "#/definitions/SaslSecurityScheme"
                 }
             ]
         },
-        "http://asyncapi.com/definitions/2.2.0/userPassword.json": {
+        "userPassword": {
             "$id": "http://asyncapi.com/definitions/2.2.0/userPassword.json",
             "type": "object",
             "required": [
@@ -1287,12 +1287,12 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.2.0/apiKey.json": {
+        "apiKey": {
             "$id": "http://asyncapi.com/definitions/2.2.0/apiKey.json",
             "type": "object",
             "required": [
@@ -1319,12 +1319,12 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.2.0/X509.json": {
+        "X509": {
             "$id": "http://asyncapi.com/definitions/2.2.0/X509.json",
             "type": "object",
             "required": [
@@ -1343,12 +1343,12 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.2.0/symmetricEncryption.json": {
+        "symmetricEncryption": {
             "$id": "http://asyncapi.com/definitions/2.2.0/symmetricEncryption.json",
             "type": "object",
             "required": [
@@ -1367,12 +1367,12 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.2.0/asymmetricEncryption.json": {
+        "asymmetricEncryption": {
             "$id": "http://asyncapi.com/definitions/2.2.0/asymmetricEncryption.json",
             "type": "object",
             "required": [
@@ -1391,26 +1391,26 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.2.0/HTTPSecurityScheme.json": {
+        "HTTPSecurityScheme": {
             "$id": "http://asyncapi.com/definitions/2.2.0/HTTPSecurityScheme.json",
             "oneOf": [
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/NonBearerHTTPSecurityScheme.json"
+                    "$ref": "#/definitions/NonBearerHTTPSecurityScheme"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/BearerHTTPSecurityScheme.json"
+                    "$ref": "#/definitions/BearerHTTPSecurityScheme"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/APIKeyHTTPSecurityScheme.json"
+                    "$ref": "#/definitions/APIKeyHTTPSecurityScheme"
                 }
             ]
         },
-        "http://asyncapi.com/definitions/2.2.0/NonBearerHTTPSecurityScheme.json": {
+        "NonBearerHTTPSecurityScheme": {
             "$id": "http://asyncapi.com/definitions/2.2.0/NonBearerHTTPSecurityScheme.json",
             "not": {
                 "type": "object",
@@ -1444,12 +1444,12 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.2.0/BearerHTTPSecurityScheme.json": {
+        "BearerHTTPSecurityScheme": {
             "$id": "http://asyncapi.com/definitions/2.2.0/BearerHTTPSecurityScheme.json",
             "type": "object",
             "required": [
@@ -1478,12 +1478,12 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.2.0/APIKeyHTTPSecurityScheme.json": {
+        "APIKeyHTTPSecurityScheme": {
             "$id": "http://asyncapi.com/definitions/2.2.0/APIKeyHTTPSecurityScheme.json",
             "type": "object",
             "required": [
@@ -1515,12 +1515,12 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.2.0/oauth2Flows.json": {
+        "oauth2Flows": {
             "$id": "http://asyncapi.com/definitions/2.2.0/oauth2Flows.json",
             "type": "object",
             "required": [
@@ -1543,7 +1543,7 @@
                         "implicit": {
                             "allOf": [
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.2.0/oauth2Flow.json"
+                                    "$ref": "#/definitions/oauth2Flow"
                                 },
                                 {
                                     "required": [
@@ -1563,7 +1563,7 @@
                         "password": {
                             "allOf": [
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.2.0/oauth2Flow.json"
+                                    "$ref": "#/definitions/oauth2Flow"
                                 },
                                 {
                                     "required": [
@@ -1583,7 +1583,7 @@
                         "clientCredentials": {
                             "allOf": [
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.2.0/oauth2Flow.json"
+                                    "$ref": "#/definitions/oauth2Flow"
                                 },
                                 {
                                     "required": [
@@ -1603,7 +1603,7 @@
                         "authorizationCode": {
                             "allOf": [
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.2.0/oauth2Flow.json"
+                                    "$ref": "#/definitions/oauth2Flow"
                                 },
                                 {
                                     "required": [
@@ -1620,11 +1620,11 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.2.0/oauth2Flow.json": {
+        "oauth2Flow": {
             "$id": "http://asyncapi.com/definitions/2.2.0/oauth2Flow.json",
             "type": "object",
             "properties": {
@@ -1641,24 +1641,24 @@
                     "format": "uri"
                 },
                 "scopes": {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/oauth2Scopes.json"
+                    "$ref": "#/definitions/oauth2Scopes"
                 }
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.2.0/oauth2Scopes.json": {
+        "oauth2Scopes": {
             "$id": "http://asyncapi.com/definitions/2.2.0/oauth2Scopes.json",
             "type": "object",
             "additionalProperties": {
                 "type": "string"
             }
         },
-        "http://asyncapi.com/definitions/2.2.0/openIdConnect.json": {
+        "openIdConnect": {
             "$id": "http://asyncapi.com/definitions/2.2.0/openIdConnect.json",
             "type": "object",
             "required": [
@@ -1682,26 +1682,26 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.2.0/SaslSecurityScheme.json": {
+        "SaslSecurityScheme": {
             "$id": "http://asyncapi.com/definitions/2.2.0/SaslSecurityScheme.json",
             "oneOf": [
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/SaslPlainSecurityScheme.json"
+                    "$ref": "#/definitions/SaslPlainSecurityScheme"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/SaslScramSecurityScheme.json"
+                    "$ref": "#/definitions/SaslScramSecurityScheme"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/SaslGssapiSecurityScheme.json"
+                    "$ref": "#/definitions/SaslGssapiSecurityScheme"
                 }
             ]
         },
-        "http://asyncapi.com/definitions/2.2.0/SaslPlainSecurityScheme.json": {
+        "SaslPlainSecurityScheme": {
             "$id": "http://asyncapi.com/definitions/2.2.0/SaslPlainSecurityScheme.json",
             "type": "object",
             "required": [
@@ -1720,12 +1720,12 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.2.0/SaslScramSecurityScheme.json": {
+        "SaslScramSecurityScheme": {
             "$id": "http://asyncapi.com/definitions/2.2.0/SaslScramSecurityScheme.json",
             "type": "object",
             "required": [
@@ -1745,12 +1745,12 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.2.0/SaslGssapiSecurityScheme.json": {
+        "SaslGssapiSecurityScheme": {
             "$id": "http://asyncapi.com/definitions/2.2.0/SaslGssapiSecurityScheme.json",
             "type": "object",
             "required": [
@@ -1769,16 +1769,16 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.2.0/parameters.json": {
+        "parameters": {
             "$id": "http://asyncapi.com/definitions/2.2.0/parameters.json",
             "type": "object",
             "additionalProperties": {
-                "$ref": "http://asyncapi.com/definitions/2.2.0/parameter.json"
+                "$ref": "#/definitions/parameter"
             },
             "description": "JSON objects describing re-usable channel parameters."
         }

--- a/schemas/2.3.0.json
+++ b/schemas/2.3.0.json
@@ -11,7 +11,7 @@
     "additionalProperties": false,
     "patternProperties": {
         "^x-[\\w\\d\\.\\x2d_]+$": {
-            "$ref": "http://asyncapi.com/definitions/2.3.0/specificationExtension.json"
+            "$ref": "#/definitions/specificationExtension"
         }
     },
     "properties": {
@@ -28,39 +28,39 @@
             "format": "uri"
         },
         "info": {
-            "$ref": "http://asyncapi.com/definitions/2.3.0/info.json"
+            "$ref": "#/definitions/info"
         },
         "servers": {
-            "$ref": "http://asyncapi.com/definitions/2.3.0/servers.json"
+            "$ref": "#/definitions/servers"
         },
         "defaultContentType": {
             "type": "string"
         },
         "channels": {
-            "$ref": "http://asyncapi.com/definitions/2.3.0/channels.json"
+            "$ref": "#/definitions/channels"
         },
         "components": {
-            "$ref": "http://asyncapi.com/definitions/2.3.0/components.json"
+            "$ref": "#/definitions/components"
         },
         "tags": {
             "type": "array",
             "items": {
-                "$ref": "http://asyncapi.com/definitions/2.3.0/tag.json"
+                "$ref": "#/definitions/tag"
             },
             "uniqueItems": true
         },
         "externalDocs": {
-            "$ref": "http://asyncapi.com/definitions/2.3.0/externalDocs.json"
+            "$ref": "#/definitions/externalDocs"
         }
     },
     "definitions": {
-        "http://asyncapi.com/definitions/2.3.0/specificationExtension.json": {
+        "specificationExtension": {
             "$id": "http://asyncapi.com/definitions/2.3.0/specificationExtension.json",
             "description": "Any property starting with x- is valid.",
             "additionalProperties": true,
             "additionalItems": true
         },
-        "http://asyncapi.com/definitions/2.3.0/info.json": {
+        "info": {
             "$id": "http://asyncapi.com/definitions/2.3.0/info.json",
             "type": "object",
             "description": "General information about the API.",
@@ -71,7 +71,7 @@
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
@@ -93,14 +93,14 @@
                     "format": "uri"
                 },
                 "contact": {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/contact.json"
+                    "$ref": "#/definitions/contact"
                 },
                 "license": {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/license.json"
+                    "$ref": "#/definitions/license"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.3.0/contact.json": {
+        "contact": {
             "$id": "http://asyncapi.com/definitions/2.3.0/contact.json",
             "type": "object",
             "description": "Contact information for the owners of the API.",
@@ -123,11 +123,11 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.3.0/license.json": {
+        "license": {
             "$id": "http://asyncapi.com/definitions/2.3.0/license.json",
             "type": "object",
             "required": [
@@ -147,26 +147,26 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.3.0/servers.json": {
+        "servers": {
             "$id": "http://asyncapi.com/definitions/2.3.0/servers.json",
             "description": "An object representing multiple servers.",
             "type": "object",
             "additionalProperties": {
                 "oneOf": [
                     {
-                        "$ref": "http://asyncapi.com/definitions/2.3.0/Reference.json"
+                        "$ref": "#/definitions/Reference"
                     },
                     {
-                        "$ref": "http://asyncapi.com/definitions/2.3.0/server.json"
+                        "$ref": "#/definitions/server"
                     }
                 ]
             }
         },
-        "http://asyncapi.com/definitions/2.3.0/Reference.json": {
+        "Reference": {
             "$id": "http://asyncapi.com/definitions/2.3.0/Reference.json",
             "type": "object",
             "required": [
@@ -174,16 +174,16 @@
             ],
             "properties": {
                 "$ref": {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/ReferenceObject.json"
+                    "$ref": "#/definitions/ReferenceObject"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.3.0/ReferenceObject.json": {
+        "ReferenceObject": {
             "$id": "http://asyncapi.com/definitions/2.3.0/ReferenceObject.json",
             "type": "string",
             "format": "uri-reference"
         },
-        "http://asyncapi.com/definitions/2.3.0/server.json": {
+        "server": {
             "$id": "http://asyncapi.com/definitions/2.3.0/server.json",
             "type": "object",
             "description": "An object representing a Server.",
@@ -194,7 +194,7 @@
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
@@ -212,34 +212,34 @@
                     "type": "string"
                 },
                 "variables": {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/serverVariables.json"
+                    "$ref": "#/definitions/serverVariables"
                 },
                 "security": {
                     "type": "array",
                     "items": {
-                        "$ref": "http://asyncapi.com/definitions/2.3.0/SecurityRequirement.json"
+                        "$ref": "#/definitions/SecurityRequirement"
                     }
                 },
                 "bindings": {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/bindingsObject.json"
+                    "$ref": "#/definitions/bindingsObject"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.3.0/serverVariables.json": {
+        "serverVariables": {
             "$id": "http://asyncapi.com/definitions/2.3.0/serverVariables.json",
             "type": "object",
             "additionalProperties": {
-                "$ref": "http://asyncapi.com/definitions/2.3.0/serverVariable.json"
+                "$ref": "#/definitions/serverVariable"
             }
         },
-        "http://asyncapi.com/definitions/2.3.0/serverVariable.json": {
+        "serverVariable": {
             "$id": "http://asyncapi.com/definitions/2.3.0/serverVariable.json",
             "type": "object",
             "description": "An object representing a Server Variable for server URL template substitution.",
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
@@ -264,7 +264,7 @@
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.3.0/SecurityRequirement.json": {
+        "SecurityRequirement": {
             "$id": "http://asyncapi.com/definitions/2.3.0/SecurityRequirement.json",
             "type": "object",
             "additionalProperties": {
@@ -275,7 +275,7 @@
                 "uniqueItems": true
             }
         },
-        "http://asyncapi.com/definitions/2.3.0/bindingsObject.json": {
+        "bindingsObject": {
             "$id": "http://asyncapi.com/definitions/2.3.0/bindingsObject.json",
             "type": "object",
             "additionalProperties": true,
@@ -298,7 +298,7 @@
                 "solace": {}
             }
         },
-        "http://asyncapi.com/definitions/2.3.0/channels.json": {
+        "channels": {
             "$id": "http://asyncapi.com/definitions/2.3.0/channels.json",
             "type": "object",
             "propertyNames": {
@@ -307,26 +307,26 @@
                 "minLength": 1
             },
             "additionalProperties": {
-                "$ref": "http://asyncapi.com/definitions/2.3.0/channelItem.json"
+                "$ref": "#/definitions/channelItem"
             }
         },
-        "http://asyncapi.com/definitions/2.3.0/channelItem.json": {
+        "channelItem": {
             "$id": "http://asyncapi.com/definitions/2.3.0/channelItem.json",
             "type": "object",
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
                 "$ref": {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/ReferenceObject.json"
+                    "$ref": "#/definitions/ReferenceObject"
                 },
                 "parameters": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "http://asyncapi.com/definitions/2.3.0/parameter.json"
+                        "$ref": "#/definitions/parameter"
                     }
                 },
                 "description": {
@@ -342,26 +342,26 @@
                     "uniqueItems": true
                 },
                 "publish": {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/operation.json"
+                    "$ref": "#/definitions/operation"
                 },
                 "subscribe": {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/operation.json"
+                    "$ref": "#/definitions/operation"
                 },
                 "deprecated": {
                     "type": "boolean",
                     "default": false
                 },
                 "bindings": {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/bindingsObject.json"
+                    "$ref": "#/definitions/bindingsObject"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.3.0/parameter.json": {
+        "parameter": {
             "$id": "http://asyncapi.com/definitions/2.3.0/parameter.json",
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
@@ -370,7 +370,7 @@
                     "description": "A brief description of the parameter. This could contain examples of use. GitHub Flavored Markdown is allowed."
                 },
                 "schema": {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/schema.json"
+                    "$ref": "#/definitions/schema"
                 },
                 "location": {
                     "type": "string",
@@ -378,27 +378,27 @@
                     "pattern": "^\\$message\\.(header|payload)#(\\/(([^\\/~])|(~[01]))*)*"
                 },
                 "$ref": {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/ReferenceObject.json"
+                    "$ref": "#/definitions/ReferenceObject"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.3.0/schema.json": {
+        "schema": {
             "$id": "http://asyncapi.com/definitions/2.3.0/schema.json",
             "allOf": [
                 {
-                    "$ref": "http://json-schema.org/draft-07/schema#"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 {
                     "patternProperties": {
                         "^x-[\\w\\d\\.\\x2d_]+$": {
-                            "$ref": "http://asyncapi.com/definitions/2.3.0/specificationExtension.json"
+                            "$ref": "#/definitions/specificationExtension"
                         }
                     },
                     "properties": {
                         "additionalProperties": {
                             "anyOf": [
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.3.0/schema.json"
+                                    "$ref": "#/definitions/schema"
                                 },
                                 {
                                     "type": "boolean"
@@ -409,13 +409,13 @@
                         "items": {
                             "anyOf": [
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.3.0/schema.json"
+                                    "$ref": "#/definitions/schema"
                                 },
                                 {
                                     "type": "array",
                                     "minItems": 1,
                                     "items": {
-                                        "$ref": "http://asyncapi.com/definitions/2.3.0/schema.json"
+                                        "$ref": "#/definitions/schema"
                                     }
                                 }
                             ],
@@ -425,51 +425,51 @@
                             "type": "array",
                             "minItems": 1,
                             "items": {
-                                "$ref": "http://asyncapi.com/definitions/2.3.0/schema.json"
+                                "$ref": "#/definitions/schema"
                             }
                         },
                         "oneOf": {
                             "type": "array",
                             "minItems": 1,
                             "items": {
-                                "$ref": "http://asyncapi.com/definitions/2.3.0/schema.json"
+                                "$ref": "#/definitions/schema"
                             }
                         },
                         "anyOf": {
                             "type": "array",
                             "minItems": 1,
                             "items": {
-                                "$ref": "http://asyncapi.com/definitions/2.3.0/schema.json"
+                                "$ref": "#/definitions/schema"
                             }
                         },
                         "not": {
-                            "$ref": "http://asyncapi.com/definitions/2.3.0/schema.json"
+                            "$ref": "#/definitions/schema"
                         },
                         "properties": {
                             "type": "object",
                             "additionalProperties": {
-                                "$ref": "http://asyncapi.com/definitions/2.3.0/schema.json"
+                                "$ref": "#/definitions/schema"
                             },
                             "default": {}
                         },
                         "patternProperties": {
                             "type": "object",
                             "additionalProperties": {
-                                "$ref": "http://asyncapi.com/definitions/2.3.0/schema.json"
+                                "$ref": "#/definitions/schema"
                             },
                             "default": {}
                         },
                         "propertyNames": {
-                            "$ref": "http://asyncapi.com/definitions/2.3.0/schema.json"
+                            "$ref": "#/definitions/schema"
                         },
                         "contains": {
-                            "$ref": "http://asyncapi.com/definitions/2.3.0/schema.json"
+                            "$ref": "#/definitions/schema"
                         },
                         "discriminator": {
                             "type": "string"
                         },
                         "externalDocs": {
-                            "$ref": "http://asyncapi.com/definitions/2.3.0/externalDocs.json"
+                            "$ref": "#/definitions/externalDocs"
                         },
                         "deprecated": {
                             "type": "boolean",
@@ -479,7 +479,7 @@
                 }
             ]
         },
-        "http://json-schema.org/draft-07/schema": {
+        "json-schema-draft-07-schema": {
             "$id": "http://json-schema.org/draft-07/schema",
             "title": "Core schema meta-schema",
             "definitions": {
@@ -487,7 +487,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#"
+                        "$ref": "#/definitions/json-schema-draft-07-schema"
                     }
                 },
                 "nonNegativeInteger": {
@@ -497,7 +497,7 @@
                 "nonNegativeIntegerDefault0": {
                     "allOf": [
                         {
-                            "$ref": "#/definitions/nonNegativeInteger"
+                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/nonNegativeInteger"
                         },
                         {
                             "default": 0
@@ -580,72 +580,72 @@
                     "type": "number"
                 },
                 "maxLength": {
-                    "$ref": "#/definitions/nonNegativeInteger"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/nonNegativeInteger"
                 },
                 "minLength": {
-                    "$ref": "#/definitions/nonNegativeIntegerDefault0"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/nonNegativeIntegerDefault0"
                 },
                 "pattern": {
                     "type": "string",
                     "format": "regex"
                 },
                 "additionalItems": {
-                    "$ref": "#"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "items": {
                     "anyOf": [
                         {
-                            "$ref": "#"
+                            "$ref": "#/definitions/json-schema-draft-07-schema"
                         },
                         {
-                            "$ref": "#/definitions/schemaArray"
+                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/schemaArray"
                         }
                     ],
                     "default": true
                 },
                 "maxItems": {
-                    "$ref": "#/definitions/nonNegativeInteger"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/nonNegativeInteger"
                 },
                 "minItems": {
-                    "$ref": "#/definitions/nonNegativeIntegerDefault0"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/nonNegativeIntegerDefault0"
                 },
                 "uniqueItems": {
                     "type": "boolean",
                     "default": false
                 },
                 "contains": {
-                    "$ref": "#"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "maxProperties": {
-                    "$ref": "#/definitions/nonNegativeInteger"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/nonNegativeInteger"
                 },
                 "minProperties": {
-                    "$ref": "#/definitions/nonNegativeIntegerDefault0"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/nonNegativeIntegerDefault0"
                 },
                 "required": {
-                    "$ref": "#/definitions/stringArray"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/stringArray"
                 },
                 "additionalProperties": {
-                    "$ref": "#"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "definitions": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "#"
+                        "$ref": "#/definitions/json-schema-draft-07-schema"
                     },
                     "default": {}
                 },
                 "properties": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "#"
+                        "$ref": "#/definitions/json-schema-draft-07-schema"
                     },
                     "default": {}
                 },
                 "patternProperties": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "#"
+                        "$ref": "#/definitions/json-schema-draft-07-schema"
                     },
                     "propertyNames": {
                         "format": "regex"
@@ -657,16 +657,16 @@
                     "additionalProperties": {
                         "anyOf": [
                             {
-                                "$ref": "#"
+                                "$ref": "#/definitions/json-schema-draft-07-schema"
                             },
                             {
-                                "$ref": "#/definitions/stringArray"
+                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/stringArray"
                             }
                         ]
                     }
                 },
                 "propertyNames": {
-                    "$ref": "#"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "const": true,
                 "enum": {
@@ -678,12 +678,12 @@
                 "type": {
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/simpleTypes"
+                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/simpleTypes"
                         },
                         {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/simpleTypes"
+                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/simpleTypes"
                             },
                             "minItems": 1,
                             "uniqueItems": true
@@ -700,30 +700,30 @@
                     "type": "string"
                 },
                 "if": {
-                    "$ref": "#"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "then": {
-                    "$ref": "#"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "else": {
-                    "$ref": "#"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "allOf": {
-                    "$ref": "#/definitions/schemaArray"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/schemaArray"
                 },
                 "anyOf": {
-                    "$ref": "#/definitions/schemaArray"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/schemaArray"
                 },
                 "oneOf": {
-                    "$ref": "#/definitions/schemaArray"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/schemaArray"
                 },
                 "not": {
-                    "$ref": "#"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 }
             },
             "default": true
         },
-        "http://asyncapi.com/definitions/2.3.0/externalDocs.json": {
+        "externalDocs": {
             "$id": "http://asyncapi.com/definitions/2.3.0/externalDocs.json",
             "type": "object",
             "additionalProperties": false,
@@ -742,17 +742,17 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.3.0/operation.json": {
+        "operation": {
             "$id": "http://asyncapi.com/definitions/2.3.0/operation.json",
             "type": "object",
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
@@ -761,10 +761,10 @@
                     "items": {
                         "oneOf": [
                             {
-                                "$ref": "http://asyncapi.com/definitions/2.3.0/Reference.json"
+                                "$ref": "#/definitions/Reference"
                             },
                             {
-                                "$ref": "http://asyncapi.com/definitions/2.3.0/operationTrait.json"
+                                "$ref": "#/definitions/operationTrait"
                             },
                             {
                                 "type": "array",
@@ -772,10 +772,10 @@
                                     {
                                         "oneOf": [
                                             {
-                                                "$ref": "http://asyncapi.com/definitions/2.3.0/Reference.json"
+                                                "$ref": "#/definitions/Reference"
                                             },
                                             {
-                                                "$ref": "http://asyncapi.com/definitions/2.3.0/operationTrait.json"
+                                                "$ref": "#/definitions/operationTrait"
                                             }
                                         ]
                                     },
@@ -797,31 +797,31 @@
                 "tags": {
                     "type": "array",
                     "items": {
-                        "$ref": "http://asyncapi.com/definitions/2.3.0/tag.json"
+                        "$ref": "#/definitions/tag"
                     },
                     "uniqueItems": true
                 },
                 "externalDocs": {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/externalDocs.json"
+                    "$ref": "#/definitions/externalDocs"
                 },
                 "operationId": {
                     "type": "string"
                 },
                 "bindings": {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/bindingsObject.json"
+                    "$ref": "#/definitions/bindingsObject"
                 },
                 "message": {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/message.json"
+                    "$ref": "#/definitions/message"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.3.0/operationTrait.json": {
+        "operationTrait": {
             "$id": "http://asyncapi.com/definitions/2.3.0/operationTrait.json",
             "type": "object",
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
@@ -834,22 +834,22 @@
                 "tags": {
                     "type": "array",
                     "items": {
-                        "$ref": "http://asyncapi.com/definitions/2.3.0/tag.json"
+                        "$ref": "#/definitions/tag"
                     },
                     "uniqueItems": true
                 },
                 "externalDocs": {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/externalDocs.json"
+                    "$ref": "#/definitions/externalDocs"
                 },
                 "operationId": {
                     "type": "string"
                 },
                 "bindings": {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/bindingsObject.json"
+                    "$ref": "#/definitions/bindingsObject"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.3.0/tag.json": {
+        "tag": {
             "$id": "http://asyncapi.com/definitions/2.3.0/tag.json",
             "type": "object",
             "additionalProperties": false,
@@ -864,20 +864,20 @@
                     "type": "string"
                 },
                 "externalDocs": {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/externalDocs.json"
+                    "$ref": "#/definitions/externalDocs"
                 }
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.3.0/message.json": {
+        "message": {
             "$id": "http://asyncapi.com/definitions/2.3.0/message.json",
             "oneOf": [
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/Reference.json"
+                    "$ref": "#/definitions/Reference"
                 },
                 {
                     "oneOf": [
@@ -891,7 +891,7 @@
                                 "oneOf": {
                                     "type": "array",
                                     "items": {
-                                        "$ref": "http://asyncapi.com/definitions/2.3.0/message.json"
+                                        "$ref": "#/definitions/message"
                                     }
                                 }
                             }
@@ -901,7 +901,7 @@
                             "additionalProperties": false,
                             "patternProperties": {
                                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                                    "$ref": "http://asyncapi.com/definitions/2.3.0/specificationExtension.json"
+                                    "$ref": "#/definitions/specificationExtension"
                                 }
                             },
                             "properties": {
@@ -914,7 +914,7 @@
                                 "headers": {
                                     "allOf": [
                                         {
-                                            "$ref": "http://asyncapi.com/definitions/2.3.0/schema.json"
+                                            "$ref": "#/definitions/schema"
                                         },
                                         {
                                             "properties": {
@@ -929,17 +929,17 @@
                                 "correlationId": {
                                     "oneOf": [
                                         {
-                                            "$ref": "http://asyncapi.com/definitions/2.3.0/Reference.json"
+                                            "$ref": "#/definitions/Reference"
                                         },
                                         {
-                                            "$ref": "http://asyncapi.com/definitions/2.3.0/correlationId.json"
+                                            "$ref": "#/definitions/correlationId"
                                         }
                                     ]
                                 },
                                 "tags": {
                                     "type": "array",
                                     "items": {
-                                        "$ref": "http://asyncapi.com/definitions/2.3.0/tag.json"
+                                        "$ref": "#/definitions/tag"
                                     },
                                     "uniqueItems": true
                                 },
@@ -960,7 +960,7 @@
                                     "description": "A longer description of the message. CommonMark is allowed."
                                 },
                                 "externalDocs": {
-                                    "$ref": "http://asyncapi.com/definitions/2.3.0/externalDocs.json"
+                                    "$ref": "#/definitions/externalDocs"
                                 },
                                 "deprecated": {
                                     "type": "boolean",
@@ -1000,17 +1000,17 @@
                                     }
                                 },
                                 "bindings": {
-                                    "$ref": "http://asyncapi.com/definitions/2.3.0/bindingsObject.json"
+                                    "$ref": "#/definitions/bindingsObject"
                                 },
                                 "traits": {
                                     "type": "array",
                                     "items": {
                                         "oneOf": [
                                             {
-                                                "$ref": "http://asyncapi.com/definitions/2.3.0/Reference.json"
+                                                "$ref": "#/definitions/Reference"
                                             },
                                             {
-                                                "$ref": "http://asyncapi.com/definitions/2.3.0/messageTrait.json"
+                                                "$ref": "#/definitions/messageTrait"
                                             },
                                             {
                                                 "type": "array",
@@ -1018,10 +1018,10 @@
                                                     {
                                                         "oneOf": [
                                                             {
-                                                                "$ref": "http://asyncapi.com/definitions/2.3.0/Reference.json"
+                                                                "$ref": "#/definitions/Reference"
                                                             },
                                                             {
-                                                                "$ref": "http://asyncapi.com/definitions/2.3.0/messageTrait.json"
+                                                                "$ref": "#/definitions/messageTrait"
                                                             }
                                                         ]
                                                     },
@@ -1040,7 +1040,7 @@
                 }
             ]
         },
-        "http://asyncapi.com/definitions/2.3.0/correlationId.json": {
+        "correlationId": {
             "$id": "http://asyncapi.com/definitions/2.3.0/correlationId.json",
             "type": "object",
             "required": [
@@ -1049,7 +1049,7 @@
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
@@ -1064,13 +1064,13 @@
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.3.0/messageTrait.json": {
+        "messageTrait": {
             "$id": "http://asyncapi.com/definitions/2.3.0/messageTrait.json",
             "type": "object",
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
@@ -1083,7 +1083,7 @@
                 "headers": {
                     "allOf": [
                         {
-                            "$ref": "http://asyncapi.com/definitions/2.3.0/schema.json"
+                            "$ref": "#/definitions/schema"
                         },
                         {
                             "properties": {
@@ -1097,17 +1097,17 @@
                 "correlationId": {
                     "oneOf": [
                         {
-                            "$ref": "http://asyncapi.com/definitions/2.3.0/Reference.json"
+                            "$ref": "#/definitions/Reference"
                         },
                         {
-                            "$ref": "http://asyncapi.com/definitions/2.3.0/correlationId.json"
+                            "$ref": "#/definitions/correlationId"
                         }
                     ]
                 },
                 "tags": {
                     "type": "array",
                     "items": {
-                        "$ref": "http://asyncapi.com/definitions/2.3.0/tag.json"
+                        "$ref": "#/definitions/tag"
                     },
                     "uniqueItems": true
                 },
@@ -1128,7 +1128,7 @@
                     "description": "A longer description of the message. CommonMark is allowed."
                 },
                 "externalDocs": {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/externalDocs.json"
+                    "$ref": "#/definitions/externalDocs"
                 },
                 "deprecated": {
                     "type": "boolean",
@@ -1141,32 +1141,32 @@
                     }
                 },
                 "bindings": {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/bindingsObject.json"
+                    "$ref": "#/definitions/bindingsObject"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.3.0/components.json": {
+        "components": {
             "$id": "http://asyncapi.com/definitions/2.3.0/components.json",
             "type": "object",
             "description": "An object to hold a set of reusable objects for different aspects of the AsyncAPI Specification.",
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
                 "schemas": {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/schemas.json"
+                    "$ref": "#/definitions/schemas"
                 },
                 "servers": {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/servers.json"
+                    "$ref": "#/definitions/servers"
                 },
                 "channels": {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/channels.json"
+                    "$ref": "#/definitions/channels"
                 },
                 "messages": {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/messages.json"
+                    "$ref": "#/definitions/messages"
                 },
                 "securitySchemes": {
                     "type": "object",
@@ -1174,17 +1174,17 @@
                         "^[\\w\\d\\.\\-_]+$": {
                             "oneOf": [
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.3.0/Reference.json"
+                                    "$ref": "#/definitions/Reference"
                                 },
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.3.0/SecurityScheme.json"
+                                    "$ref": "#/definitions/SecurityScheme"
                                 }
                             ]
                         }
                     }
                 },
                 "parameters": {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/parameters.json"
+                    "$ref": "#/definitions/parameters"
                 },
                 "correlationIds": {
                     "type": "object",
@@ -1192,10 +1192,10 @@
                         "^[\\w\\d\\.\\-_]+$": {
                             "oneOf": [
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.3.0/Reference.json"
+                                    "$ref": "#/definitions/Reference"
                                 },
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.3.0/correlationId.json"
+                                    "$ref": "#/definitions/correlationId"
                                 }
                             ]
                         }
@@ -1204,90 +1204,90 @@
                 "operationTraits": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "http://asyncapi.com/definitions/2.3.0/operationTrait.json"
+                        "$ref": "#/definitions/operationTrait"
                     }
                 },
                 "messageTraits": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "http://asyncapi.com/definitions/2.3.0/messageTrait.json"
+                        "$ref": "#/definitions/messageTrait"
                     }
                 },
                 "serverBindings": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "http://asyncapi.com/definitions/2.3.0/bindingsObject.json"
+                        "$ref": "#/definitions/bindingsObject"
                     }
                 },
                 "channelBindings": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "http://asyncapi.com/definitions/2.3.0/bindingsObject.json"
+                        "$ref": "#/definitions/bindingsObject"
                     }
                 },
                 "operationBindings": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "http://asyncapi.com/definitions/2.3.0/bindingsObject.json"
+                        "$ref": "#/definitions/bindingsObject"
                     }
                 },
                 "messageBindings": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "http://asyncapi.com/definitions/2.3.0/bindingsObject.json"
+                        "$ref": "#/definitions/bindingsObject"
                     }
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.3.0/schemas.json": {
+        "schemas": {
             "$id": "http://asyncapi.com/definitions/2.3.0/schemas.json",
             "type": "object",
             "additionalProperties": {
-                "$ref": "http://asyncapi.com/definitions/2.3.0/schema.json"
+                "$ref": "#/definitions/schema"
             },
             "description": "JSON objects describing schemas the API uses."
         },
-        "http://asyncapi.com/definitions/2.3.0/messages.json": {
+        "messages": {
             "$id": "http://asyncapi.com/definitions/2.3.0/messages.json",
             "type": "object",
             "additionalProperties": {
-                "$ref": "http://asyncapi.com/definitions/2.3.0/message.json"
+                "$ref": "#/definitions/message"
             },
             "description": "JSON objects describing the messages being consumed and produced by the API."
         },
-        "http://asyncapi.com/definitions/2.3.0/SecurityScheme.json": {
+        "SecurityScheme": {
             "$id": "http://asyncapi.com/definitions/2.3.0/SecurityScheme.json",
             "oneOf": [
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/userPassword.json"
+                    "$ref": "#/definitions/userPassword"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/apiKey.json"
+                    "$ref": "#/definitions/apiKey"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/X509.json"
+                    "$ref": "#/definitions/X509"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/symmetricEncryption.json"
+                    "$ref": "#/definitions/symmetricEncryption"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/asymmetricEncryption.json"
+                    "$ref": "#/definitions/asymmetricEncryption"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/HTTPSecurityScheme.json"
+                    "$ref": "#/definitions/HTTPSecurityScheme"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/oauth2Flows.json"
+                    "$ref": "#/definitions/oauth2Flows"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/openIdConnect.json"
+                    "$ref": "#/definitions/openIdConnect"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/SaslSecurityScheme.json"
+                    "$ref": "#/definitions/SaslSecurityScheme"
                 }
             ]
         },
-        "http://asyncapi.com/definitions/2.3.0/userPassword.json": {
+        "userPassword": {
             "$id": "http://asyncapi.com/definitions/2.3.0/userPassword.json",
             "type": "object",
             "required": [
@@ -1306,12 +1306,12 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.3.0/apiKey.json": {
+        "apiKey": {
             "$id": "http://asyncapi.com/definitions/2.3.0/apiKey.json",
             "type": "object",
             "required": [
@@ -1338,12 +1338,12 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.3.0/X509.json": {
+        "X509": {
             "$id": "http://asyncapi.com/definitions/2.3.0/X509.json",
             "type": "object",
             "required": [
@@ -1362,12 +1362,12 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.3.0/symmetricEncryption.json": {
+        "symmetricEncryption": {
             "$id": "http://asyncapi.com/definitions/2.3.0/symmetricEncryption.json",
             "type": "object",
             "required": [
@@ -1386,12 +1386,12 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.3.0/asymmetricEncryption.json": {
+        "asymmetricEncryption": {
             "$id": "http://asyncapi.com/definitions/2.3.0/asymmetricEncryption.json",
             "type": "object",
             "required": [
@@ -1410,26 +1410,26 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.3.0/HTTPSecurityScheme.json": {
+        "HTTPSecurityScheme": {
             "$id": "http://asyncapi.com/definitions/2.3.0/HTTPSecurityScheme.json",
             "oneOf": [
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/NonBearerHTTPSecurityScheme.json"
+                    "$ref": "#/definitions/NonBearerHTTPSecurityScheme"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/BearerHTTPSecurityScheme.json"
+                    "$ref": "#/definitions/BearerHTTPSecurityScheme"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/APIKeyHTTPSecurityScheme.json"
+                    "$ref": "#/definitions/APIKeyHTTPSecurityScheme"
                 }
             ]
         },
-        "http://asyncapi.com/definitions/2.3.0/NonBearerHTTPSecurityScheme.json": {
+        "NonBearerHTTPSecurityScheme": {
             "$id": "http://asyncapi.com/definitions/2.3.0/NonBearerHTTPSecurityScheme.json",
             "not": {
                 "type": "object",
@@ -1463,12 +1463,12 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.3.0/BearerHTTPSecurityScheme.json": {
+        "BearerHTTPSecurityScheme": {
             "$id": "http://asyncapi.com/definitions/2.3.0/BearerHTTPSecurityScheme.json",
             "type": "object",
             "required": [
@@ -1497,12 +1497,12 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.3.0/APIKeyHTTPSecurityScheme.json": {
+        "APIKeyHTTPSecurityScheme": {
             "$id": "http://asyncapi.com/definitions/2.3.0/APIKeyHTTPSecurityScheme.json",
             "type": "object",
             "required": [
@@ -1534,12 +1534,12 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.3.0/oauth2Flows.json": {
+        "oauth2Flows": {
             "$id": "http://asyncapi.com/definitions/2.3.0/oauth2Flows.json",
             "type": "object",
             "required": [
@@ -1562,7 +1562,7 @@
                         "implicit": {
                             "allOf": [
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.3.0/oauth2Flow.json"
+                                    "$ref": "#/definitions/oauth2Flow"
                                 },
                                 {
                                     "required": [
@@ -1582,7 +1582,7 @@
                         "password": {
                             "allOf": [
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.3.0/oauth2Flow.json"
+                                    "$ref": "#/definitions/oauth2Flow"
                                 },
                                 {
                                     "required": [
@@ -1602,7 +1602,7 @@
                         "clientCredentials": {
                             "allOf": [
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.3.0/oauth2Flow.json"
+                                    "$ref": "#/definitions/oauth2Flow"
                                 },
                                 {
                                     "required": [
@@ -1622,7 +1622,7 @@
                         "authorizationCode": {
                             "allOf": [
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.3.0/oauth2Flow.json"
+                                    "$ref": "#/definitions/oauth2Flow"
                                 },
                                 {
                                     "required": [
@@ -1639,11 +1639,11 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.3.0/oauth2Flow.json": {
+        "oauth2Flow": {
             "$id": "http://asyncapi.com/definitions/2.3.0/oauth2Flow.json",
             "type": "object",
             "properties": {
@@ -1660,24 +1660,24 @@
                     "format": "uri"
                 },
                 "scopes": {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/oauth2Scopes.json"
+                    "$ref": "#/definitions/oauth2Scopes"
                 }
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.3.0/oauth2Scopes.json": {
+        "oauth2Scopes": {
             "$id": "http://asyncapi.com/definitions/2.3.0/oauth2Scopes.json",
             "type": "object",
             "additionalProperties": {
                 "type": "string"
             }
         },
-        "http://asyncapi.com/definitions/2.3.0/openIdConnect.json": {
+        "openIdConnect": {
             "$id": "http://asyncapi.com/definitions/2.3.0/openIdConnect.json",
             "type": "object",
             "required": [
@@ -1701,26 +1701,26 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.3.0/SaslSecurityScheme.json": {
+        "SaslSecurityScheme": {
             "$id": "http://asyncapi.com/definitions/2.3.0/SaslSecurityScheme.json",
             "oneOf": [
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/SaslPlainSecurityScheme.json"
+                    "$ref": "#/definitions/SaslPlainSecurityScheme"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/SaslScramSecurityScheme.json"
+                    "$ref": "#/definitions/SaslScramSecurityScheme"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/SaslGssapiSecurityScheme.json"
+                    "$ref": "#/definitions/SaslGssapiSecurityScheme"
                 }
             ]
         },
-        "http://asyncapi.com/definitions/2.3.0/SaslPlainSecurityScheme.json": {
+        "SaslPlainSecurityScheme": {
             "$id": "http://asyncapi.com/definitions/2.3.0/SaslPlainSecurityScheme.json",
             "type": "object",
             "required": [
@@ -1739,12 +1739,12 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.3.0/SaslScramSecurityScheme.json": {
+        "SaslScramSecurityScheme": {
             "$id": "http://asyncapi.com/definitions/2.3.0/SaslScramSecurityScheme.json",
             "type": "object",
             "required": [
@@ -1764,12 +1764,12 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.3.0/SaslGssapiSecurityScheme.json": {
+        "SaslGssapiSecurityScheme": {
             "$id": "http://asyncapi.com/definitions/2.3.0/SaslGssapiSecurityScheme.json",
             "type": "object",
             "required": [
@@ -1788,16 +1788,16 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.3.0/parameters.json": {
+        "parameters": {
             "$id": "http://asyncapi.com/definitions/2.3.0/parameters.json",
             "type": "object",
             "additionalProperties": {
-                "$ref": "http://asyncapi.com/definitions/2.3.0/parameter.json"
+                "$ref": "#/definitions/parameter"
             },
             "description": "JSON objects describing re-usable channel parameters."
         }

--- a/schemas/2.4.0.json
+++ b/schemas/2.4.0.json
@@ -11,7 +11,7 @@
     "additionalProperties": false,
     "patternProperties": {
         "^x-[\\w\\d\\.\\x2d_]+$": {
-            "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+            "$ref": "#/definitions/specificationExtension"
         }
     },
     "properties": {
@@ -28,39 +28,39 @@
             "format": "uri"
         },
         "info": {
-            "$ref": "http://asyncapi.com/definitions/2.4.0/info.json"
+            "$ref": "#/definitions/info"
         },
         "servers": {
-            "$ref": "http://asyncapi.com/definitions/2.4.0/servers.json"
+            "$ref": "#/definitions/servers"
         },
         "defaultContentType": {
             "type": "string"
         },
         "channels": {
-            "$ref": "http://asyncapi.com/definitions/2.4.0/channels.json"
+            "$ref": "#/definitions/channels"
         },
         "components": {
-            "$ref": "http://asyncapi.com/definitions/2.4.0/components.json"
+            "$ref": "#/definitions/components"
         },
         "tags": {
             "type": "array",
             "items": {
-                "$ref": "http://asyncapi.com/definitions/2.4.0/tag.json"
+                "$ref": "#/definitions/tag"
             },
             "uniqueItems": true
         },
         "externalDocs": {
-            "$ref": "http://asyncapi.com/definitions/2.4.0/externalDocs.json"
+            "$ref": "#/definitions/externalDocs"
         }
     },
     "definitions": {
-        "http://asyncapi.com/definitions/2.4.0/specificationExtension.json": {
+        "specificationExtension": {
             "$id": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json",
             "description": "Any property starting with x- is valid.",
             "additionalProperties": true,
             "additionalItems": true
         },
-        "http://asyncapi.com/definitions/2.4.0/info.json": {
+        "info": {
             "$id": "http://asyncapi.com/definitions/2.4.0/info.json",
             "type": "object",
             "description": "General information about the API.",
@@ -71,7 +71,7 @@
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
@@ -93,14 +93,14 @@
                     "format": "uri"
                 },
                 "contact": {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/contact.json"
+                    "$ref": "#/definitions/contact"
                 },
                 "license": {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/license.json"
+                    "$ref": "#/definitions/license"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.4.0/contact.json": {
+        "contact": {
             "$id": "http://asyncapi.com/definitions/2.4.0/contact.json",
             "type": "object",
             "description": "Contact information for the owners of the API.",
@@ -123,11 +123,11 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.4.0/license.json": {
+        "license": {
             "$id": "http://asyncapi.com/definitions/2.4.0/license.json",
             "type": "object",
             "required": [
@@ -147,26 +147,26 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.4.0/servers.json": {
+        "servers": {
             "$id": "http://asyncapi.com/definitions/2.4.0/servers.json",
             "description": "An object representing multiple servers.",
             "type": "object",
             "additionalProperties": {
                 "oneOf": [
                     {
-                        "$ref": "http://asyncapi.com/definitions/2.4.0/Reference.json"
+                        "$ref": "#/definitions/Reference"
                     },
                     {
-                        "$ref": "http://asyncapi.com/definitions/2.4.0/server.json"
+                        "$ref": "#/definitions/server"
                     }
                 ]
             }
         },
-        "http://asyncapi.com/definitions/2.4.0/Reference.json": {
+        "Reference": {
             "$id": "http://asyncapi.com/definitions/2.4.0/Reference.json",
             "type": "object",
             "required": [
@@ -174,16 +174,16 @@
             ],
             "properties": {
                 "$ref": {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/ReferenceObject.json"
+                    "$ref": "#/definitions/ReferenceObject"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.4.0/ReferenceObject.json": {
+        "ReferenceObject": {
             "$id": "http://asyncapi.com/definitions/2.4.0/ReferenceObject.json",
             "type": "string",
             "format": "uri-reference"
         },
-        "http://asyncapi.com/definitions/2.4.0/server.json": {
+        "server": {
             "$id": "http://asyncapi.com/definitions/2.4.0/server.json",
             "type": "object",
             "description": "An object representing a Server.",
@@ -194,7 +194,7 @@
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
@@ -212,34 +212,34 @@
                     "type": "string"
                 },
                 "variables": {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/serverVariables.json"
+                    "$ref": "#/definitions/serverVariables"
                 },
                 "security": {
                     "type": "array",
                     "items": {
-                        "$ref": "http://asyncapi.com/definitions/2.4.0/SecurityRequirement.json"
+                        "$ref": "#/definitions/SecurityRequirement"
                     }
                 },
                 "bindings": {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/bindingsObject.json"
+                    "$ref": "#/definitions/bindingsObject"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.4.0/serverVariables.json": {
+        "serverVariables": {
             "$id": "http://asyncapi.com/definitions/2.4.0/serverVariables.json",
             "type": "object",
             "additionalProperties": {
-                "$ref": "http://asyncapi.com/definitions/2.4.0/serverVariable.json"
+                "$ref": "#/definitions/serverVariable"
             }
         },
-        "http://asyncapi.com/definitions/2.4.0/serverVariable.json": {
+        "serverVariable": {
             "$id": "http://asyncapi.com/definitions/2.4.0/serverVariable.json",
             "type": "object",
             "description": "An object representing a Server Variable for server URL template substitution.",
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
@@ -264,7 +264,7 @@
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.4.0/SecurityRequirement.json": {
+        "SecurityRequirement": {
             "$id": "http://asyncapi.com/definitions/2.4.0/SecurityRequirement.json",
             "type": "object",
             "additionalProperties": {
@@ -275,7 +275,7 @@
                 "uniqueItems": true
             }
         },
-        "http://asyncapi.com/definitions/2.4.0/bindingsObject.json": {
+        "bindingsObject": {
             "$id": "http://asyncapi.com/definitions/2.4.0/bindingsObject.json",
             "type": "object",
             "additionalProperties": true,
@@ -298,7 +298,7 @@
                 "solace": {}
             }
         },
-        "http://asyncapi.com/definitions/2.4.0/channels.json": {
+        "channels": {
             "$id": "http://asyncapi.com/definitions/2.4.0/channels.json",
             "type": "object",
             "propertyNames": {
@@ -307,26 +307,26 @@
                 "minLength": 1
             },
             "additionalProperties": {
-                "$ref": "http://asyncapi.com/definitions/2.4.0/channelItem.json"
+                "$ref": "#/definitions/channelItem"
             }
         },
-        "http://asyncapi.com/definitions/2.4.0/channelItem.json": {
+        "channelItem": {
             "$id": "http://asyncapi.com/definitions/2.4.0/channelItem.json",
             "type": "object",
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
                 "$ref": {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/ReferenceObject.json"
+                    "$ref": "#/definitions/ReferenceObject"
                 },
                 "parameters": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "http://asyncapi.com/definitions/2.4.0/parameter.json"
+                        "$ref": "#/definitions/parameter"
                     }
                 },
                 "description": {
@@ -342,26 +342,26 @@
                     "uniqueItems": true
                 },
                 "publish": {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/operation.json"
+                    "$ref": "#/definitions/operation"
                 },
                 "subscribe": {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/operation.json"
+                    "$ref": "#/definitions/operation"
                 },
                 "deprecated": {
                     "type": "boolean",
                     "default": false
                 },
                 "bindings": {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/bindingsObject.json"
+                    "$ref": "#/definitions/bindingsObject"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.4.0/parameter.json": {
+        "parameter": {
             "$id": "http://asyncapi.com/definitions/2.4.0/parameter.json",
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
@@ -370,7 +370,7 @@
                     "description": "A brief description of the parameter. This could contain examples of use. GitHub Flavored Markdown is allowed."
                 },
                 "schema": {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/schema.json"
+                    "$ref": "#/definitions/schema"
                 },
                 "location": {
                     "type": "string",
@@ -378,27 +378,27 @@
                     "pattern": "^\\$message\\.(header|payload)#(\\/(([^\\/~])|(~[01]))*)*"
                 },
                 "$ref": {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/ReferenceObject.json"
+                    "$ref": "#/definitions/ReferenceObject"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.4.0/schema.json": {
+        "schema": {
             "$id": "http://asyncapi.com/definitions/2.4.0/schema.json",
             "allOf": [
                 {
-                    "$ref": "http://json-schema.org/draft-07/schema#"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 {
                     "patternProperties": {
                         "^x-[\\w\\d\\.\\x2d_]+$": {
-                            "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+                            "$ref": "#/definitions/specificationExtension"
                         }
                     },
                     "properties": {
                         "additionalProperties": {
                             "anyOf": [
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.4.0/schema.json"
+                                    "$ref": "#/definitions/schema"
                                 },
                                 {
                                     "type": "boolean"
@@ -409,13 +409,13 @@
                         "items": {
                             "anyOf": [
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.4.0/schema.json"
+                                    "$ref": "#/definitions/schema"
                                 },
                                 {
                                     "type": "array",
                                     "minItems": 1,
                                     "items": {
-                                        "$ref": "http://asyncapi.com/definitions/2.4.0/schema.json"
+                                        "$ref": "#/definitions/schema"
                                     }
                                 }
                             ],
@@ -425,51 +425,51 @@
                             "type": "array",
                             "minItems": 1,
                             "items": {
-                                "$ref": "http://asyncapi.com/definitions/2.4.0/schema.json"
+                                "$ref": "#/definitions/schema"
                             }
                         },
                         "oneOf": {
                             "type": "array",
                             "minItems": 1,
                             "items": {
-                                "$ref": "http://asyncapi.com/definitions/2.4.0/schema.json"
+                                "$ref": "#/definitions/schema"
                             }
                         },
                         "anyOf": {
                             "type": "array",
                             "minItems": 1,
                             "items": {
-                                "$ref": "http://asyncapi.com/definitions/2.4.0/schema.json"
+                                "$ref": "#/definitions/schema"
                             }
                         },
                         "not": {
-                            "$ref": "http://asyncapi.com/definitions/2.4.0/schema.json"
+                            "$ref": "#/definitions/schema"
                         },
                         "properties": {
                             "type": "object",
                             "additionalProperties": {
-                                "$ref": "http://asyncapi.com/definitions/2.4.0/schema.json"
+                                "$ref": "#/definitions/schema"
                             },
                             "default": {}
                         },
                         "patternProperties": {
                             "type": "object",
                             "additionalProperties": {
-                                "$ref": "http://asyncapi.com/definitions/2.4.0/schema.json"
+                                "$ref": "#/definitions/schema"
                             },
                             "default": {}
                         },
                         "propertyNames": {
-                            "$ref": "http://asyncapi.com/definitions/2.4.0/schema.json"
+                            "$ref": "#/definitions/schema"
                         },
                         "contains": {
-                            "$ref": "http://asyncapi.com/definitions/2.4.0/schema.json"
+                            "$ref": "#/definitions/schema"
                         },
                         "discriminator": {
                             "type": "string"
                         },
                         "externalDocs": {
-                            "$ref": "http://asyncapi.com/definitions/2.4.0/externalDocs.json"
+                            "$ref": "#/definitions/externalDocs"
                         },
                         "deprecated": {
                             "type": "boolean",
@@ -479,7 +479,7 @@
                 }
             ]
         },
-        "http://json-schema.org/draft-07/schema": {
+        "json-schema-draft-07-schema": {
             "$id": "http://json-schema.org/draft-07/schema",
             "title": "Core schema meta-schema",
             "definitions": {
@@ -487,7 +487,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#"
+                        "$ref": "#/definitions/json-schema-draft-07-schema"
                     }
                 },
                 "nonNegativeInteger": {
@@ -497,7 +497,7 @@
                 "nonNegativeIntegerDefault0": {
                     "allOf": [
                         {
-                            "$ref": "#/definitions/nonNegativeInteger"
+                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/nonNegativeInteger"
                         },
                         {
                             "default": 0
@@ -580,72 +580,72 @@
                     "type": "number"
                 },
                 "maxLength": {
-                    "$ref": "#/definitions/nonNegativeInteger"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/nonNegativeInteger"
                 },
                 "minLength": {
-                    "$ref": "#/definitions/nonNegativeIntegerDefault0"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/nonNegativeIntegerDefault0"
                 },
                 "pattern": {
                     "type": "string",
                     "format": "regex"
                 },
                 "additionalItems": {
-                    "$ref": "#"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "items": {
                     "anyOf": [
                         {
-                            "$ref": "#"
+                            "$ref": "#/definitions/json-schema-draft-07-schema"
                         },
                         {
-                            "$ref": "#/definitions/schemaArray"
+                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/schemaArray"
                         }
                     ],
                     "default": true
                 },
                 "maxItems": {
-                    "$ref": "#/definitions/nonNegativeInteger"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/nonNegativeInteger"
                 },
                 "minItems": {
-                    "$ref": "#/definitions/nonNegativeIntegerDefault0"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/nonNegativeIntegerDefault0"
                 },
                 "uniqueItems": {
                     "type": "boolean",
                     "default": false
                 },
                 "contains": {
-                    "$ref": "#"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "maxProperties": {
-                    "$ref": "#/definitions/nonNegativeInteger"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/nonNegativeInteger"
                 },
                 "minProperties": {
-                    "$ref": "#/definitions/nonNegativeIntegerDefault0"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/nonNegativeIntegerDefault0"
                 },
                 "required": {
-                    "$ref": "#/definitions/stringArray"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/stringArray"
                 },
                 "additionalProperties": {
-                    "$ref": "#"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "definitions": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "#"
+                        "$ref": "#/definitions/json-schema-draft-07-schema"
                     },
                     "default": {}
                 },
                 "properties": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "#"
+                        "$ref": "#/definitions/json-schema-draft-07-schema"
                     },
                     "default": {}
                 },
                 "patternProperties": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "#"
+                        "$ref": "#/definitions/json-schema-draft-07-schema"
                     },
                     "propertyNames": {
                         "format": "regex"
@@ -657,16 +657,16 @@
                     "additionalProperties": {
                         "anyOf": [
                             {
-                                "$ref": "#"
+                                "$ref": "#/definitions/json-schema-draft-07-schema"
                             },
                             {
-                                "$ref": "#/definitions/stringArray"
+                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/stringArray"
                             }
                         ]
                     }
                 },
                 "propertyNames": {
-                    "$ref": "#"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "const": true,
                 "enum": {
@@ -678,12 +678,12 @@
                 "type": {
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/simpleTypes"
+                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/simpleTypes"
                         },
                         {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/simpleTypes"
+                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/simpleTypes"
                             },
                             "minItems": 1,
                             "uniqueItems": true
@@ -700,30 +700,30 @@
                     "type": "string"
                 },
                 "if": {
-                    "$ref": "#"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "then": {
-                    "$ref": "#"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "else": {
-                    "$ref": "#"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "allOf": {
-                    "$ref": "#/definitions/schemaArray"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/schemaArray"
                 },
                 "anyOf": {
-                    "$ref": "#/definitions/schemaArray"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/schemaArray"
                 },
                 "oneOf": {
-                    "$ref": "#/definitions/schemaArray"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/schemaArray"
                 },
                 "not": {
-                    "$ref": "#"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 }
             },
             "default": true
         },
-        "http://asyncapi.com/definitions/2.4.0/externalDocs.json": {
+        "externalDocs": {
             "$id": "http://asyncapi.com/definitions/2.4.0/externalDocs.json",
             "type": "object",
             "additionalProperties": false,
@@ -742,17 +742,17 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.4.0/operation.json": {
+        "operation": {
             "$id": "http://asyncapi.com/definitions/2.4.0/operation.json",
             "type": "object",
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
@@ -761,10 +761,10 @@
                     "items": {
                         "oneOf": [
                             {
-                                "$ref": "http://asyncapi.com/definitions/2.4.0/Reference.json"
+                                "$ref": "#/definitions/Reference"
                             },
                             {
-                                "$ref": "http://asyncapi.com/definitions/2.4.0/operationTrait.json"
+                                "$ref": "#/definitions/operationTrait"
                             },
                             {
                                 "type": "array",
@@ -772,10 +772,10 @@
                                     {
                                         "oneOf": [
                                             {
-                                                "$ref": "http://asyncapi.com/definitions/2.4.0/Reference.json"
+                                                "$ref": "#/definitions/Reference"
                                             },
                                             {
-                                                "$ref": "http://asyncapi.com/definitions/2.4.0/operationTrait.json"
+                                                "$ref": "#/definitions/operationTrait"
                                             }
                                         ]
                                     },
@@ -797,37 +797,37 @@
                 "security": {
                     "type": "array",
                     "items": {
-                        "$ref": "http://asyncapi.com/definitions/2.4.0/SecurityRequirement.json"
+                        "$ref": "#/definitions/SecurityRequirement"
                     }
                 },
                 "tags": {
                     "type": "array",
                     "items": {
-                        "$ref": "http://asyncapi.com/definitions/2.4.0/tag.json"
+                        "$ref": "#/definitions/tag"
                     },
                     "uniqueItems": true
                 },
                 "externalDocs": {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/externalDocs.json"
+                    "$ref": "#/definitions/externalDocs"
                 },
                 "operationId": {
                     "type": "string"
                 },
                 "bindings": {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/bindingsObject.json"
+                    "$ref": "#/definitions/bindingsObject"
                 },
                 "message": {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/message.json"
+                    "$ref": "#/definitions/message"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.4.0/operationTrait.json": {
+        "operationTrait": {
             "$id": "http://asyncapi.com/definitions/2.4.0/operationTrait.json",
             "type": "object",
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
@@ -840,12 +840,12 @@
                 "tags": {
                     "type": "array",
                     "items": {
-                        "$ref": "http://asyncapi.com/definitions/2.4.0/tag.json"
+                        "$ref": "#/definitions/tag"
                     },
                     "uniqueItems": true
                 },
                 "externalDocs": {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/externalDocs.json"
+                    "$ref": "#/definitions/externalDocs"
                 },
                 "operationId": {
                     "type": "string"
@@ -853,15 +853,15 @@
                 "security": {
                     "type": "array",
                     "items": {
-                        "$ref": "http://asyncapi.com/definitions/2.4.0/SecurityRequirement.json"
+                        "$ref": "#/definitions/SecurityRequirement"
                     }
                 },
                 "bindings": {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/bindingsObject.json"
+                    "$ref": "#/definitions/bindingsObject"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.4.0/tag.json": {
+        "tag": {
             "$id": "http://asyncapi.com/definitions/2.4.0/tag.json",
             "type": "object",
             "additionalProperties": false,
@@ -876,20 +876,20 @@
                     "type": "string"
                 },
                 "externalDocs": {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/externalDocs.json"
+                    "$ref": "#/definitions/externalDocs"
                 }
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.4.0/message.json": {
+        "message": {
             "$id": "http://asyncapi.com/definitions/2.4.0/message.json",
             "oneOf": [
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/Reference.json"
+                    "$ref": "#/definitions/Reference"
                 },
                 {
                     "oneOf": [
@@ -903,7 +903,7 @@
                                 "oneOf": {
                                     "type": "array",
                                     "items": {
-                                        "$ref": "http://asyncapi.com/definitions/2.4.0/message.json"
+                                        "$ref": "#/definitions/message"
                                     }
                                 }
                             }
@@ -913,7 +913,7 @@
                             "additionalProperties": false,
                             "patternProperties": {
                                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                                    "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+                                    "$ref": "#/definitions/specificationExtension"
                                 }
                             },
                             "properties": {
@@ -926,7 +926,7 @@
                                 "headers": {
                                     "allOf": [
                                         {
-                                            "$ref": "http://asyncapi.com/definitions/2.4.0/schema.json"
+                                            "$ref": "#/definitions/schema"
                                         },
                                         {
                                             "properties": {
@@ -944,17 +944,17 @@
                                 "correlationId": {
                                     "oneOf": [
                                         {
-                                            "$ref": "http://asyncapi.com/definitions/2.4.0/Reference.json"
+                                            "$ref": "#/definitions/Reference"
                                         },
                                         {
-                                            "$ref": "http://asyncapi.com/definitions/2.4.0/correlationId.json"
+                                            "$ref": "#/definitions/correlationId"
                                         }
                                     ]
                                 },
                                 "tags": {
                                     "type": "array",
                                     "items": {
-                                        "$ref": "http://asyncapi.com/definitions/2.4.0/tag.json"
+                                        "$ref": "#/definitions/tag"
                                     },
                                     "uniqueItems": true
                                 },
@@ -975,7 +975,7 @@
                                     "description": "A longer description of the message. CommonMark is allowed."
                                 },
                                 "externalDocs": {
-                                    "$ref": "http://asyncapi.com/definitions/2.4.0/externalDocs.json"
+                                    "$ref": "#/definitions/externalDocs"
                                 },
                                 "deprecated": {
                                     "type": "boolean",
@@ -1015,17 +1015,17 @@
                                     }
                                 },
                                 "bindings": {
-                                    "$ref": "http://asyncapi.com/definitions/2.4.0/bindingsObject.json"
+                                    "$ref": "#/definitions/bindingsObject"
                                 },
                                 "traits": {
                                     "type": "array",
                                     "items": {
                                         "oneOf": [
                                             {
-                                                "$ref": "http://asyncapi.com/definitions/2.4.0/Reference.json"
+                                                "$ref": "#/definitions/Reference"
                                             },
                                             {
-                                                "$ref": "http://asyncapi.com/definitions/2.4.0/messageTrait.json"
+                                                "$ref": "#/definitions/messageTrait"
                                             },
                                             {
                                                 "type": "array",
@@ -1033,10 +1033,10 @@
                                                     {
                                                         "oneOf": [
                                                             {
-                                                                "$ref": "http://asyncapi.com/definitions/2.4.0/Reference.json"
+                                                                "$ref": "#/definitions/Reference"
                                                             },
                                                             {
-                                                                "$ref": "http://asyncapi.com/definitions/2.4.0/messageTrait.json"
+                                                                "$ref": "#/definitions/messageTrait"
                                                             }
                                                         ]
                                                     },
@@ -1055,7 +1055,7 @@
                 }
             ]
         },
-        "http://asyncapi.com/definitions/2.4.0/correlationId.json": {
+        "correlationId": {
             "$id": "http://asyncapi.com/definitions/2.4.0/correlationId.json",
             "type": "object",
             "required": [
@@ -1064,7 +1064,7 @@
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
@@ -1079,13 +1079,13 @@
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.4.0/messageTrait.json": {
+        "messageTrait": {
             "$id": "http://asyncapi.com/definitions/2.4.0/messageTrait.json",
             "type": "object",
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
@@ -1098,7 +1098,7 @@
                 "headers": {
                     "allOf": [
                         {
-                            "$ref": "http://asyncapi.com/definitions/2.4.0/schema.json"
+                            "$ref": "#/definitions/schema"
                         },
                         {
                             "properties": {
@@ -1115,17 +1115,17 @@
                 "correlationId": {
                     "oneOf": [
                         {
-                            "$ref": "http://asyncapi.com/definitions/2.4.0/Reference.json"
+                            "$ref": "#/definitions/Reference"
                         },
                         {
-                            "$ref": "http://asyncapi.com/definitions/2.4.0/correlationId.json"
+                            "$ref": "#/definitions/correlationId"
                         }
                     ]
                 },
                 "tags": {
                     "type": "array",
                     "items": {
-                        "$ref": "http://asyncapi.com/definitions/2.4.0/tag.json"
+                        "$ref": "#/definitions/tag"
                     },
                     "uniqueItems": true
                 },
@@ -1146,7 +1146,7 @@
                     "description": "A longer description of the message. CommonMark is allowed."
                 },
                 "externalDocs": {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/externalDocs.json"
+                    "$ref": "#/definitions/externalDocs"
                 },
                 "deprecated": {
                     "type": "boolean",
@@ -1159,35 +1159,35 @@
                     }
                 },
                 "bindings": {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/bindingsObject.json"
+                    "$ref": "#/definitions/bindingsObject"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.4.0/components.json": {
+        "components": {
             "$id": "http://asyncapi.com/definitions/2.4.0/components.json",
             "type": "object",
             "description": "An object to hold a set of reusable objects for different aspects of the AsyncAPI Specification.",
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
                 "schemas": {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/schemas.json"
+                    "$ref": "#/definitions/schemas"
                 },
                 "servers": {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/servers.json"
+                    "$ref": "#/definitions/servers"
                 },
                 "channels": {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/channels.json"
+                    "$ref": "#/definitions/channels"
                 },
                 "serverVariables": {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/serverVariables.json"
+                    "$ref": "#/definitions/serverVariables"
                 },
                 "messages": {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/messages.json"
+                    "$ref": "#/definitions/messages"
                 },
                 "securitySchemes": {
                     "type": "object",
@@ -1195,17 +1195,17 @@
                         "^[\\w\\d\\.\\-_]+$": {
                             "oneOf": [
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.4.0/Reference.json"
+                                    "$ref": "#/definitions/Reference"
                                 },
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.4.0/SecurityScheme.json"
+                                    "$ref": "#/definitions/SecurityScheme"
                                 }
                             ]
                         }
                     }
                 },
                 "parameters": {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/parameters.json"
+                    "$ref": "#/definitions/parameters"
                 },
                 "correlationIds": {
                     "type": "object",
@@ -1213,10 +1213,10 @@
                         "^[\\w\\d\\.\\-_]+$": {
                             "oneOf": [
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.4.0/Reference.json"
+                                    "$ref": "#/definitions/Reference"
                                 },
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.4.0/correlationId.json"
+                                    "$ref": "#/definitions/correlationId"
                                 }
                             ]
                         }
@@ -1225,90 +1225,90 @@
                 "operationTraits": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "http://asyncapi.com/definitions/2.4.0/operationTrait.json"
+                        "$ref": "#/definitions/operationTrait"
                     }
                 },
                 "messageTraits": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "http://asyncapi.com/definitions/2.4.0/messageTrait.json"
+                        "$ref": "#/definitions/messageTrait"
                     }
                 },
                 "serverBindings": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "http://asyncapi.com/definitions/2.4.0/bindingsObject.json"
+                        "$ref": "#/definitions/bindingsObject"
                     }
                 },
                 "channelBindings": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "http://asyncapi.com/definitions/2.4.0/bindingsObject.json"
+                        "$ref": "#/definitions/bindingsObject"
                     }
                 },
                 "operationBindings": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "http://asyncapi.com/definitions/2.4.0/bindingsObject.json"
+                        "$ref": "#/definitions/bindingsObject"
                     }
                 },
                 "messageBindings": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "http://asyncapi.com/definitions/2.4.0/bindingsObject.json"
+                        "$ref": "#/definitions/bindingsObject"
                     }
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.4.0/schemas.json": {
+        "schemas": {
             "$id": "http://asyncapi.com/definitions/2.4.0/schemas.json",
             "type": "object",
             "additionalProperties": {
-                "$ref": "http://asyncapi.com/definitions/2.4.0/schema.json"
+                "$ref": "#/definitions/schema"
             },
             "description": "JSON objects describing schemas the API uses."
         },
-        "http://asyncapi.com/definitions/2.4.0/messages.json": {
+        "messages": {
             "$id": "http://asyncapi.com/definitions/2.4.0/messages.json",
             "type": "object",
             "additionalProperties": {
-                "$ref": "http://asyncapi.com/definitions/2.4.0/message.json"
+                "$ref": "#/definitions/message"
             },
             "description": "JSON objects describing the messages being consumed and produced by the API."
         },
-        "http://asyncapi.com/definitions/2.4.0/SecurityScheme.json": {
+        "SecurityScheme": {
             "$id": "http://asyncapi.com/definitions/2.4.0/SecurityScheme.json",
             "oneOf": [
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/userPassword.json"
+                    "$ref": "#/definitions/userPassword"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/apiKey.json"
+                    "$ref": "#/definitions/apiKey"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/X509.json"
+                    "$ref": "#/definitions/X509"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/symmetricEncryption.json"
+                    "$ref": "#/definitions/symmetricEncryption"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/asymmetricEncryption.json"
+                    "$ref": "#/definitions/asymmetricEncryption"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/HTTPSecurityScheme.json"
+                    "$ref": "#/definitions/HTTPSecurityScheme"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/oauth2Flows.json"
+                    "$ref": "#/definitions/oauth2Flows"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/openIdConnect.json"
+                    "$ref": "#/definitions/openIdConnect"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/SaslSecurityScheme.json"
+                    "$ref": "#/definitions/SaslSecurityScheme"
                 }
             ]
         },
-        "http://asyncapi.com/definitions/2.4.0/userPassword.json": {
+        "userPassword": {
             "$id": "http://asyncapi.com/definitions/2.4.0/userPassword.json",
             "type": "object",
             "required": [
@@ -1327,12 +1327,12 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.4.0/apiKey.json": {
+        "apiKey": {
             "$id": "http://asyncapi.com/definitions/2.4.0/apiKey.json",
             "type": "object",
             "required": [
@@ -1359,12 +1359,12 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.4.0/X509.json": {
+        "X509": {
             "$id": "http://asyncapi.com/definitions/2.4.0/X509.json",
             "type": "object",
             "required": [
@@ -1383,12 +1383,12 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.4.0/symmetricEncryption.json": {
+        "symmetricEncryption": {
             "$id": "http://asyncapi.com/definitions/2.4.0/symmetricEncryption.json",
             "type": "object",
             "required": [
@@ -1407,12 +1407,12 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.4.0/asymmetricEncryption.json": {
+        "asymmetricEncryption": {
             "$id": "http://asyncapi.com/definitions/2.4.0/asymmetricEncryption.json",
             "type": "object",
             "required": [
@@ -1431,26 +1431,26 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.4.0/HTTPSecurityScheme.json": {
+        "HTTPSecurityScheme": {
             "$id": "http://asyncapi.com/definitions/2.4.0/HTTPSecurityScheme.json",
             "oneOf": [
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/NonBearerHTTPSecurityScheme.json"
+                    "$ref": "#/definitions/NonBearerHTTPSecurityScheme"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/BearerHTTPSecurityScheme.json"
+                    "$ref": "#/definitions/BearerHTTPSecurityScheme"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/APIKeyHTTPSecurityScheme.json"
+                    "$ref": "#/definitions/APIKeyHTTPSecurityScheme"
                 }
             ]
         },
-        "http://asyncapi.com/definitions/2.4.0/NonBearerHTTPSecurityScheme.json": {
+        "NonBearerHTTPSecurityScheme": {
             "$id": "http://asyncapi.com/definitions/2.4.0/NonBearerHTTPSecurityScheme.json",
             "not": {
                 "type": "object",
@@ -1484,12 +1484,12 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.4.0/BearerHTTPSecurityScheme.json": {
+        "BearerHTTPSecurityScheme": {
             "$id": "http://asyncapi.com/definitions/2.4.0/BearerHTTPSecurityScheme.json",
             "type": "object",
             "required": [
@@ -1518,12 +1518,12 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.4.0/APIKeyHTTPSecurityScheme.json": {
+        "APIKeyHTTPSecurityScheme": {
             "$id": "http://asyncapi.com/definitions/2.4.0/APIKeyHTTPSecurityScheme.json",
             "type": "object",
             "required": [
@@ -1555,12 +1555,12 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.4.0/oauth2Flows.json": {
+        "oauth2Flows": {
             "$id": "http://asyncapi.com/definitions/2.4.0/oauth2Flows.json",
             "type": "object",
             "required": [
@@ -1583,7 +1583,7 @@
                         "implicit": {
                             "allOf": [
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.4.0/oauth2Flow.json"
+                                    "$ref": "#/definitions/oauth2Flow"
                                 },
                                 {
                                     "required": [
@@ -1603,7 +1603,7 @@
                         "password": {
                             "allOf": [
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.4.0/oauth2Flow.json"
+                                    "$ref": "#/definitions/oauth2Flow"
                                 },
                                 {
                                     "required": [
@@ -1623,7 +1623,7 @@
                         "clientCredentials": {
                             "allOf": [
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.4.0/oauth2Flow.json"
+                                    "$ref": "#/definitions/oauth2Flow"
                                 },
                                 {
                                     "required": [
@@ -1643,7 +1643,7 @@
                         "authorizationCode": {
                             "allOf": [
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.4.0/oauth2Flow.json"
+                                    "$ref": "#/definitions/oauth2Flow"
                                 },
                                 {
                                     "required": [
@@ -1660,11 +1660,11 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.4.0/oauth2Flow.json": {
+        "oauth2Flow": {
             "$id": "http://asyncapi.com/definitions/2.4.0/oauth2Flow.json",
             "type": "object",
             "properties": {
@@ -1681,24 +1681,24 @@
                     "format": "uri"
                 },
                 "scopes": {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/oauth2Scopes.json"
+                    "$ref": "#/definitions/oauth2Scopes"
                 }
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.4.0/oauth2Scopes.json": {
+        "oauth2Scopes": {
             "$id": "http://asyncapi.com/definitions/2.4.0/oauth2Scopes.json",
             "type": "object",
             "additionalProperties": {
                 "type": "string"
             }
         },
-        "http://asyncapi.com/definitions/2.4.0/openIdConnect.json": {
+        "openIdConnect": {
             "$id": "http://asyncapi.com/definitions/2.4.0/openIdConnect.json",
             "type": "object",
             "required": [
@@ -1722,26 +1722,26 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.4.0/SaslSecurityScheme.json": {
+        "SaslSecurityScheme": {
             "$id": "http://asyncapi.com/definitions/2.4.0/SaslSecurityScheme.json",
             "oneOf": [
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/SaslPlainSecurityScheme.json"
+                    "$ref": "#/definitions/SaslPlainSecurityScheme"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/SaslScramSecurityScheme.json"
+                    "$ref": "#/definitions/SaslScramSecurityScheme"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/SaslGssapiSecurityScheme.json"
+                    "$ref": "#/definitions/SaslGssapiSecurityScheme"
                 }
             ]
         },
-        "http://asyncapi.com/definitions/2.4.0/SaslPlainSecurityScheme.json": {
+        "SaslPlainSecurityScheme": {
             "$id": "http://asyncapi.com/definitions/2.4.0/SaslPlainSecurityScheme.json",
             "type": "object",
             "required": [
@@ -1760,12 +1760,12 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.4.0/SaslScramSecurityScheme.json": {
+        "SaslScramSecurityScheme": {
             "$id": "http://asyncapi.com/definitions/2.4.0/SaslScramSecurityScheme.json",
             "type": "object",
             "required": [
@@ -1785,12 +1785,12 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.4.0/SaslGssapiSecurityScheme.json": {
+        "SaslGssapiSecurityScheme": {
             "$id": "http://asyncapi.com/definitions/2.4.0/SaslGssapiSecurityScheme.json",
             "type": "object",
             "required": [
@@ -1809,16 +1809,16 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.4.0/parameters.json": {
+        "parameters": {
             "$id": "http://asyncapi.com/definitions/2.4.0/parameters.json",
             "type": "object",
             "additionalProperties": {
-                "$ref": "http://asyncapi.com/definitions/2.4.0/parameter.json"
+                "$ref": "#/definitions/parameter"
             },
             "description": "JSON objects describing re-usable channel parameters."
         }

--- a/schemas/2.5.0.json
+++ b/schemas/2.5.0.json
@@ -11,7 +11,7 @@
     "additionalProperties": false,
     "patternProperties": {
         "^x-[\\w\\d\\.\\x2d_]+$": {
-            "$ref": "http://asyncapi.com/definitions/2.5.0/specificationExtension.json"
+            "$ref": "#/definitions/specificationExtension"
         }
     },
     "properties": {
@@ -28,39 +28,39 @@
             "format": "uri"
         },
         "info": {
-            "$ref": "http://asyncapi.com/definitions/2.5.0/info.json"
+            "$ref": "#/definitions/info"
         },
         "servers": {
-            "$ref": "http://asyncapi.com/definitions/2.5.0/servers.json"
+            "$ref": "#/definitions/servers"
         },
         "defaultContentType": {
             "type": "string"
         },
         "channels": {
-            "$ref": "http://asyncapi.com/definitions/2.5.0/channels.json"
+            "$ref": "#/definitions/channels"
         },
         "components": {
-            "$ref": "http://asyncapi.com/definitions/2.5.0/components.json"
+            "$ref": "#/definitions/components"
         },
         "tags": {
             "type": "array",
             "items": {
-                "$ref": "http://asyncapi.com/definitions/2.5.0/tag.json"
+                "$ref": "#/definitions/tag"
             },
             "uniqueItems": true
         },
         "externalDocs": {
-            "$ref": "http://asyncapi.com/definitions/2.5.0/externalDocs.json"
+            "$ref": "#/definitions/externalDocs"
         }
     },
     "definitions": {
-        "http://asyncapi.com/definitions/2.5.0/specificationExtension.json": {
+        "specificationExtension": {
             "$id": "http://asyncapi.com/definitions/2.5.0/specificationExtension.json",
             "description": "Any property starting with x- is valid.",
             "additionalProperties": true,
             "additionalItems": true
         },
-        "http://asyncapi.com/definitions/2.5.0/info.json": {
+        "info": {
             "$id": "http://asyncapi.com/definitions/2.5.0/info.json",
             "type": "object",
             "description": "General information about the API.",
@@ -71,7 +71,7 @@
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
@@ -93,14 +93,14 @@
                     "format": "uri"
                 },
                 "contact": {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/contact.json"
+                    "$ref": "#/definitions/contact"
                 },
                 "license": {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/license.json"
+                    "$ref": "#/definitions/license"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.5.0/contact.json": {
+        "contact": {
             "$id": "http://asyncapi.com/definitions/2.5.0/contact.json",
             "type": "object",
             "description": "Contact information for the owners of the API.",
@@ -123,11 +123,11 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.5.0/license.json": {
+        "license": {
             "$id": "http://asyncapi.com/definitions/2.5.0/license.json",
             "type": "object",
             "required": [
@@ -147,26 +147,26 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.5.0/servers.json": {
+        "servers": {
             "$id": "http://asyncapi.com/definitions/2.5.0/servers.json",
             "description": "An object representing multiple servers.",
             "type": "object",
             "additionalProperties": {
                 "oneOf": [
                     {
-                        "$ref": "http://asyncapi.com/definitions/2.5.0/Reference.json"
+                        "$ref": "#/definitions/Reference"
                     },
                     {
-                        "$ref": "http://asyncapi.com/definitions/2.5.0/server.json"
+                        "$ref": "#/definitions/server"
                     }
                 ]
             }
         },
-        "http://asyncapi.com/definitions/2.5.0/Reference.json": {
+        "Reference": {
             "$id": "http://asyncapi.com/definitions/2.5.0/Reference.json",
             "type": "object",
             "required": [
@@ -174,16 +174,16 @@
             ],
             "properties": {
                 "$ref": {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/ReferenceObject.json"
+                    "$ref": "#/definitions/ReferenceObject"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.5.0/ReferenceObject.json": {
+        "ReferenceObject": {
             "$id": "http://asyncapi.com/definitions/2.5.0/ReferenceObject.json",
             "type": "string",
             "format": "uri-reference"
         },
-        "http://asyncapi.com/definitions/2.5.0/server.json": {
+        "server": {
             "$id": "http://asyncapi.com/definitions/2.5.0/server.json",
             "type": "object",
             "description": "An object representing a Server.",
@@ -194,7 +194,7 @@
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
@@ -212,48 +212,48 @@
                     "type": "string"
                 },
                 "variables": {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/serverVariables.json"
+                    "$ref": "#/definitions/serverVariables"
                 },
                 "security": {
                     "type": "array",
                     "items": {
-                        "$ref": "http://asyncapi.com/definitions/2.5.0/SecurityRequirement.json"
+                        "$ref": "#/definitions/SecurityRequirement"
                     }
                 },
                 "bindings": {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/bindingsObject.json"
+                    "$ref": "#/definitions/bindingsObject"
                 },
                 "tags": {
                     "type": "array",
                     "items": {
-                        "$ref": "http://asyncapi.com/definitions/2.5.0/tag.json"
+                        "$ref": "#/definitions/tag"
                     },
                     "uniqueItems": true
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.5.0/serverVariables.json": {
+        "serverVariables": {
             "$id": "http://asyncapi.com/definitions/2.5.0/serverVariables.json",
             "type": "object",
             "additionalProperties": {
                 "oneOf": [
                     {
-                        "$ref": "http://asyncapi.com/definitions/2.5.0/Reference.json"
+                        "$ref": "#/definitions/Reference"
                     },
                     {
-                        "$ref": "http://asyncapi.com/definitions/2.5.0/serverVariable.json"
+                        "$ref": "#/definitions/serverVariable"
                     }
                 ]
             }
         },
-        "http://asyncapi.com/definitions/2.5.0/serverVariable.json": {
+        "serverVariable": {
             "$id": "http://asyncapi.com/definitions/2.5.0/serverVariable.json",
             "type": "object",
             "description": "An object representing a Server Variable for server URL template substitution.",
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
@@ -278,7 +278,7 @@
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.5.0/SecurityRequirement.json": {
+        "SecurityRequirement": {
             "$id": "http://asyncapi.com/definitions/2.5.0/SecurityRequirement.json",
             "type": "object",
             "additionalProperties": {
@@ -289,7 +289,7 @@
                 "uniqueItems": true
             }
         },
-        "http://asyncapi.com/definitions/2.5.0/bindingsObject.json": {
+        "bindingsObject": {
             "$id": "http://asyncapi.com/definitions/2.5.0/bindingsObject.json",
             "type": "object",
             "additionalProperties": true,
@@ -312,7 +312,7 @@
                 "solace": {}
             }
         },
-        "http://asyncapi.com/definitions/2.5.0/tag.json": {
+        "tag": {
             "$id": "http://asyncapi.com/definitions/2.5.0/tag.json",
             "type": "object",
             "additionalProperties": false,
@@ -327,16 +327,16 @@
                     "type": "string"
                 },
                 "externalDocs": {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/externalDocs.json"
+                    "$ref": "#/definitions/externalDocs"
                 }
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.5.0/externalDocs.json": {
+        "externalDocs": {
             "$id": "http://asyncapi.com/definitions/2.5.0/externalDocs.json",
             "type": "object",
             "additionalProperties": false,
@@ -355,11 +355,11 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.5.0/channels.json": {
+        "channels": {
             "$id": "http://asyncapi.com/definitions/2.5.0/channels.json",
             "type": "object",
             "propertyNames": {
@@ -368,26 +368,26 @@
                 "minLength": 1
             },
             "additionalProperties": {
-                "$ref": "http://asyncapi.com/definitions/2.5.0/channelItem.json"
+                "$ref": "#/definitions/channelItem"
             }
         },
-        "http://asyncapi.com/definitions/2.5.0/channelItem.json": {
+        "channelItem": {
             "$id": "http://asyncapi.com/definitions/2.5.0/channelItem.json",
             "type": "object",
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
                 "$ref": {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/ReferenceObject.json"
+                    "$ref": "#/definitions/ReferenceObject"
                 },
                 "parameters": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "http://asyncapi.com/definitions/2.5.0/parameter.json"
+                        "$ref": "#/definitions/parameters"
                     }
                 },
                 "description": {
@@ -403,26 +403,41 @@
                     "uniqueItems": true
                 },
                 "publish": {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/operation.json"
+                    "$ref": "#/definitions/operation"
                 },
                 "subscribe": {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/operation.json"
+                    "$ref": "#/definitions/operation"
                 },
                 "deprecated": {
                     "type": "boolean",
                     "default": false
                 },
                 "bindings": {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/bindingsObject.json"
+                    "$ref": "#/definitions/bindingsObject"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.5.0/parameter.json": {
+        "parameters": {
+            "$id": "http://asyncapi.com/definitions/2.5.0/parameters.json",
+            "type": "object",
+            "additionalProperties": {
+                "oneOf": [
+                    {
+                        "$ref": "#/definitions/Reference"
+                    },
+                    {
+                        "$ref": "#/definitions/parameter"
+                    }
+                ]
+            },
+            "description": "JSON objects describing re-usable channel parameters."
+        },
+        "parameter": {
             "$id": "http://asyncapi.com/definitions/2.5.0/parameter.json",
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
@@ -431,7 +446,7 @@
                     "description": "A brief description of the parameter. This could contain examples of use. GitHub Flavored Markdown is allowed."
                 },
                 "schema": {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/schema.json"
+                    "$ref": "#/definitions/schema"
                 },
                 "location": {
                     "type": "string",
@@ -440,23 +455,23 @@
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.5.0/schema.json": {
+        "schema": {
             "$id": "http://asyncapi.com/definitions/2.5.0/schema.json",
             "allOf": [
                 {
-                    "$ref": "http://json-schema.org/draft-07/schema#"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 {
                     "patternProperties": {
                         "^x-[\\w\\d\\.\\x2d_]+$": {
-                            "$ref": "http://asyncapi.com/definitions/2.5.0/specificationExtension.json"
+                            "$ref": "#/definitions/specificationExtension"
                         }
                     },
                     "properties": {
                         "additionalProperties": {
                             "anyOf": [
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.5.0/schema.json"
+                                    "$ref": "#/definitions/schema"
                                 },
                                 {
                                     "type": "boolean"
@@ -467,13 +482,13 @@
                         "items": {
                             "anyOf": [
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.5.0/schema.json"
+                                    "$ref": "#/definitions/schema"
                                 },
                                 {
                                     "type": "array",
                                     "minItems": 1,
                                     "items": {
-                                        "$ref": "http://asyncapi.com/definitions/2.5.0/schema.json"
+                                        "$ref": "#/definitions/schema"
                                     }
                                 }
                             ],
@@ -483,51 +498,51 @@
                             "type": "array",
                             "minItems": 1,
                             "items": {
-                                "$ref": "http://asyncapi.com/definitions/2.5.0/schema.json"
+                                "$ref": "#/definitions/schema"
                             }
                         },
                         "oneOf": {
                             "type": "array",
                             "minItems": 1,
                             "items": {
-                                "$ref": "http://asyncapi.com/definitions/2.5.0/schema.json"
+                                "$ref": "#/definitions/schema"
                             }
                         },
                         "anyOf": {
                             "type": "array",
                             "minItems": 1,
                             "items": {
-                                "$ref": "http://asyncapi.com/definitions/2.5.0/schema.json"
+                                "$ref": "#/definitions/schema"
                             }
                         },
                         "not": {
-                            "$ref": "http://asyncapi.com/definitions/2.5.0/schema.json"
+                            "$ref": "#/definitions/schema"
                         },
                         "properties": {
                             "type": "object",
                             "additionalProperties": {
-                                "$ref": "http://asyncapi.com/definitions/2.5.0/schema.json"
+                                "$ref": "#/definitions/schema"
                             },
                             "default": {}
                         },
                         "patternProperties": {
                             "type": "object",
                             "additionalProperties": {
-                                "$ref": "http://asyncapi.com/definitions/2.5.0/schema.json"
+                                "$ref": "#/definitions/schema"
                             },
                             "default": {}
                         },
                         "propertyNames": {
-                            "$ref": "http://asyncapi.com/definitions/2.5.0/schema.json"
+                            "$ref": "#/definitions/schema"
                         },
                         "contains": {
-                            "$ref": "http://asyncapi.com/definitions/2.5.0/schema.json"
+                            "$ref": "#/definitions/schema"
                         },
                         "discriminator": {
                             "type": "string"
                         },
                         "externalDocs": {
-                            "$ref": "http://asyncapi.com/definitions/2.5.0/externalDocs.json"
+                            "$ref": "#/definitions/externalDocs"
                         },
                         "deprecated": {
                             "type": "boolean",
@@ -537,7 +552,7 @@
                 }
             ]
         },
-        "http://json-schema.org/draft-07/schema": {
+        "json-schema-draft-07-schema": {
             "$id": "http://json-schema.org/draft-07/schema",
             "title": "Core schema meta-schema",
             "definitions": {
@@ -545,7 +560,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#"
+                        "$ref": "#/definitions/json-schema-draft-07-schema"
                     }
                 },
                 "nonNegativeInteger": {
@@ -555,7 +570,7 @@
                 "nonNegativeIntegerDefault0": {
                     "allOf": [
                         {
-                            "$ref": "#/definitions/nonNegativeInteger"
+                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/nonNegativeInteger"
                         },
                         {
                             "default": 0
@@ -638,72 +653,72 @@
                     "type": "number"
                 },
                 "maxLength": {
-                    "$ref": "#/definitions/nonNegativeInteger"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/nonNegativeInteger"
                 },
                 "minLength": {
-                    "$ref": "#/definitions/nonNegativeIntegerDefault0"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/nonNegativeIntegerDefault0"
                 },
                 "pattern": {
                     "type": "string",
                     "format": "regex"
                 },
                 "additionalItems": {
-                    "$ref": "#"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "items": {
                     "anyOf": [
                         {
-                            "$ref": "#"
+                            "$ref": "#/definitions/json-schema-draft-07-schema"
                         },
                         {
-                            "$ref": "#/definitions/schemaArray"
+                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/schemaArray"
                         }
                     ],
                     "default": true
                 },
                 "maxItems": {
-                    "$ref": "#/definitions/nonNegativeInteger"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/nonNegativeInteger"
                 },
                 "minItems": {
-                    "$ref": "#/definitions/nonNegativeIntegerDefault0"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/nonNegativeIntegerDefault0"
                 },
                 "uniqueItems": {
                     "type": "boolean",
                     "default": false
                 },
                 "contains": {
-                    "$ref": "#"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "maxProperties": {
-                    "$ref": "#/definitions/nonNegativeInteger"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/nonNegativeInteger"
                 },
                 "minProperties": {
-                    "$ref": "#/definitions/nonNegativeIntegerDefault0"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/nonNegativeIntegerDefault0"
                 },
                 "required": {
-                    "$ref": "#/definitions/stringArray"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/stringArray"
                 },
                 "additionalProperties": {
-                    "$ref": "#"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "definitions": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "#"
+                        "$ref": "#/definitions/json-schema-draft-07-schema"
                     },
                     "default": {}
                 },
                 "properties": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "#"
+                        "$ref": "#/definitions/json-schema-draft-07-schema"
                     },
                     "default": {}
                 },
                 "patternProperties": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "#"
+                        "$ref": "#/definitions/json-schema-draft-07-schema"
                     },
                     "propertyNames": {
                         "format": "regex"
@@ -715,16 +730,16 @@
                     "additionalProperties": {
                         "anyOf": [
                             {
-                                "$ref": "#"
+                                "$ref": "#/definitions/json-schema-draft-07-schema"
                             },
                             {
-                                "$ref": "#/definitions/stringArray"
+                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/stringArray"
                             }
                         ]
                     }
                 },
                 "propertyNames": {
-                    "$ref": "#"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "const": true,
                 "enum": {
@@ -736,12 +751,12 @@
                 "type": {
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/simpleTypes"
+                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/simpleTypes"
                         },
                         {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/simpleTypes"
+                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/simpleTypes"
                             },
                             "minItems": 1,
                             "uniqueItems": true
@@ -758,36 +773,36 @@
                     "type": "string"
                 },
                 "if": {
-                    "$ref": "#"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "then": {
-                    "$ref": "#"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "else": {
-                    "$ref": "#"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 },
                 "allOf": {
-                    "$ref": "#/definitions/schemaArray"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/schemaArray"
                 },
                 "anyOf": {
-                    "$ref": "#/definitions/schemaArray"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/schemaArray"
                 },
                 "oneOf": {
-                    "$ref": "#/definitions/schemaArray"
+                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/schemaArray"
                 },
                 "not": {
-                    "$ref": "#"
+                    "$ref": "#/definitions/json-schema-draft-07-schema"
                 }
             },
             "default": true
         },
-        "http://asyncapi.com/definitions/2.5.0/operation.json": {
+        "operation": {
             "$id": "http://asyncapi.com/definitions/2.5.0/operation.json",
             "type": "object",
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
@@ -796,10 +811,10 @@
                     "items": {
                         "oneOf": [
                             {
-                                "$ref": "http://asyncapi.com/definitions/2.5.0/Reference.json"
+                                "$ref": "#/definitions/Reference"
                             },
                             {
-                                "$ref": "http://asyncapi.com/definitions/2.5.0/operationTrait.json"
+                                "$ref": "#/definitions/operationTrait"
                             },
                             {
                                 "type": "array",
@@ -807,10 +822,10 @@
                                     {
                                         "oneOf": [
                                             {
-                                                "$ref": "http://asyncapi.com/definitions/2.5.0/Reference.json"
+                                                "$ref": "#/definitions/Reference"
                                             },
                                             {
-                                                "$ref": "http://asyncapi.com/definitions/2.5.0/operationTrait.json"
+                                                "$ref": "#/definitions/operationTrait"
                                             }
                                         ]
                                     },
@@ -832,37 +847,37 @@
                 "security": {
                     "type": "array",
                     "items": {
-                        "$ref": "http://asyncapi.com/definitions/2.5.0/SecurityRequirement.json"
+                        "$ref": "#/definitions/SecurityRequirement"
                     }
                 },
                 "tags": {
                     "type": "array",
                     "items": {
-                        "$ref": "http://asyncapi.com/definitions/2.5.0/tag.json"
+                        "$ref": "#/definitions/tag"
                     },
                     "uniqueItems": true
                 },
                 "externalDocs": {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/externalDocs.json"
+                    "$ref": "#/definitions/externalDocs"
                 },
                 "operationId": {
                     "type": "string"
                 },
                 "bindings": {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/bindingsObject.json"
+                    "$ref": "#/definitions/bindingsObject"
                 },
                 "message": {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/message.json"
+                    "$ref": "#/definitions/message"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.5.0/operationTrait.json": {
+        "operationTrait": {
             "$id": "http://asyncapi.com/definitions/2.5.0/operationTrait.json",
             "type": "object",
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
@@ -875,12 +890,12 @@
                 "tags": {
                     "type": "array",
                     "items": {
-                        "$ref": "http://asyncapi.com/definitions/2.5.0/tag.json"
+                        "$ref": "#/definitions/tag"
                     },
                     "uniqueItems": true
                 },
                 "externalDocs": {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/externalDocs.json"
+                    "$ref": "#/definitions/externalDocs"
                 },
                 "operationId": {
                     "type": "string"
@@ -888,19 +903,19 @@
                 "security": {
                     "type": "array",
                     "items": {
-                        "$ref": "http://asyncapi.com/definitions/2.5.0/SecurityRequirement.json"
+                        "$ref": "#/definitions/SecurityRequirement"
                     }
                 },
                 "bindings": {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/bindingsObject.json"
+                    "$ref": "#/definitions/bindingsObject"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.5.0/message.json": {
+        "message": {
             "$id": "http://asyncapi.com/definitions/2.5.0/message.json",
             "oneOf": [
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/Reference.json"
+                    "$ref": "#/definitions/Reference"
                 },
                 {
                     "oneOf": [
@@ -914,7 +929,7 @@
                                 "oneOf": {
                                     "type": "array",
                                     "items": {
-                                        "$ref": "http://asyncapi.com/definitions/2.5.0/message.json"
+                                        "$ref": "#/definitions/message"
                                     }
                                 }
                             }
@@ -924,7 +939,7 @@
                             "additionalProperties": false,
                             "patternProperties": {
                                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                                    "$ref": "http://asyncapi.com/definitions/2.5.0/specificationExtension.json"
+                                    "$ref": "#/definitions/specificationExtension"
                                 }
                             },
                             "properties": {
@@ -937,7 +952,7 @@
                                 "headers": {
                                     "allOf": [
                                         {
-                                            "$ref": "http://asyncapi.com/definitions/2.5.0/schema.json"
+                                            "$ref": "#/definitions/schema"
                                         },
                                         {
                                             "properties": {
@@ -955,17 +970,17 @@
                                 "correlationId": {
                                     "oneOf": [
                                         {
-                                            "$ref": "http://asyncapi.com/definitions/2.5.0/Reference.json"
+                                            "$ref": "#/definitions/Reference"
                                         },
                                         {
-                                            "$ref": "http://asyncapi.com/definitions/2.5.0/correlationId.json"
+                                            "$ref": "#/definitions/correlationId"
                                         }
                                     ]
                                 },
                                 "tags": {
                                     "type": "array",
                                     "items": {
-                                        "$ref": "http://asyncapi.com/definitions/2.5.0/tag.json"
+                                        "$ref": "#/definitions/tag"
                                     },
                                     "uniqueItems": true
                                 },
@@ -986,7 +1001,7 @@
                                     "description": "A longer description of the message. CommonMark is allowed."
                                 },
                                 "externalDocs": {
-                                    "$ref": "http://asyncapi.com/definitions/2.5.0/externalDocs.json"
+                                    "$ref": "#/definitions/externalDocs"
                                 },
                                 "deprecated": {
                                     "type": "boolean",
@@ -1026,17 +1041,17 @@
                                     }
                                 },
                                 "bindings": {
-                                    "$ref": "http://asyncapi.com/definitions/2.5.0/bindingsObject.json"
+                                    "$ref": "#/definitions/bindingsObject"
                                 },
                                 "traits": {
                                     "type": "array",
                                     "items": {
                                         "oneOf": [
                                             {
-                                                "$ref": "http://asyncapi.com/definitions/2.5.0/Reference.json"
+                                                "$ref": "#/definitions/Reference"
                                             },
                                             {
-                                                "$ref": "http://asyncapi.com/definitions/2.5.0/messageTrait.json"
+                                                "$ref": "#/definitions/messageTrait"
                                             },
                                             {
                                                 "type": "array",
@@ -1044,10 +1059,10 @@
                                                     {
                                                         "oneOf": [
                                                             {
-                                                                "$ref": "http://asyncapi.com/definitions/2.5.0/Reference.json"
+                                                                "$ref": "#/definitions/Reference"
                                                             },
                                                             {
-                                                                "$ref": "http://asyncapi.com/definitions/2.5.0/messageTrait.json"
+                                                                "$ref": "#/definitions/messageTrait"
                                                             }
                                                         ]
                                                     },
@@ -1066,7 +1081,7 @@
                 }
             ]
         },
-        "http://asyncapi.com/definitions/2.5.0/correlationId.json": {
+        "correlationId": {
             "$id": "http://asyncapi.com/definitions/2.5.0/correlationId.json",
             "type": "object",
             "required": [
@@ -1075,7 +1090,7 @@
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
@@ -1090,13 +1105,13 @@
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.5.0/messageTrait.json": {
+        "messageTrait": {
             "$id": "http://asyncapi.com/definitions/2.5.0/messageTrait.json",
             "type": "object",
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
@@ -1109,7 +1124,7 @@
                 "headers": {
                     "allOf": [
                         {
-                            "$ref": "http://asyncapi.com/definitions/2.5.0/schema.json"
+                            "$ref": "#/definitions/schema"
                         },
                         {
                             "properties": {
@@ -1126,17 +1141,17 @@
                 "correlationId": {
                     "oneOf": [
                         {
-                            "$ref": "http://asyncapi.com/definitions/2.5.0/Reference.json"
+                            "$ref": "#/definitions/Reference"
                         },
                         {
-                            "$ref": "http://asyncapi.com/definitions/2.5.0/correlationId.json"
+                            "$ref": "#/definitions/correlationId"
                         }
                     ]
                 },
                 "tags": {
                     "type": "array",
                     "items": {
-                        "$ref": "http://asyncapi.com/definitions/2.5.0/tag.json"
+                        "$ref": "#/definitions/tag"
                     },
                     "uniqueItems": true
                 },
@@ -1157,7 +1172,7 @@
                     "description": "A longer description of the message. CommonMark is allowed."
                 },
                 "externalDocs": {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/externalDocs.json"
+                    "$ref": "#/definitions/externalDocs"
                 },
                 "deprecated": {
                     "type": "boolean",
@@ -1170,35 +1185,35 @@
                     }
                 },
                 "bindings": {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/bindingsObject.json"
+                    "$ref": "#/definitions/bindingsObject"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.5.0/components.json": {
+        "components": {
             "$id": "http://asyncapi.com/definitions/2.5.0/components.json",
             "type": "object",
             "description": "An object to hold a set of reusable objects for different aspects of the AsyncAPI Specification.",
             "additionalProperties": false,
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "properties": {
                 "schemas": {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/schemas.json"
+                    "$ref": "#/definitions/schemas"
                 },
                 "servers": {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/servers.json"
+                    "$ref": "#/definitions/servers"
                 },
                 "channels": {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/channels.json"
+                    "$ref": "#/definitions/channels"
                 },
                 "serverVariables": {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/serverVariables.json"
+                    "$ref": "#/definitions/serverVariables"
                 },
                 "messages": {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/messages.json"
+                    "$ref": "#/definitions/messages"
                 },
                 "securitySchemes": {
                     "type": "object",
@@ -1206,17 +1221,17 @@
                         "^[\\w\\d\\.\\-_]+$": {
                             "oneOf": [
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.5.0/Reference.json"
+                                    "$ref": "#/definitions/Reference"
                                 },
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.5.0/SecurityScheme.json"
+                                    "$ref": "#/definitions/SecurityScheme"
                                 }
                             ]
                         }
                     }
                 },
                 "parameters": {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/parameters.json"
+                    "$ref": "#/definitions/parameters"
                 },
                 "correlationIds": {
                     "type": "object",
@@ -1224,10 +1239,10 @@
                         "^[\\w\\d\\.\\-_]+$": {
                             "oneOf": [
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.5.0/Reference.json"
+                                    "$ref": "#/definitions/Reference"
                                 },
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.5.0/correlationId.json"
+                                    "$ref": "#/definitions/correlationId"
                                 }
                             ]
                         }
@@ -1236,90 +1251,90 @@
                 "operationTraits": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "http://asyncapi.com/definitions/2.5.0/operationTrait.json"
+                        "$ref": "#/definitions/operationTrait"
                     }
                 },
                 "messageTraits": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "http://asyncapi.com/definitions/2.5.0/messageTrait.json"
+                        "$ref": "#/definitions/messageTrait"
                     }
                 },
                 "serverBindings": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "http://asyncapi.com/definitions/2.5.0/bindingsObject.json"
+                        "$ref": "#/definitions/bindingsObject"
                     }
                 },
                 "channelBindings": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "http://asyncapi.com/definitions/2.5.0/bindingsObject.json"
+                        "$ref": "#/definitions/bindingsObject"
                     }
                 },
                 "operationBindings": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "http://asyncapi.com/definitions/2.5.0/bindingsObject.json"
+                        "$ref": "#/definitions/bindingsObject"
                     }
                 },
                 "messageBindings": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "http://asyncapi.com/definitions/2.5.0/bindingsObject.json"
+                        "$ref": "#/definitions/bindingsObject"
                     }
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.5.0/schemas.json": {
+        "schemas": {
             "$id": "http://asyncapi.com/definitions/2.5.0/schemas.json",
             "type": "object",
             "additionalProperties": {
-                "$ref": "http://asyncapi.com/definitions/2.5.0/schema.json"
+                "$ref": "#/definitions/schema"
             },
             "description": "JSON objects describing schemas the API uses."
         },
-        "http://asyncapi.com/definitions/2.5.0/messages.json": {
+        "messages": {
             "$id": "http://asyncapi.com/definitions/2.5.0/messages.json",
             "type": "object",
             "additionalProperties": {
-                "$ref": "http://asyncapi.com/definitions/2.5.0/message.json"
+                "$ref": "#/definitions/message"
             },
             "description": "JSON objects describing the messages being consumed and produced by the API."
         },
-        "http://asyncapi.com/definitions/2.5.0/SecurityScheme.json": {
+        "SecurityScheme": {
             "$id": "http://asyncapi.com/definitions/2.5.0/SecurityScheme.json",
             "oneOf": [
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/userPassword.json"
+                    "$ref": "#/definitions/userPassword"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/apiKey.json"
+                    "$ref": "#/definitions/apiKey"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/X509.json"
+                    "$ref": "#/definitions/X509"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/symmetricEncryption.json"
+                    "$ref": "#/definitions/symmetricEncryption"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/asymmetricEncryption.json"
+                    "$ref": "#/definitions/asymmetricEncryption"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/HTTPSecurityScheme.json"
+                    "$ref": "#/definitions/HTTPSecurityScheme"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/oauth2Flows.json"
+                    "$ref": "#/definitions/oauth2Flows"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/openIdConnect.json"
+                    "$ref": "#/definitions/openIdConnect"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/SaslSecurityScheme.json"
+                    "$ref": "#/definitions/SaslSecurityScheme"
                 }
             ]
         },
-        "http://asyncapi.com/definitions/2.5.0/userPassword.json": {
+        "userPassword": {
             "$id": "http://asyncapi.com/definitions/2.5.0/userPassword.json",
             "type": "object",
             "required": [
@@ -1338,12 +1353,12 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.5.0/apiKey.json": {
+        "apiKey": {
             "$id": "http://asyncapi.com/definitions/2.5.0/apiKey.json",
             "type": "object",
             "required": [
@@ -1370,12 +1385,12 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.5.0/X509.json": {
+        "X509": {
             "$id": "http://asyncapi.com/definitions/2.5.0/X509.json",
             "type": "object",
             "required": [
@@ -1394,12 +1409,12 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.5.0/symmetricEncryption.json": {
+        "symmetricEncryption": {
             "$id": "http://asyncapi.com/definitions/2.5.0/symmetricEncryption.json",
             "type": "object",
             "required": [
@@ -1418,12 +1433,12 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.5.0/asymmetricEncryption.json": {
+        "asymmetricEncryption": {
             "$id": "http://asyncapi.com/definitions/2.5.0/asymmetricEncryption.json",
             "type": "object",
             "required": [
@@ -1442,26 +1457,26 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.5.0/HTTPSecurityScheme.json": {
+        "HTTPSecurityScheme": {
             "$id": "http://asyncapi.com/definitions/2.5.0/HTTPSecurityScheme.json",
             "oneOf": [
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/NonBearerHTTPSecurityScheme.json"
+                    "$ref": "#/definitions/NonBearerHTTPSecurityScheme"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/BearerHTTPSecurityScheme.json"
+                    "$ref": "#/definitions/BearerHTTPSecurityScheme"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/APIKeyHTTPSecurityScheme.json"
+                    "$ref": "#/definitions/APIKeyHTTPSecurityScheme"
                 }
             ]
         },
-        "http://asyncapi.com/definitions/2.5.0/NonBearerHTTPSecurityScheme.json": {
+        "NonBearerHTTPSecurityScheme": {
             "$id": "http://asyncapi.com/definitions/2.5.0/NonBearerHTTPSecurityScheme.json",
             "not": {
                 "type": "object",
@@ -1495,12 +1510,12 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.5.0/BearerHTTPSecurityScheme.json": {
+        "BearerHTTPSecurityScheme": {
             "$id": "http://asyncapi.com/definitions/2.5.0/BearerHTTPSecurityScheme.json",
             "type": "object",
             "required": [
@@ -1529,12 +1544,12 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.5.0/APIKeyHTTPSecurityScheme.json": {
+        "APIKeyHTTPSecurityScheme": {
             "$id": "http://asyncapi.com/definitions/2.5.0/APIKeyHTTPSecurityScheme.json",
             "type": "object",
             "required": [
@@ -1566,12 +1581,12 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.5.0/oauth2Flows.json": {
+        "oauth2Flows": {
             "$id": "http://asyncapi.com/definitions/2.5.0/oauth2Flows.json",
             "type": "object",
             "required": [
@@ -1594,7 +1609,7 @@
                         "implicit": {
                             "allOf": [
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.5.0/oauth2Flow.json"
+                                    "$ref": "#/definitions/oauth2Flow"
                                 },
                                 {
                                     "required": [
@@ -1614,7 +1629,7 @@
                         "password": {
                             "allOf": [
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.5.0/oauth2Flow.json"
+                                    "$ref": "#/definitions/oauth2Flow"
                                 },
                                 {
                                     "required": [
@@ -1634,7 +1649,7 @@
                         "clientCredentials": {
                             "allOf": [
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.5.0/oauth2Flow.json"
+                                    "$ref": "#/definitions/oauth2Flow"
                                 },
                                 {
                                     "required": [
@@ -1654,7 +1669,7 @@
                         "authorizationCode": {
                             "allOf": [
                                 {
-                                    "$ref": "http://asyncapi.com/definitions/2.5.0/oauth2Flow.json"
+                                    "$ref": "#/definitions/oauth2Flow"
                                 },
                                 {
                                     "required": [
@@ -1671,11 +1686,11 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             }
         },
-        "http://asyncapi.com/definitions/2.5.0/oauth2Flow.json": {
+        "oauth2Flow": {
             "$id": "http://asyncapi.com/definitions/2.5.0/oauth2Flow.json",
             "type": "object",
             "properties": {
@@ -1692,24 +1707,24 @@
                     "format": "uri"
                 },
                 "scopes": {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/oauth2Scopes.json"
+                    "$ref": "#/definitions/oauth2Scopes"
                 }
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.5.0/oauth2Scopes.json": {
+        "oauth2Scopes": {
             "$id": "http://asyncapi.com/definitions/2.5.0/oauth2Scopes.json",
             "type": "object",
             "additionalProperties": {
                 "type": "string"
             }
         },
-        "http://asyncapi.com/definitions/2.5.0/openIdConnect.json": {
+        "openIdConnect": {
             "$id": "http://asyncapi.com/definitions/2.5.0/openIdConnect.json",
             "type": "object",
             "required": [
@@ -1733,26 +1748,26 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.5.0/SaslSecurityScheme.json": {
+        "SaslSecurityScheme": {
             "$id": "http://asyncapi.com/definitions/2.5.0/SaslSecurityScheme.json",
             "oneOf": [
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/SaslPlainSecurityScheme.json"
+                    "$ref": "#/definitions/SaslPlainSecurityScheme"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/SaslScramSecurityScheme.json"
+                    "$ref": "#/definitions/SaslScramSecurityScheme"
                 },
                 {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/SaslGssapiSecurityScheme.json"
+                    "$ref": "#/definitions/SaslGssapiSecurityScheme"
                 }
             ]
         },
-        "http://asyncapi.com/definitions/2.5.0/SaslPlainSecurityScheme.json": {
+        "SaslPlainSecurityScheme": {
             "$id": "http://asyncapi.com/definitions/2.5.0/SaslPlainSecurityScheme.json",
             "type": "object",
             "required": [
@@ -1771,12 +1786,12 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.5.0/SaslScramSecurityScheme.json": {
+        "SaslScramSecurityScheme": {
             "$id": "http://asyncapi.com/definitions/2.5.0/SaslScramSecurityScheme.json",
             "type": "object",
             "required": [
@@ -1796,12 +1811,12 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
         },
-        "http://asyncapi.com/definitions/2.5.0/SaslGssapiSecurityScheme.json": {
+        "SaslGssapiSecurityScheme": {
             "$id": "http://asyncapi.com/definitions/2.5.0/SaslGssapiSecurityScheme.json",
             "type": "object",
             "required": [
@@ -1820,25 +1835,10 @@
             },
             "patternProperties": {
                 "^x-[\\w\\d\\.\\x2d_]+$": {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/specificationExtension.json"
+                    "$ref": "#/definitions/specificationExtension"
                 }
             },
             "additionalProperties": false
-        },
-        "http://asyncapi.com/definitions/2.5.0/parameters.json": {
-            "$id": "http://asyncapi.com/definitions/2.5.0/parameters.json",
-            "type": "object",
-            "additionalProperties": {
-                "oneOf": [
-                    {
-                        "$ref": "http://asyncapi.com/definitions/2.5.0/Reference.json"
-                    },
-                    {
-                        "$ref": "http://asyncapi.com/definitions/2.5.0/parameter.json"
-                    }
-                ]
-            },
-            "description": "JSON objects describing re-usable channel parameters."
         }
     },
     "description": "!!Auto generated!! \n Do not manually edit. "

--- a/tools/bundler/index.js
+++ b/tools/bundler/index.js
@@ -31,11 +31,11 @@ console.log(`Using the following output directory: ${outputDirectory}`);
       const filePathToBundle = `file://${versionDir}/asyncapi.json`;
       const fileToBundle = await Bundler.get(filePathToBundle);
       const bundledSchema = await Bundler.bundle(fileToBundle);
-      const schemaWithoutURLs = modifyRefsandDefinitions(bundledSchema);
-      schemaWithoutURLs.description = `!!Auto generated!! \n Do not manually edit. ${schemaWithoutURLs.description ?? ''}`;
+      modifyRefsandDefinitions(bundledSchema);
+      bundledSchema.description = `!!Auto generated!! \n Do not manually edit. ${bundledSchema.description ?? ''}`;
       const outputFile = path.resolve(outputDirectory, `${version}.json`);
       console.log(`Writing the bundled file to: ${outputFile}`);
-      await fs.promises.writeFile(outputFile, JSON.stringify(schemaWithoutURLs, null, 4));
+      await fs.promises.writeFile(outputFile, JSON.stringify(bundledSchema, null, 4));
     }catch(e) {
       throw new Error(e);
     }
@@ -49,20 +49,17 @@ console.log(`Using the following output directory: ${outputDirectory}`);
  * than update refs to point to new definitions, always inline never remote
  */
 function modifyRefsandDefinitions(bundledSchema) {
-  const schemaWithoutUrls = bundledSchema;
 
   //first we need to improve names of the definitions from URL to their names
-  for (const def of Object.keys(schemaWithoutUrls.definitions)) {
+  for (const def of Object.keys(bundledSchema.definitions)) {
     const newDefName = getDefinitionName(def);
     
     //creating copy of definition under new name so later definition stored under URL name can be removed
-    schemaWithoutUrls.definitions[newDefName] = schemaWithoutUrls.definitions[def];
-    delete schemaWithoutUrls.definitions[def]
+    bundledSchema.definitions[newDefName] = bundledSchema.definitions[def];
+    delete bundledSchema.definitions[def]
   }
 
-  traverse(schemaWithoutUrls, replaceRef);
-
-  return schemaWithoutUrls;
+  traverse(bundledSchema, replaceRef);
 }
 
 /**


### PR DESCRIPTION
Fixes https://github.com/asyncapi/spec-json-schemas/issues/247
Fixes https://github.com/asyncapi/spec-json-schemas/issues/296

This is a workaround implementation. I'm not proud of it but it is better than the current situation.

Our AsyncAPI JSON Schema is created following JSON Schema best practices and also requirements of https://github.com/hyperjump-io/json-schema-bundle - which means we have beautiful `$id` and our references are based on these, which makes schema unreadable for humans (like me that completely do not understand `$id` and `$ref` concept, but my issues could be ignored and I could learn) and are not understood by some tools (like https://github.com/redhat-developer/vscode-yaml that VSCode YAML autocompletion and validation is based on, and this is a problem for us).

- Why workaround and not something we can solve at above-mentioned bundler level? -> https://github.com/hyperjump-io/json-schema-bundle/issues/9
- Why not solve this with the above-mentioned YAML plugin managed by RedHat? -> let me answer with question: what assurance do we get it will not break in the future with further contributions to the plugin, or that other tools do it the proper way?

---
- This PR also contains generated schemas, under `schemas` dir for reference so you see what has changed in these because of the new bundler
- I tested newly generated schemas with asyncapi file on local,  and autocompletion and validation works + this way I discovered issue with `parameters`


PS. @jonaslagoni not sure if `$id` should be removed from these schemas 🤔 

