### PR TITLE
fix: oneOf should not be allowed in message components

### DIFF
--- a/definitions/3.0.0/components.json
+++ b/definitions/3.0.0/components.json
@@ -21,7 +21,19 @@
       "$ref": "http://asyncapi.com/definitions/3.0.0/serverVariables.json"
     },
     "messages": {
-      "$ref": "http://asyncapi.com/definitions/3.0.0/messages.json"
+      "type": "object",
+      "patternProperties": {
+        "^[\\w\\d\\.\\-_]+$": {
+          "oneOf": [
+            {
+              "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+            },
+            {
+              "$ref": "http://asyncapi.com/definitions/3.0.0/messageObject.json"
+            }
+          ]
+        }
+      }
     },
     "securitySchemes": {
       "type": "object",


### PR DESCRIPTION
**Description**
This PR fixes that it currently possible to define messages with oneOf in components when the spec clearly doesn't allow it.

Currently allowed, but should not:
```
components:
  messages:
    UserSignedUp:
      oneOf:
        - payload:
            type: object
            properties:
              displayName:
                type: string
                description: Name of the user
              email:
                type: string
                format: email
                description: Email of the user
```

**Related issue(s)**
Fixes https://github.com/asyncapi/spec-json-schemas/issues/335