### PR TITLE
fix: remove unnecessary property

### DIFF
--- a/definitions/2.0.0-rc1/message.json
+++ b/definitions/2.0.0-rc1/message.json
@@ -103,8 +103,7 @@
                 ]
               },
               {
-                "type": "object",
-                "additionalItems": true
+                "type": "object"
               }
             ]
           }

--- a/definitions/2.0.0-rc1/operation.json
+++ b/definitions/2.0.0-rc1/operation.json
@@ -31,8 +31,7 @@
                 ]
               },
               {
-                "type": "object",
-                "additionalItems": true
+                "type": "object"
               }
             ]
           }

--- a/definitions/2.0.0-rc2/message.json
+++ b/definitions/2.0.0-rc2/message.json
@@ -112,8 +112,7 @@
                         ]
                       },
                       {
-                        "type": "object",
-                        "additionalItems": true
+                        "type": "object"
                       }
                     ]
                   }

--- a/definitions/2.0.0-rc2/operation.json
+++ b/definitions/2.0.0-rc2/operation.json
@@ -31,8 +31,7 @@
                 ]
               },
               {
-                "type": "object",
-                "additionalItems": true
+                "type": "object"
               }
             ]
           }

--- a/definitions/2.0.0/message.json
+++ b/definitions/2.0.0/message.json
@@ -130,8 +130,7 @@
                         ]
                       },
                       {
-                        "type": "object",
-                        "additionalItems": true
+                        "type": "object"
                       }
                     ]
                   }

--- a/definitions/2.0.0/operation.json
+++ b/definitions/2.0.0/operation.json
@@ -31,8 +31,7 @@
                 ]
               },
               {
-                "type": "object",
-                "additionalItems": true
+                "type": "object"
               }
             ]
           }

--- a/definitions/2.1.0/message.json
+++ b/definitions/2.1.0/message.json
@@ -150,8 +150,7 @@
                         ]
                       },
                       {
-                        "type": "object",
-                        "additionalItems": true
+                        "type": "object"
                       }
                     ]
                   }

--- a/definitions/2.1.0/operation.json
+++ b/definitions/2.1.0/operation.json
@@ -31,8 +31,7 @@
                 ]
               },
               {
-                "type": "object",
-                "additionalItems": true
+                "type": "object"
               }
             ]
           }

--- a/definitions/2.2.0/message.json
+++ b/definitions/2.2.0/message.json
@@ -150,8 +150,7 @@
                         ]
                       },
                       {
-                        "type": "object",
-                        "additionalItems": true
+                        "type": "object"
                       }
                     ]
                   }

--- a/definitions/2.2.0/operation.json
+++ b/definitions/2.2.0/operation.json
@@ -31,8 +31,7 @@
                 ]
               },
               {
-                "type": "object",
-                "additionalItems": true
+                "type": "object"
               }
             ]
           }

--- a/definitions/2.3.0/message.json
+++ b/definitions/2.3.0/message.json
@@ -150,8 +150,7 @@
                         ]
                       },
                       {
-                        "type": "object",
-                        "additionalItems": true
+                        "type": "object"
                       }
                     ]
                   }

--- a/definitions/2.3.0/operation.json
+++ b/definitions/2.3.0/operation.json
@@ -31,8 +31,7 @@
                 ]
               },
               {
-                "type": "object",
-                "additionalItems": true
+                "type": "object"
               }
             ]
           }

--- a/definitions/2.4.0/message.json
+++ b/definitions/2.4.0/message.json
@@ -153,8 +153,7 @@
                         ]
                       },
                       {
-                        "type": "object",
-                        "additionalItems": true
+                        "type": "object"
                       }
                     ]
                   }

--- a/definitions/2.4.0/operation.json
+++ b/definitions/2.4.0/operation.json
@@ -31,8 +31,7 @@
                 ]
               },
               {
-                "type": "object",
-                "additionalItems": true
+                "type": "object"
               }
             ]
           }

--- a/definitions/2.5.0/message.json
+++ b/definitions/2.5.0/message.json
@@ -153,8 +153,7 @@
                         ]
                       },
                       {
-                        "type": "object",
-                        "additionalItems": true
+                        "type": "object"
                       }
                     ]
                   }

--- a/definitions/2.5.0/operation.json
+++ b/definitions/2.5.0/operation.json
@@ -31,8 +31,7 @@
                 ]
               },
               {
-                "type": "object",
-                "additionalItems": true
+                "type": "object"
               }
             ]
           }

--- a/definitions/2.6.0/message.json
+++ b/definitions/2.6.0/message.json
@@ -153,8 +153,7 @@
                         ]
                       },
                       {
-                        "type": "object",
-                        "additionalItems": true
+                        "type": "object"
                       }
                     ]
                   }

--- a/definitions/2.6.0/operation.json
+++ b/definitions/2.6.0/operation.json
@@ -31,8 +31,7 @@
                 ]
               },
               {
-                "type": "object",
-                "additionalItems": true
+                "type": "object"
               }
             ]
           }


### PR DESCRIPTION
**Description**
This PR removes the unnecessary `additionalItems` keyword.

**Related issue(s)**
Fixes https://github.com/asyncapi/spec-json-schemas/issues/81