### PR TITLE
feat: channel's servers field allows references

### DIFF
--- a/definitions/3.0.0/channel.json
+++ b/definitions/3.0.0/channel.json
@@ -26,9 +26,9 @@
     },
     "servers": {
       "type": "array",
-      "description": "The names of the servers on which this channel is available. If absent or empty then this channel must be available on all servers.",
+      "description": "The references of the servers on which this channel is available. If absent or empty then this channel must be available on all servers.",
       "items": {
-        "type": "string"
+        "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
       },
       "uniqueItems": true
     },


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Channel's `servers` field allows references to the servers (not names).

Spec PR: https://github.com/asyncapi/spec/pull/852

**Related issue(s)**
Part of https://github.com/asyncapi/spec/pull/852