### PR TITLE
fix: go module version now supports v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ const asyncapi = versions['1.1.0'];
 Grab a specific AsyncAPI version:
 
 ```go
-import "github.com/asyncapi/spec_json_schemas/v2"
+import "github.com/asyncapi/spec_json_schemas/v4"
 
 func Do() {
     schema, err := spec_json_schemas.Get("1.1.0")
@@ -152,3 +152,8 @@ The manual process of creating a new version is to:
        ]
     }
     ```
+
+### Handling breaking changes
+Whenever a Breaking Change is introduced, the following steps should be taken in Go package:
+
+1. Edit `go.mod` file, and increase the version package suffix in the module name. For example, if the current version is `v2.0.0`, and you are releasing `v3.0.0`, the module name should be `github.com/asyncapi/spec-json-schemas/v3`.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/asyncapi/spec-json-schemas/v2
+module github.com/asyncapi/spec-json-schemas/v4
 
 go 1.17
 


### PR DESCRIPTION
**Description**

Caused by https://github.com/asyncapi/spec-json-schemas/issues/376

Go package module name was never updated, and it should be done every time a major version is released.
It is not ideal, but at this time there is no other choice. We will investigate further in https://github.com/asyncapi/spec-json-schemas/issues/376.

**Related issue(s)**
https://github.com/asyncapi/spec-json-schemas/issues/376