### PR TITLE
fix: remove nested traits for operation and message

### DIFF
--- a/definitions/2.0.0/message.json
+++ b/definitions/2.0.0/message.json
@@ -115,25 +115,6 @@
                   },
                   {
                     "$ref": "http://asyncapi.com/definitions/2.0.0/messageTrait.json"
-                  },
-                  {
-                    "type": "array",
-                    "items": [
-                      {
-                        "oneOf": [
-                          {
-                            "$ref": "http://asyncapi.com/definitions/2.0.0/Reference.json"
-                          },
-                          {
-                            "$ref": "http://asyncapi.com/definitions/2.0.0/messageTrait.json"
-                          }
-                        ]
-                      },
-                      {
-                        "type": "object",
-                        "additionalItems": true
-                      }
-                    ]
                   }
                 ]
               }

--- a/definitions/2.0.0/operation.json
+++ b/definitions/2.0.0/operation.json
@@ -16,25 +16,6 @@
           },
           {
             "$ref": "http://asyncapi.com/definitions/2.0.0/operationTrait.json"
-          },
-          {
-            "type": "array",
-            "items": [
-              {
-                "oneOf": [
-                  {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0/Reference.json"
-                  },
-                  {
-                    "$ref": "http://asyncapi.com/definitions/2.0.0/operationTrait.json"
-                  }
-                ]
-              },
-              {
-                "type": "object",
-                "additionalItems": true
-              }
-            ]
           }
         ]
       }

--- a/definitions/2.1.0/message.json
+++ b/definitions/2.1.0/message.json
@@ -135,25 +135,6 @@
                   },
                   {
                     "$ref": "http://asyncapi.com/definitions/2.1.0/messageTrait.json"
-                  },
-                  {
-                    "type": "array",
-                    "items": [
-                      {
-                        "oneOf": [
-                          {
-                            "$ref": "http://asyncapi.com/definitions/2.1.0/Reference.json"
-                          },
-                          {
-                            "$ref": "http://asyncapi.com/definitions/2.1.0/messageTrait.json"
-                          }
-                        ]
-                      },
-                      {
-                        "type": "object",
-                        "additionalItems": true
-                      }
-                    ]
                   }
                 ]
               }

--- a/definitions/2.1.0/operation.json
+++ b/definitions/2.1.0/operation.json
@@ -16,25 +16,6 @@
           },
           {
             "$ref": "http://asyncapi.com/definitions/2.1.0/operationTrait.json"
-          },
-          {
-            "type": "array",
-            "items": [
-              {
-                "oneOf": [
-                  {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/Reference.json"
-                  },
-                  {
-                    "$ref": "http://asyncapi.com/definitions/2.1.0/operationTrait.json"
-                  }
-                ]
-              },
-              {
-                "type": "object",
-                "additionalItems": true
-              }
-            ]
           }
         ]
       }

--- a/definitions/2.2.0/message.json
+++ b/definitions/2.2.0/message.json
@@ -135,25 +135,6 @@
                   },
                   {
                     "$ref": "http://asyncapi.com/definitions/2.2.0/messageTrait.json"
-                  },
-                  {
-                    "type": "array",
-                    "items": [
-                      {
-                        "oneOf": [
-                          {
-                            "$ref": "http://asyncapi.com/definitions/2.2.0/Reference.json"
-                          },
-                          {
-                            "$ref": "http://asyncapi.com/definitions/2.2.0/messageTrait.json"
-                          }
-                        ]
-                      },
-                      {
-                        "type": "object",
-                        "additionalItems": true
-                      }
-                    ]
                   }
                 ]
               }

--- a/definitions/2.2.0/operation.json
+++ b/definitions/2.2.0/operation.json
@@ -16,25 +16,6 @@
           },
           {
             "$ref": "http://asyncapi.com/definitions/2.2.0/operationTrait.json"
-          },
-          {
-            "type": "array",
-            "items": [
-              {
-                "oneOf": [
-                  {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/Reference.json"
-                  },
-                  {
-                    "$ref": "http://asyncapi.com/definitions/2.2.0/operationTrait.json"
-                  }
-                ]
-              },
-              {
-                "type": "object",
-                "additionalItems": true
-              }
-            ]
           }
         ]
       }

--- a/definitions/2.3.0/message.json
+++ b/definitions/2.3.0/message.json
@@ -135,25 +135,6 @@
                   },
                   {
                     "$ref": "http://asyncapi.com/definitions/2.3.0/messageTrait.json"
-                  },
-                  {
-                    "type": "array",
-                    "items": [
-                      {
-                        "oneOf": [
-                          {
-                            "$ref": "http://asyncapi.com/definitions/2.3.0/Reference.json"
-                          },
-                          {
-                            "$ref": "http://asyncapi.com/definitions/2.3.0/messageTrait.json"
-                          }
-                        ]
-                      },
-                      {
-                        "type": "object",
-                        "additionalItems": true
-                      }
-                    ]
                   }
                 ]
               }

