### PR TITLE
fix: allow references in parameters

### DIFF
--- a/definitions/2.0.0-rc1/channelItem.json
+++ b/definitions/2.0.0-rc1/channelItem.json
@@ -12,12 +12,7 @@
       "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/ReferenceObject.json"
     },
     "parameters": {
-      "type": "array",
-      "uniqueItems": true,
-      "minItems": 1,
-      "items": {
-        "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/parameter.json"
-      }
+      "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/parameters.json"
     },
     "publish": {
       "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/operation.json"

--- a/definitions/2.0.0-rc1/parameters.json
+++ b/definitions/2.0.0-rc1/parameters.json
@@ -1,7 +1,14 @@
 {
   "type": "object",
   "additionalProperties": {
-    "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/parameter.json"
+    "oneOf": [
+      {
+        "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/Reference.json"
+      },
+      {
+        "$ref": "http://asyncapi.com/definitions/2.0.0-rc1/parameter.json"
+      }
+    ]
   },
   "description": "JSON objects describing re-usable channel parameters.",
   "$schema": "http://json-schema.org/draft-07/schema#",

--- a/definitions/2.0.0-rc2/channelItem.json
+++ b/definitions/2.0.0-rc2/channelItem.json
@@ -12,10 +12,7 @@
       "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/ReferenceObject.json"
     },
     "parameters": {
-      "type": "object",
-      "additionalProperties": {
-        "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/parameter.json"
-      }
+      "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/parameters.json"
     },
     "description": {
       "type": "string",

--- a/definitions/2.0.0-rc2/parameters.json
+++ b/definitions/2.0.0-rc2/parameters.json
@@ -1,7 +1,14 @@
 {
   "type": "object",
   "additionalProperties": {
-    "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/parameter.json"
+    "oneOf": [
+      {
+        "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/Reference.json"
+      },
+      {
+        "$ref": "http://asyncapi.com/definitions/2.0.0-rc2/parameter.json"
+      }
+    ]
   },
   "description": "JSON objects describing re-usable channel parameters.",
   "$schema": "http://json-schema.org/draft-07/schema#",

--- a/definitions/2.0.0/channelItem.json
+++ b/definitions/2.0.0/channelItem.json
@@ -11,10 +11,7 @@
       "$ref": "http://asyncapi.com/definitions/2.0.0/ReferenceObject.json"
     },
     "parameters": {
-      "type": "object",
-      "additionalProperties": {
-        "$ref": "http://asyncapi.com/definitions/2.0.0/parameter.json"
-      }
+      "$ref": "http://asyncapi.com/definitions/2.0.0/parameters.json"
     },
     "description": {
       "type": "string",

--- a/definitions/2.0.0/parameters.json
+++ b/definitions/2.0.0/parameters.json
@@ -1,7 +1,14 @@
 {
   "type": "object",
   "additionalProperties": {
-    "$ref": "http://asyncapi.com/definitions/2.0.0/parameter.json"
+    "oneOf": [
+      {
+        "$ref": "http://asyncapi.com/definitions/2.0.0/Reference.json"
+      },
+      {
+        "$ref": "http://asyncapi.com/definitions/2.0.0/parameter.json"
+      }
+    ]
   },
   "description": "JSON objects describing re-usable channel parameters.",
   "$schema": "http://json-schema.org/draft-07/schema#",

--- a/definitions/2.1.0/channelItem.json
+++ b/definitions/2.1.0/channelItem.json
@@ -11,10 +11,7 @@
       "$ref": "http://asyncapi.com/definitions/2.1.0/ReferenceObject.json"
     },
     "parameters": {
-      "type": "object",
-      "additionalProperties": {
-        "$ref": "http://asyncapi.com/definitions/2.1.0/parameter.json"
-      }
+      "$ref": "http://asyncapi.com/definitions/2.1.0/parameters.json"
     },
     "description": {
       "type": "string",

--- a/definitions/2.1.0/parameters.json
+++ b/definitions/2.1.0/parameters.json
@@ -1,7 +1,14 @@
 {
   "type": "object",
   "additionalProperties": {
-    "$ref": "http://asyncapi.com/definitions/2.1.0/parameter.json"
+    "oneOf": [
+      {
+        "$ref": "http://asyncapi.com/definitions/2.1.0/Reference.json"
+      },
+      {
+        "$ref": "http://asyncapi.com/definitions/2.1.0/parameter.json"
+      }
+    ]
   },
   "description": "JSON objects describing re-usable channel parameters.",
   "$schema": "http://json-schema.org/draft-07/schema#",

--- a/definitions/2.2.0/channelItem.json
+++ b/definitions/2.2.0/channelItem.json
@@ -11,10 +11,7 @@
       "$ref": "http://asyncapi.com/definitions/2.2.0/ReferenceObject.json"
     },
     "parameters": {
-      "type": "object",
-      "additionalProperties": {
-        "$ref": "http://asyncapi.com/definitions/2.2.0/parameter.json"
-      }
+      "$ref": "http://asyncapi.com/definitions/2.2.0/parameters.json"
     },
     "description": {
       "type": "string",

--- a/definitions/2.2.0/parameters.json
+++ b/definitions/2.2.0/parameters.json
@@ -1,7 +1,14 @@
 {
   "type": "object",
   "additionalProperties": {
-    "$ref": "http://asyncapi.com/definitions/2.2.0/parameter.json"
+    "oneOf": [
+      {
+        "$ref": "http://asyncapi.com/definitions/2.2.0/Reference.json"
+      },
+      {
+        "$ref": "http://asyncapi.com/definitions/2.2.0/parameter.json"
+      }
+    ]
   },
   "description": "JSON objects describing re-usable channel parameters.",
   "$schema": "http://json-schema.org/draft-07/schema#",

--- a/definitions/2.3.0/channelItem.json
+++ b/definitions/2.3.0/channelItem.json
@@ -11,10 +11,7 @@
       "$ref": "http://asyncapi.com/definitions/2.3.0/ReferenceObject.json"
     },
     "parameters": {
-      "type": "object",
-      "additionalProperties": {
-        "$ref": "http://asyncapi.com/definitions/2.3.0/parameter.json"
-      }
+      "$ref": "http://asyncapi.com/definitions/2.3.0/parameters.json"
     },
     "description": {
       "type": "string",

--- a/definitions/2.3.0/parameters.json
+++ b/definitions/2.3.0/parameters.json
@@ -1,7 +1,14 @@
 {
   "type": "object",
   "additionalProperties": {
-    "$ref": "http://asyncapi.com/definitions/2.3.0/parameter.json"
+    "oneOf": [
+      {
+        "$ref": "http://asyncapi.com/definitions/2.3.0/Reference.json"
+      },
+      {
+        "$ref": "http://asyncapi.com/definitions/2.3.0/parameter.json"
+      }
+    ]
   },
   "description": "JSON objects describing re-usable channel parameters.",
   "$schema": "http://json-schema.org/draft-07/schema#",

--- a/definitions/2.4.0/channelItem.json
+++ b/definitions/2.4.0/channelItem.json
@@ -11,10 +11,7 @@
       "$ref": "http://asyncapi.com/definitions/2.4.0/ReferenceObject.json"
     },
     "parameters": {
-      "type": "object",
-      "additionalProperties": {
-        "$ref": "http://asyncapi.com/definitions/2.4.0/parameter.json"
-      }
+      "$ref": "http://asyncapi.com/definitions/2.4.0/parameters.json"
     },
     "description": {
       "type": "string",

--- a/definitions/2.4.0/parameters.json
+++ b/definitions/2.4.0/parameters.json
@@ -1,7 +1,14 @@
 {
   "type": "object",
   "additionalProperties": {
-    "$ref": "http://asyncapi.com/definitions/2.4.0/parameter.json"
+    "oneOf": [
+      {
+        "$ref": "http://asyncapi.com/definitions/2.4.0/Reference.json"
+      },
+      {
+        "$ref": "http://asyncapi.com/definitions/2.4.0/parameter.json"
+      }
+    ]
   },
   "description": "JSON objects describing re-usable channel parameters.",
   "$schema": "http://json-schema.org/draft-07/schema#",

--- a/definitions/2.5.0/channelItem.json
+++ b/definitions/2.5.0/channelItem.json
@@ -11,10 +11,7 @@
       "$ref": "http://asyncapi.com/definitions/2.5.0/ReferenceObject.json"
     },
     "parameters": {
-      "type": "object",
-      "additionalProperties": {
-        "$ref": "http://asyncapi.com/definitions/2.5.0/parameter.json"
-      }
+      "$ref": "http://asyncapi.com/definitions/2.5.0/parameters.json"
     },
     "description": {
       "type": "string",

--- a/definitions/2.6.0/channelItem.json
+++ b/definitions/2.6.0/channelItem.json
@@ -11,10 +11,7 @@
       "$ref": "http://asyncapi.com/definitions/2.6.0/ReferenceObject.json"
     },
     "parameters": {
-      "type": "object",
-      "additionalProperties": {
-        "$ref": "http://asyncapi.com/definitions/2.6.0/parameter.json"
-      }
+      "$ref": "http://asyncapi.com/definitions/2.6.0/parameters.json"
     },
     "description": {
       "type": "string",


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Allow references in channel parameters - fix all versions from `2.0.0-rc1`.

**Related issue(s)**
Fixes https://github.com/asyncapi/spec-json-schemas/issues/296