--- a/definitions/2.3.0/operation.json
+++ b/definitions/2.3.0/operation.json
@@ -16,25 +16,6 @@
           },
           {
             "$ref": "http://asyncapi.com/definitions/2.3.0/operationTrait.json"
-          },
-          {
-            "type": "array",
-            "items": [
-              {
-                "oneOf": [
-                  {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/Reference.json"
-                  },
-                  {
-                    "$ref": "http://asyncapi.com/definitions/2.3.0/operationTrait.json"
-                  }
-                ]
-              },
-              {
-                "type": "object",
-                "additionalItems": true
-              }
-            ]
           }
         ]
       }

--- a/definitions/2.4.0/message.json
+++ b/definitions/2.4.0/message.json
@@ -138,25 +138,6 @@
                   },
                   {
                     "$ref": "http://asyncapi.com/definitions/2.4.0/messageTrait.json"
-                  },
-                  {
-                    "type": "array",
-                    "items": [
-                      {
-                        "oneOf": [
-                          {
-                            "$ref": "http://asyncapi.com/definitions/2.4.0/Reference.json"
-                          },
-                          {
-                            "$ref": "http://asyncapi.com/definitions/2.4.0/messageTrait.json"
-                          }
-                        ]
-                      },
-                      {
-                        "type": "object",
-                        "additionalItems": true
-                      }
-                    ]
                   }
                 ]
               }

--- a/definitions/2.4.0/operation.json
+++ b/definitions/2.4.0/operation.json
@@ -16,25 +16,6 @@
           },
           {
             "$ref": "http://asyncapi.com/definitions/2.4.0/operationTrait.json"
-          },
-          {
-            "type": "array",
-            "items": [
-              {
-                "oneOf": [
-                  {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/Reference.json"
-                  },
-                  {
-                    "$ref": "http://asyncapi.com/definitions/2.4.0/operationTrait.json"
-                  }
-                ]
-              },
-              {
-                "type": "object",
-                "additionalItems": true
-              }
-            ]
           }
         ]
       }

--- a/definitions/2.5.0/message.json
+++ b/definitions/2.5.0/message.json
@@ -138,25 +138,6 @@
                   },
                   {
                     "$ref": "http://asyncapi.com/definitions/2.5.0/messageTrait.json"
-                  },
-                  {
-                    "type": "array",
-                    "items": [
-                      {
-                        "oneOf": [
-                          {
-                            "$ref": "http://asyncapi.com/definitions/2.5.0/Reference.json"
-                          },
-                          {
-                            "$ref": "http://asyncapi.com/definitions/2.5.0/messageTrait.json"
-                          }
-                        ]
-                      },
-                      {
-                        "type": "object",
-                        "additionalItems": true
-                      }
-                    ]
                   }
                 ]
               }

--- a/definitions/2.5.0/operation.json
+++ b/definitions/2.5.0/operation.json
@@ -16,25 +16,6 @@
           },
           {
             "$ref": "http://asyncapi.com/definitions/2.5.0/operationTrait.json"
-          },
-          {
-            "type": "array",
-            "items": [
-              {
-                "oneOf": [
-                  {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/Reference.json"
-                  },
-                  {
-                    "$ref": "http://asyncapi.com/definitions/2.5.0/operationTrait.json"
-                  }
-                ]
-              },
-              {
-                "type": "object",
-                "additionalItems": true
-              }
-            ]
           }
         ]
       }

--- a/definitions/2.6.0/message.json
+++ b/definitions/2.6.0/message.json
@@ -138,25 +138,6 @@
                   },
                   {
                     "$ref": "http://asyncapi.com/definitions/2.6.0/messageTrait.json"
-                  },
-                  {
-                    "type": "array",
-                    "items": [
-                      {
-                        "oneOf": [
-                          {
-                            "$ref": "http://asyncapi.com/definitions/2.6.0/Reference.json"
-                          },
-                          {
-                            "$ref": "http://asyncapi.com/definitions/2.6.0/messageTrait.json"
-                          }
-                        ]
-                      },
-                      {
-                        "type": "object",
-                        "additionalItems": true
-                      }
-                    ]
                   }
                 ]
               }

--- a/definitions/2.6.0/operation.json
+++ b/definitions/2.6.0/operation.json
@@ -16,25 +16,6 @@
           },
           {
             "$ref": "http://asyncapi.com/definitions/2.6.0/operationTrait.json"
-          },
-          {
-            "type": "array",
-            "items": [
-              {
-                "oneOf": [
-                  {
-                    "$ref": "http://asyncapi.com/definitions/2.6.0/Reference.json"
-                  },
-                  {
-                    "$ref": "http://asyncapi.com/definitions/2.6.0/operationTrait.json"
-                  }
-                ]
-              },
-              {
-                "type": "object",
-                "additionalItems": true
-              }
-            ]
           }
         ]
       }


### PR DESCRIPTION
**Description**
This PR removes the nested traits from operation and messages.

**Related issue(s)**
Resolves https://github.com/asyncapi/spec-json-schemas/issues/273
Resolves https://github.com/asyncapi/spec-json-schemas/issues/81