### PR TITLE
fix: update references for avro and openapi schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Whenever you make changes in AsyncAPI JSON Schema, you should always manually ve
 - Once you make changes in schemas, bundle them with `npm run bundle`
 - Edit [this sample AsyncAPI document](./test/fixtures/asyncapi.yml). Add a new field, hover over some property to see if tooltip still shows up. This sample document contains the following line that assures YAML uses your local schema and not the one from SchemaStore. Make sure it points to the schema bundle that you generated and that contains your changes:
    ```yaml
-   # yaml-language-server: $schema=/Users/wookiee/sources/asyncapi-node/schemas/2.6.0-without-$id.json
+   # yaml-language-server: $schema=YOUR-PROJECTS-DIRECTORY/spec-json-schemas/schemas/2.6.0-without-$id.json
    ```
 
 

--- a/README.md
+++ b/README.md
@@ -125,9 +125,9 @@ These definitions are automatically bundled together on new releases through the
 
 For example, for [2.2.0](./definitions/2.2.0), the [bundler](./tools/bundler/index.js) starts with the [asyncapi.json](definitions/2.2.0/asyncapi.json) file and recursively goes through all references (`$ref`) to create the [appropriate bundled version](./schemas/2.2.0.json).
 
-### Creating a new version
+## Creating a new version
 
-## 1a Automated:
+### 1a Automated:
 
 ```bash
 npm run startNewVersion --new-version=x.x.x
@@ -135,14 +135,14 @@ npm run startNewVersion --new-version=x.x.x
 
 Where `x.x.x` is the new version you want to create.
 
-## 1a Manual
+### 1a Manual
 
 The manual process of creating a new version is to:
 1. Duplicate the latest version (`y.y.y`) under definitions (so we have the correct base to make changes from). 
 1. Rename the folder to the new version (`x.x.x`).
 1. Search and replace in the new duplicated folder for `y.y.y` and replace it with `x.x.x`.
 
-## 2 Further steps
+### 2 Further steps
 
 1. Edit the [index.js](./index.js) file adding a new line with the new version. I.e.:
    ```js
@@ -173,7 +173,24 @@ The manual process of creating a new version is to:
     }
     ```
 
-### Handling breaking changes
+## Handling breaking changes
 Whenever a Breaking Change is introduced, the following steps should be taken in Go package:
 
 1. Edit `go.mod` file, and increase the version package suffix in the module name. For example, if the current version is `v2.0.0`, and you are releasing `v3.0.0`, the module name should be `github.com/asyncapi/spec-json-schemas/v3`.
+
+## SchemaStore compatibility testing
+
+AsyncAPI JSON Schema is referenced in [SchemaStore](https://www.schemastore.org/json/). In many IDEs, like VSCode, some extensions integrate with SchemaStore, like [YAML](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml). This way we enable autocompletion, validation and tooltips that helps writing AsyncAPI documents.
+
+Whenever you make changes in AsyncAPI JSON Schema, you should always manually verify that the schema is still supported by [YAML](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml) and that it will be able to fetch and dereference it.
+
+- Make sure you have VSCode and YAML extension
+- Once you make changes in schemas, bundle them with `npm run bundle`
+- Edit [this sample AsyncAPI document](./test/fixtures/asyncapi.yml). Add a new field, hover over some property to see if tooltip still shows up. This sample document contains the following line that assures YAML uses your local schema and not the one from SchemaStore. Make sure it points to the schema bundle that you generated and that contains your changes:
+   ```yaml
+   # yaml-language-server: $schema=/Users/wookiee/sources/asyncapi-node/schemas/2.6.0-without-$id.json
+   ```
+
+
+
+

--- a/schemas/2.0.0-without-$id.json
+++ b/schemas/2.0.0-without-$id.json
@@ -1324,10 +1324,10 @@
                 "not": {
                     "oneOf": [
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema"
+                            "$ref": "#/definitions/openapiSchema_3_0"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/Reference"
+                            "$ref": "#/definitions/openapiSchema_3_0/definitions/Reference"
                         }
                     ]
                 },
@@ -1336,10 +1336,10 @@
                     "items": {
                         "oneOf": [
                             {
-                                "$ref": "#/definitions/json-schema-draft-07-schema"
+                                "$ref": "#/definitions/openapiSchema_3_0"
                             },
                             {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/Reference"
+                                "$ref": "#/definitions/openapiSchema_3_0/definitions/Reference"
                             }
                         ]
                     }
@@ -1349,10 +1349,10 @@
                     "items": {
                         "oneOf": [
                             {
-                                "$ref": "#/definitions/json-schema-draft-07-schema"
+                                "$ref": "#/definitions/openapiSchema_3_0"
                             },
                             {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/Reference"
+                                "$ref": "#/definitions/openapiSchema_3_0/definitions/Reference"
                             }
                         ]
                     }
@@ -1362,10 +1362,10 @@
                     "items": {
                         "oneOf": [
                             {
-                                "$ref": "#/definitions/json-schema-draft-07-schema"
+                                "$ref": "#/definitions/openapiSchema_3_0"
                             },
                             {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/Reference"
+                                "$ref": "#/definitions/openapiSchema_3_0/definitions/Reference"
                             }
                         ]
                     }
@@ -1373,10 +1373,10 @@
                 "items": {
                     "oneOf": [
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema"
+                            "$ref": "#/definitions/openapiSchema_3_0"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/Reference"
+                            "$ref": "#/definitions/openapiSchema_3_0/definitions/Reference"
                         }
                     ]
                 },
@@ -1385,10 +1385,10 @@
                     "additionalProperties": {
                         "oneOf": [
                             {
-                                "$ref": "#/definitions/json-schema-draft-07-schema"
+                                "$ref": "#/definitions/openapiSchema_3_0"
                             },
                             {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/Reference"
+                                "$ref": "#/definitions/openapiSchema_3_0/definitions/Reference"
                             }
                         ]
                     }
@@ -1396,10 +1396,10 @@
                 "additionalProperties": {
                     "oneOf": [
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema"
+                            "$ref": "#/definitions/openapiSchema_3_0"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/Reference"
+                            "$ref": "#/definitions/openapiSchema_3_0/definitions/Reference"
                         },
                         {
                             "type": "boolean"
@@ -1419,7 +1419,7 @@
                     "default": false
                 },
                 "discriminator": {
-                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/Discriminator"
+                    "$ref": "#/definitions/openapiSchema_3_0/definitions/Discriminator"
                 },
                 "readOnly": {
                     "type": "boolean",
@@ -1431,14 +1431,14 @@
                 },
                 "example": true,
                 "externalDocs": {
-                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/ExternalDocumentation"
+                    "$ref": "#/definitions/openapiSchema_3_0/definitions/ExternalDocumentation"
                 },
                 "deprecated": {
                     "type": "boolean",
                     "default": false
                 },
                 "xml": {
-                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/XML"
+                    "$ref": "#/definitions/openapiSchema_3_0/definitions/XML"
                 }
             },
             "patternProperties": {
@@ -1453,7 +1453,7 @@
                     "description": "Root Schema",
                     "oneOf": [
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/types"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/types"
                         }
                     ]
                 },
@@ -1462,31 +1462,31 @@
                     "description": "Allowed Avro types",
                     "oneOf": [
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/primitiveType"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/primitiveType"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/primitiveTypeWithMetadata"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/primitiveTypeWithMetadata"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/customTypeReference"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/customTypeReference"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/avroRecord"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/avroRecord"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/avroEnum"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/avroEnum"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/avroArray"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/avroArray"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/avroMap"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/avroMap"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/avroFixed"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/avroFixed"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/avroUnion"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/avroUnion"
                         }
                     ]
                 },
@@ -1511,7 +1511,7 @@
                     "type": "object",
                     "properties": {
                         "type": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/primitiveType"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/primitiveType"
                         }
                     },
                     "required": [
@@ -1522,7 +1522,7 @@
                     "title": "Custom Type",
                     "description": "Reference to a ComplexType",
                     "not": {
-                        "$ref": "#/definitions/json-schema-draft-07-schema/definitions/primitiveType"
+                        "$ref": "#/definitions/avroSchema_v1/definitions/primitiveType"
                     },
                     "type": "string",
                     "pattern": "^[A-Za-z_][A-Za-z0-9_]*(\\.[A-Za-z_][A-Za-z0-9_]*)*$"
@@ -1532,7 +1532,7 @@
                     "description": "A Union of types",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/json-schema-draft-07-schema/definitions/avroSchema"
+                        "$ref": "#/definitions/avroSchema_v1/definitions/avroSchema"
                     },
                     "minItems": 1
                 },
@@ -1542,10 +1542,10 @@
                     "type": "object",
                     "properties": {
                         "name": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/name"
                         },
                         "type": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/types"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/types"
                         },
                         "doc": {
                             "type": "string"
@@ -1561,7 +1561,7 @@
                         "aliases": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                                "$ref": "#/definitions/avroSchema_v1/definitions/name"
                             }
                         }
                     },
@@ -1580,10 +1580,10 @@
                             "const": "record"
                         },
                         "name": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/name"
                         },
                         "namespace": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/namespace"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/namespace"
                         },
                         "doc": {
                             "type": "string"
@@ -1591,13 +1591,13 @@
                         "aliases": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                                "$ref": "#/definitions/avroSchema_v1/definitions/name"
                             }
                         },
                         "fields": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/avroField"
+                                "$ref": "#/definitions/avroSchema_v1/definitions/avroField"
                             }
                         }
                     },
@@ -1617,10 +1617,10 @@
                             "const": "enum"
                         },
                         "name": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/name"
                         },
                         "namespace": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/namespace"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/namespace"
                         },
                         "doc": {
                             "type": "string"
@@ -1628,13 +1628,13 @@
                         "aliases": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                                "$ref": "#/definitions/avroSchema_v1/definitions/name"
                             }
                         },
                         "symbols": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                                "$ref": "#/definitions/avroSchema_v1/definitions/name"
                             }
                         }
                     },
@@ -1654,10 +1654,10 @@
                             "const": "array"
                         },
                         "name": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/name"
                         },
                         "namespace": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/namespace"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/namespace"
                         },
                         "doc": {
                             "type": "string"
@@ -1665,11 +1665,11 @@
                         "aliases": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                                "$ref": "#/definitions/avroSchema_v1/definitions/name"
                             }
                         },
                         "items": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/types"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/types"
                         }
                     },
                     "required": [
@@ -1687,10 +1687,10 @@
                             "const": "map"
                         },
                         "name": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/name"
                         },
                         "namespace": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/namespace"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/namespace"
                         },
                         "doc": {
                             "type": "string"
@@ -1698,11 +1698,11 @@
                         "aliases": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                                "$ref": "#/definitions/avroSchema_v1/definitions/name"
                             }
                         },
                         "values": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/types"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/types"
                         }
                     },
                     "required": [
@@ -1720,10 +1720,10 @@
                             "const": "fixed"
                         },
                         "name": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/name"
                         },
                         "namespace": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/namespace"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/namespace"
                         },
                         "doc": {
                             "type": "string"
@@ -1731,7 +1731,7 @@
                         "aliases": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                                "$ref": "#/definitions/avroSchema_v1/definitions/name"
                             }
                         },
                         "size": {
@@ -1756,7 +1756,7 @@
             "description": "Json-Schema definition for Avro AVSC files.",
             "oneOf": [
                 {
-                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/avroSchema"
+                    "$ref": "#/definitions/avroSchema_v1/definitions/avroSchema"
                 }
             ],
             "title": "Avro Schema Definition"

--- a/schemas/2.1.0-without-$id.json
+++ b/schemas/2.1.0-without-$id.json
@@ -1375,10 +1375,10 @@
                 "not": {
                     "oneOf": [
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema"
+                            "$ref": "#/definitions/openapiSchema_3_0"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/Reference"
+                            "$ref": "#/definitions/openapiSchema_3_0/definitions/Reference"
                         }
                     ]
                 },
@@ -1387,10 +1387,10 @@
                     "items": {
                         "oneOf": [
                             {
-                                "$ref": "#/definitions/json-schema-draft-07-schema"
+                                "$ref": "#/definitions/openapiSchema_3_0"
                             },
                             {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/Reference"
+                                "$ref": "#/definitions/openapiSchema_3_0/definitions/Reference"
                             }
                         ]
                     }
@@ -1400,10 +1400,10 @@
                     "items": {
                         "oneOf": [
                             {
-                                "$ref": "#/definitions/json-schema-draft-07-schema"
+                                "$ref": "#/definitions/openapiSchema_3_0"
                             },
                             {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/Reference"
+                                "$ref": "#/definitions/openapiSchema_3_0/definitions/Reference"
                             }
                         ]
                     }
@@ -1413,10 +1413,10 @@
                     "items": {
                         "oneOf": [
                             {
-                                "$ref": "#/definitions/json-schema-draft-07-schema"
+                                "$ref": "#/definitions/openapiSchema_3_0"
                             },
                             {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/Reference"
+                                "$ref": "#/definitions/openapiSchema_3_0/definitions/Reference"
                             }
                         ]
                     }
@@ -1424,10 +1424,10 @@
                 "items": {
                     "oneOf": [
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema"
+                            "$ref": "#/definitions/openapiSchema_3_0"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/Reference"
+                            "$ref": "#/definitions/openapiSchema_3_0/definitions/Reference"
                         }
                     ]
                 },
@@ -1436,10 +1436,10 @@
                     "additionalProperties": {
                         "oneOf": [
                             {
-                                "$ref": "#/definitions/json-schema-draft-07-schema"
+                                "$ref": "#/definitions/openapiSchema_3_0"
                             },
                             {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/Reference"
+                                "$ref": "#/definitions/openapiSchema_3_0/definitions/Reference"
                             }
                         ]
                     }
@@ -1447,10 +1447,10 @@
                 "additionalProperties": {
                     "oneOf": [
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema"
+                            "$ref": "#/definitions/openapiSchema_3_0"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/Reference"
+                            "$ref": "#/definitions/openapiSchema_3_0/definitions/Reference"
                         },
                         {
                             "type": "boolean"
@@ -1470,7 +1470,7 @@
                     "default": false
                 },
                 "discriminator": {
-                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/Discriminator"
+                    "$ref": "#/definitions/openapiSchema_3_0/definitions/Discriminator"
                 },
                 "readOnly": {
                     "type": "boolean",
@@ -1482,14 +1482,14 @@
                 },
                 "example": true,
                 "externalDocs": {
-                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/ExternalDocumentation"
+                    "$ref": "#/definitions/openapiSchema_3_0/definitions/ExternalDocumentation"
                 },
                 "deprecated": {
                     "type": "boolean",
                     "default": false
                 },
                 "xml": {
-                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/XML"
+                    "$ref": "#/definitions/openapiSchema_3_0/definitions/XML"
                 }
             },
             "patternProperties": {
@@ -1504,7 +1504,7 @@
                     "description": "Root Schema",
                     "oneOf": [
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/types"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/types"
                         }
                     ]
                 },
@@ -1513,31 +1513,31 @@
                     "description": "Allowed Avro types",
                     "oneOf": [
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/primitiveType"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/primitiveType"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/primitiveTypeWithMetadata"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/primitiveTypeWithMetadata"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/customTypeReference"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/customTypeReference"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/avroRecord"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/avroRecord"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/avroEnum"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/avroEnum"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/avroArray"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/avroArray"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/avroMap"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/avroMap"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/avroFixed"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/avroFixed"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/avroUnion"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/avroUnion"
                         }
                     ]
                 },
@@ -1562,7 +1562,7 @@
                     "type": "object",
                     "properties": {
                         "type": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/primitiveType"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/primitiveType"
                         }
                     },
                     "required": [
@@ -1573,7 +1573,7 @@
                     "title": "Custom Type",
                     "description": "Reference to a ComplexType",
                     "not": {
-                        "$ref": "#/definitions/json-schema-draft-07-schema/definitions/primitiveType"
+                        "$ref": "#/definitions/avroSchema_v1/definitions/primitiveType"
                     },
                     "type": "string",
                     "pattern": "^[A-Za-z_][A-Za-z0-9_]*(\\.[A-Za-z_][A-Za-z0-9_]*)*$"
@@ -1583,7 +1583,7 @@
                     "description": "A Union of types",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/json-schema-draft-07-schema/definitions/avroSchema"
+                        "$ref": "#/definitions/avroSchema_v1/definitions/avroSchema"
                     },
                     "minItems": 1
                 },
@@ -1593,10 +1593,10 @@
                     "type": "object",
                     "properties": {
                         "name": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/name"
                         },
                         "type": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/types"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/types"
                         },
                         "doc": {
                             "type": "string"
@@ -1612,7 +1612,7 @@
                         "aliases": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                                "$ref": "#/definitions/avroSchema_v1/definitions/name"
                             }
                         }
                     },
@@ -1631,10 +1631,10 @@
                             "const": "record"
                         },
                         "name": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/name"
                         },
                         "namespace": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/namespace"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/namespace"
                         },
                         "doc": {
                             "type": "string"
@@ -1642,13 +1642,13 @@
                         "aliases": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                                "$ref": "#/definitions/avroSchema_v1/definitions/name"
                             }
                         },
                         "fields": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/avroField"
+                                "$ref": "#/definitions/avroSchema_v1/definitions/avroField"
                             }
                         }
                     },
@@ -1668,10 +1668,10 @@
                             "const": "enum"
                         },
                         "name": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/name"
                         },
                         "namespace": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/namespace"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/namespace"
                         },
                         "doc": {
                             "type": "string"
@@ -1679,13 +1679,13 @@
                         "aliases": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                                "$ref": "#/definitions/avroSchema_v1/definitions/name"
                             }
                         },
                         "symbols": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                                "$ref": "#/definitions/avroSchema_v1/definitions/name"
                             }
                         }
                     },
@@ -1705,10 +1705,10 @@
                             "const": "array"
                         },
                         "name": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/name"
                         },
                         "namespace": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/namespace"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/namespace"
                         },
                         "doc": {
                             "type": "string"
@@ -1716,11 +1716,11 @@
                         "aliases": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                                "$ref": "#/definitions/avroSchema_v1/definitions/name"
                             }
                         },
                         "items": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/types"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/types"
                         }
                     },
                     "required": [
@@ -1738,10 +1738,10 @@
                             "const": "map"
                         },
                         "name": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/name"
                         },
                         "namespace": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/namespace"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/namespace"
                         },
                         "doc": {
                             "type": "string"
@@ -1749,11 +1749,11 @@
                         "aliases": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                                "$ref": "#/definitions/avroSchema_v1/definitions/name"
                             }
                         },
                         "values": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/types"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/types"
                         }
                     },
                     "required": [
@@ -1771,10 +1771,10 @@
                             "const": "fixed"
                         },
                         "name": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/name"
                         },
                         "namespace": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/namespace"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/namespace"
                         },
                         "doc": {
                             "type": "string"
@@ -1782,7 +1782,7 @@
                         "aliases": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                                "$ref": "#/definitions/avroSchema_v1/definitions/name"
                             }
                         },
                         "size": {
@@ -1807,7 +1807,7 @@
             "description": "Json-Schema definition for Avro AVSC files.",
             "oneOf": [
                 {
-                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/avroSchema"
+                    "$ref": "#/definitions/avroSchema_v1/definitions/avroSchema"
                 }
             ],
             "title": "Avro Schema Definition"

--- a/schemas/2.2.0-without-$id.json
+++ b/schemas/2.2.0-without-$id.json
@@ -1360,10 +1360,10 @@
                 "not": {
                     "oneOf": [
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema"
+                            "$ref": "#/definitions/openapiSchema_3_0"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/Reference"
+                            "$ref": "#/definitions/openapiSchema_3_0/definitions/Reference"
                         }
                     ]
                 },
@@ -1372,10 +1372,10 @@
                     "items": {
                         "oneOf": [
                             {
-                                "$ref": "#/definitions/json-schema-draft-07-schema"
+                                "$ref": "#/definitions/openapiSchema_3_0"
                             },
                             {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/Reference"
+                                "$ref": "#/definitions/openapiSchema_3_0/definitions/Reference"
                             }
                         ]
                     }
@@ -1385,10 +1385,10 @@
                     "items": {
                         "oneOf": [
                             {
-                                "$ref": "#/definitions/json-schema-draft-07-schema"
+                                "$ref": "#/definitions/openapiSchema_3_0"
                             },
                             {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/Reference"
+                                "$ref": "#/definitions/openapiSchema_3_0/definitions/Reference"
                             }
                         ]
                     }
@@ -1398,10 +1398,10 @@
                     "items": {
                         "oneOf": [
                             {
-                                "$ref": "#/definitions/json-schema-draft-07-schema"
+                                "$ref": "#/definitions/openapiSchema_3_0"
                             },
                             {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/Reference"
+                                "$ref": "#/definitions/openapiSchema_3_0/definitions/Reference"
                             }
                         ]
                     }
@@ -1409,10 +1409,10 @@
                 "items": {
                     "oneOf": [
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema"
+                            "$ref": "#/definitions/openapiSchema_3_0"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/Reference"
+                            "$ref": "#/definitions/openapiSchema_3_0/definitions/Reference"
                         }
                     ]
                 },
@@ -1421,10 +1421,10 @@
                     "additionalProperties": {
                         "oneOf": [
                             {
-                                "$ref": "#/definitions/json-schema-draft-07-schema"
+                                "$ref": "#/definitions/openapiSchema_3_0"
                             },
                             {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/Reference"
+                                "$ref": "#/definitions/openapiSchema_3_0/definitions/Reference"
                             }
                         ]
                     }
@@ -1432,10 +1432,10 @@
                 "additionalProperties": {
                     "oneOf": [
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema"
+                            "$ref": "#/definitions/openapiSchema_3_0"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/Reference"
+                            "$ref": "#/definitions/openapiSchema_3_0/definitions/Reference"
                         },
                         {
                             "type": "boolean"
@@ -1455,7 +1455,7 @@
                     "default": false
                 },
                 "discriminator": {
-                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/Discriminator"
+                    "$ref": "#/definitions/openapiSchema_3_0/definitions/Discriminator"
                 },
                 "readOnly": {
                     "type": "boolean",
@@ -1467,14 +1467,14 @@
                 },
                 "example": true,
                 "externalDocs": {
-                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/ExternalDocumentation"
+                    "$ref": "#/definitions/openapiSchema_3_0/definitions/ExternalDocumentation"
                 },
                 "deprecated": {
                     "type": "boolean",
                     "default": false
                 },
                 "xml": {
-                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/XML"
+                    "$ref": "#/definitions/openapiSchema_3_0/definitions/XML"
                 }
             },
             "patternProperties": {
@@ -1489,7 +1489,7 @@
                     "description": "Root Schema",
                     "oneOf": [
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/types"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/types"
                         }
                     ]
                 },
@@ -1498,31 +1498,31 @@
                     "description": "Allowed Avro types",
                     "oneOf": [
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/primitiveType"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/primitiveType"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/primitiveTypeWithMetadata"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/primitiveTypeWithMetadata"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/customTypeReference"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/customTypeReference"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/avroRecord"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/avroRecord"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/avroEnum"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/avroEnum"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/avroArray"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/avroArray"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/avroMap"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/avroMap"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/avroFixed"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/avroFixed"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/avroUnion"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/avroUnion"
                         }
                     ]
                 },
@@ -1547,7 +1547,7 @@
                     "type": "object",
                     "properties": {
                         "type": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/primitiveType"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/primitiveType"
                         }
                     },
                     "required": [
@@ -1558,7 +1558,7 @@
                     "title": "Custom Type",
                     "description": "Reference to a ComplexType",
                     "not": {
-                        "$ref": "#/definitions/json-schema-draft-07-schema/definitions/primitiveType"
+                        "$ref": "#/definitions/avroSchema_v1/definitions/primitiveType"
                     },
                     "type": "string",
                     "pattern": "^[A-Za-z_][A-Za-z0-9_]*(\\.[A-Za-z_][A-Za-z0-9_]*)*$"
@@ -1568,7 +1568,7 @@
                     "description": "A Union of types",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/json-schema-draft-07-schema/definitions/avroSchema"
+                        "$ref": "#/definitions/avroSchema_v1/definitions/avroSchema"
                     },
                     "minItems": 1
                 },
@@ -1578,10 +1578,10 @@
                     "type": "object",
                     "properties": {
                         "name": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/name"
                         },
                         "type": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/types"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/types"
                         },
                         "doc": {
                             "type": "string"
@@ -1597,7 +1597,7 @@
                         "aliases": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                                "$ref": "#/definitions/avroSchema_v1/definitions/name"
                             }
                         }
                     },
@@ -1616,10 +1616,10 @@
                             "const": "record"
                         },
                         "name": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/name"
                         },
                         "namespace": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/namespace"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/namespace"
                         },
                         "doc": {
                             "type": "string"
@@ -1627,13 +1627,13 @@
                         "aliases": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                                "$ref": "#/definitions/avroSchema_v1/definitions/name"
                             }
                         },
                         "fields": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/avroField"
+                                "$ref": "#/definitions/avroSchema_v1/definitions/avroField"
                             }
                         }
                     },
@@ -1653,10 +1653,10 @@
                             "const": "enum"
                         },
                         "name": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/name"
                         },
                         "namespace": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/namespace"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/namespace"
                         },
                         "doc": {
                             "type": "string"
@@ -1664,13 +1664,13 @@
                         "aliases": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                                "$ref": "#/definitions/avroSchema_v1/definitions/name"
                             }
                         },
                         "symbols": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                                "$ref": "#/definitions/avroSchema_v1/definitions/name"
                             }
                         }
                     },
@@ -1690,10 +1690,10 @@
                             "const": "array"
                         },
                         "name": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/name"
                         },
                         "namespace": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/namespace"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/namespace"
                         },
                         "doc": {
                             "type": "string"
@@ -1701,11 +1701,11 @@
                         "aliases": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                                "$ref": "#/definitions/avroSchema_v1/definitions/name"
                             }
                         },
                         "items": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/types"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/types"
                         }
                     },
                     "required": [
@@ -1723,10 +1723,10 @@
                             "const": "map"
                         },
                         "name": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/name"
                         },
                         "namespace": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/namespace"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/namespace"
                         },
                         "doc": {
                             "type": "string"
@@ -1734,11 +1734,11 @@
                         "aliases": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                                "$ref": "#/definitions/avroSchema_v1/definitions/name"
                             }
                         },
                         "values": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/types"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/types"
                         }
                     },
                     "required": [
@@ -1756,10 +1756,10 @@
                             "const": "fixed"
                         },
                         "name": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/name"
                         },
                         "namespace": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/namespace"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/namespace"
                         },
                         "doc": {
                             "type": "string"
@@ -1767,7 +1767,7 @@
                         "aliases": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                                "$ref": "#/definitions/avroSchema_v1/definitions/name"
                             }
                         },
                         "size": {
@@ -1792,7 +1792,7 @@
             "description": "Json-Schema definition for Avro AVSC files.",
             "oneOf": [
                 {
-                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/avroSchema"
+                    "$ref": "#/definitions/avroSchema_v1/definitions/avroSchema"
                 }
             ],
             "title": "Avro Schema Definition"

--- a/schemas/2.3.0-without-$id.json
+++ b/schemas/2.3.0-without-$id.json
@@ -1375,10 +1375,10 @@
                 "not": {
                     "oneOf": [
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema"
+                            "$ref": "#/definitions/openapiSchema_3_0"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/Reference"
+                            "$ref": "#/definitions/openapiSchema_3_0/definitions/Reference"
                         }
                     ]
                 },
@@ -1387,10 +1387,10 @@
                     "items": {
                         "oneOf": [
                             {
-                                "$ref": "#/definitions/json-schema-draft-07-schema"
+                                "$ref": "#/definitions/openapiSchema_3_0"
                             },
                             {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/Reference"
+                                "$ref": "#/definitions/openapiSchema_3_0/definitions/Reference"
                             }
                         ]
                     }
@@ -1400,10 +1400,10 @@
                     "items": {
                         "oneOf": [
                             {
-                                "$ref": "#/definitions/json-schema-draft-07-schema"
+                                "$ref": "#/definitions/openapiSchema_3_0"
                             },
                             {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/Reference"
+                                "$ref": "#/definitions/openapiSchema_3_0/definitions/Reference"
                             }
                         ]
                     }
@@ -1413,10 +1413,10 @@
                     "items": {
                         "oneOf": [
                             {
-                                "$ref": "#/definitions/json-schema-draft-07-schema"
+                                "$ref": "#/definitions/openapiSchema_3_0"
                             },
                             {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/Reference"
+                                "$ref": "#/definitions/openapiSchema_3_0/definitions/Reference"
                             }
                         ]
                     }
@@ -1424,10 +1424,10 @@
                 "items": {
                     "oneOf": [
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema"
+                            "$ref": "#/definitions/openapiSchema_3_0"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/Reference"
+                            "$ref": "#/definitions/openapiSchema_3_0/definitions/Reference"
                         }
                     ]
                 },
@@ -1436,10 +1436,10 @@
                     "additionalProperties": {
                         "oneOf": [
                             {
-                                "$ref": "#/definitions/json-schema-draft-07-schema"
+                                "$ref": "#/definitions/openapiSchema_3_0"
                             },
                             {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/Reference"
+                                "$ref": "#/definitions/openapiSchema_3_0/definitions/Reference"
                             }
                         ]
                     }
@@ -1447,10 +1447,10 @@
                 "additionalProperties": {
                     "oneOf": [
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema"
+                            "$ref": "#/definitions/openapiSchema_3_0"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/Reference"
+                            "$ref": "#/definitions/openapiSchema_3_0/definitions/Reference"
                         },
                         {
                             "type": "boolean"
@@ -1470,7 +1470,7 @@
                     "default": false
                 },
                 "discriminator": {
-                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/Discriminator"
+                    "$ref": "#/definitions/openapiSchema_3_0/definitions/Discriminator"
                 },
                 "readOnly": {
                     "type": "boolean",
@@ -1482,14 +1482,14 @@
                 },
                 "example": true,
                 "externalDocs": {
-                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/ExternalDocumentation"
+                    "$ref": "#/definitions/openapiSchema_3_0/definitions/ExternalDocumentation"
                 },
                 "deprecated": {
                     "type": "boolean",
                     "default": false
                 },
                 "xml": {
-                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/XML"
+                    "$ref": "#/definitions/openapiSchema_3_0/definitions/XML"
                 }
             },
             "patternProperties": {
@@ -1504,7 +1504,7 @@
                     "description": "Root Schema",
                     "oneOf": [
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/types"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/types"
                         }
                     ]
                 },
@@ -1513,31 +1513,31 @@
                     "description": "Allowed Avro types",
                     "oneOf": [
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/primitiveType"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/primitiveType"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/primitiveTypeWithMetadata"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/primitiveTypeWithMetadata"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/customTypeReference"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/customTypeReference"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/avroRecord"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/avroRecord"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/avroEnum"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/avroEnum"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/avroArray"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/avroArray"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/avroMap"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/avroMap"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/avroFixed"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/avroFixed"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/avroUnion"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/avroUnion"
                         }
                     ]
                 },
@@ -1562,7 +1562,7 @@
                     "type": "object",
                     "properties": {
                         "type": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/primitiveType"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/primitiveType"
                         }
                     },
                     "required": [
@@ -1573,7 +1573,7 @@
                     "title": "Custom Type",
                     "description": "Reference to a ComplexType",
                     "not": {
-                        "$ref": "#/definitions/json-schema-draft-07-schema/definitions/primitiveType"
+                        "$ref": "#/definitions/avroSchema_v1/definitions/primitiveType"
                     },
                     "type": "string",
                     "pattern": "^[A-Za-z_][A-Za-z0-9_]*(\\.[A-Za-z_][A-Za-z0-9_]*)*$"
@@ -1583,7 +1583,7 @@
                     "description": "A Union of types",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/json-schema-draft-07-schema/definitions/avroSchema"
+                        "$ref": "#/definitions/avroSchema_v1/definitions/avroSchema"
                     },
                     "minItems": 1
                 },
@@ -1593,10 +1593,10 @@
                     "type": "object",
                     "properties": {
                         "name": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/name"
                         },
                         "type": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/types"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/types"
                         },
                         "doc": {
                             "type": "string"
@@ -1612,7 +1612,7 @@
                         "aliases": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                                "$ref": "#/definitions/avroSchema_v1/definitions/name"
                             }
                         }
                     },
@@ -1631,10 +1631,10 @@
                             "const": "record"
                         },
                         "name": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/name"
                         },
                         "namespace": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/namespace"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/namespace"
                         },
                         "doc": {
                             "type": "string"
@@ -1642,13 +1642,13 @@
                         "aliases": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                                "$ref": "#/definitions/avroSchema_v1/definitions/name"
                             }
                         },
                         "fields": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/avroField"
+                                "$ref": "#/definitions/avroSchema_v1/definitions/avroField"
                             }
                         }
                     },
@@ -1668,10 +1668,10 @@
                             "const": "enum"
                         },
                         "name": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/name"
                         },
                         "namespace": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/namespace"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/namespace"
                         },
                         "doc": {
                             "type": "string"
@@ -1679,13 +1679,13 @@
                         "aliases": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                                "$ref": "#/definitions/avroSchema_v1/definitions/name"
                             }
                         },
                         "symbols": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                                "$ref": "#/definitions/avroSchema_v1/definitions/name"
                             }
                         }
                     },
@@ -1705,10 +1705,10 @@
                             "const": "array"
                         },
                         "name": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/name"
                         },
                         "namespace": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/namespace"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/namespace"
                         },
                         "doc": {
                             "type": "string"
@@ -1716,11 +1716,11 @@
                         "aliases": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                                "$ref": "#/definitions/avroSchema_v1/definitions/name"
                             }
                         },
                         "items": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/types"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/types"
                         }
                     },
                     "required": [
@@ -1738,10 +1738,10 @@
                             "const": "map"
                         },
                         "name": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/name"
                         },
                         "namespace": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/namespace"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/namespace"
                         },
                         "doc": {
                             "type": "string"
@@ -1749,11 +1749,11 @@
                         "aliases": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                                "$ref": "#/definitions/avroSchema_v1/definitions/name"
                             }
                         },
                         "values": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/types"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/types"
                         }
                     },
                     "required": [
@@ -1771,10 +1771,10 @@
                             "const": "fixed"
                         },
                         "name": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/name"
                         },
                         "namespace": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/namespace"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/namespace"
                         },
                         "doc": {
                             "type": "string"
@@ -1782,7 +1782,7 @@
                         "aliases": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                                "$ref": "#/definitions/avroSchema_v1/definitions/name"
                             }
                         },
                         "size": {
@@ -1807,7 +1807,7 @@
             "description": "Json-Schema definition for Avro AVSC files.",
             "oneOf": [
                 {
-                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/avroSchema"
+                    "$ref": "#/definitions/avroSchema_v1/definitions/avroSchema"
                 }
             ],
             "title": "Avro Schema Definition"

--- a/schemas/2.4.0-without-$id.json
+++ b/schemas/2.4.0-without-$id.json
@@ -1396,10 +1396,10 @@
                 "not": {
                     "oneOf": [
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema"
+                            "$ref": "#/definitions/openapiSchema_3_0"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/Reference"
+                            "$ref": "#/definitions/openapiSchema_3_0/definitions/Reference"
                         }
                     ]
                 },
@@ -1408,10 +1408,10 @@
                     "items": {
                         "oneOf": [
                             {
-                                "$ref": "#/definitions/json-schema-draft-07-schema"
+                                "$ref": "#/definitions/openapiSchema_3_0"
                             },
                             {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/Reference"
+                                "$ref": "#/definitions/openapiSchema_3_0/definitions/Reference"
                             }
                         ]
                     }
@@ -1421,10 +1421,10 @@
                     "items": {
                         "oneOf": [
                             {
-                                "$ref": "#/definitions/json-schema-draft-07-schema"
+                                "$ref": "#/definitions/openapiSchema_3_0"
                             },
                             {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/Reference"
+                                "$ref": "#/definitions/openapiSchema_3_0/definitions/Reference"
                             }
                         ]
                     }
@@ -1434,10 +1434,10 @@
                     "items": {
                         "oneOf": [
                             {
-                                "$ref": "#/definitions/json-schema-draft-07-schema"
+                                "$ref": "#/definitions/openapiSchema_3_0"
                             },
                             {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/Reference"
+                                "$ref": "#/definitions/openapiSchema_3_0/definitions/Reference"
                             }
                         ]
                     }
@@ -1445,10 +1445,10 @@
                 "items": {
                     "oneOf": [
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema"
+                            "$ref": "#/definitions/openapiSchema_3_0"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/Reference"
+                            "$ref": "#/definitions/openapiSchema_3_0/definitions/Reference"
                         }
                     ]
                 },
@@ -1457,10 +1457,10 @@
                     "additionalProperties": {
                         "oneOf": [
                             {
-                                "$ref": "#/definitions/json-schema-draft-07-schema"
+                                "$ref": "#/definitions/openapiSchema_3_0"
                             },
                             {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/Reference"
+                                "$ref": "#/definitions/openapiSchema_3_0/definitions/Reference"
                             }
                         ]
                     }
@@ -1468,10 +1468,10 @@
                 "additionalProperties": {
                     "oneOf": [
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema"
+                            "$ref": "#/definitions/openapiSchema_3_0"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/Reference"
+                            "$ref": "#/definitions/openapiSchema_3_0/definitions/Reference"
                         },
                         {
                             "type": "boolean"
@@ -1491,7 +1491,7 @@
                     "default": false
                 },
                 "discriminator": {
-                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/Discriminator"
+                    "$ref": "#/definitions/openapiSchema_3_0/definitions/Discriminator"
                 },
                 "readOnly": {
                     "type": "boolean",
@@ -1503,14 +1503,14 @@
                 },
                 "example": true,
                 "externalDocs": {
-                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/ExternalDocumentation"
+                    "$ref": "#/definitions/openapiSchema_3_0/definitions/ExternalDocumentation"
                 },
                 "deprecated": {
                     "type": "boolean",
                     "default": false
                 },
                 "xml": {
-                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/XML"
+                    "$ref": "#/definitions/openapiSchema_3_0/definitions/XML"
                 }
             },
             "patternProperties": {
@@ -1525,7 +1525,7 @@
                     "description": "Root Schema",
                     "oneOf": [
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/types"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/types"
                         }
                     ]
                 },
@@ -1534,31 +1534,31 @@
                     "description": "Allowed Avro types",
                     "oneOf": [
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/primitiveType"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/primitiveType"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/primitiveTypeWithMetadata"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/primitiveTypeWithMetadata"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/customTypeReference"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/customTypeReference"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/avroRecord"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/avroRecord"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/avroEnum"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/avroEnum"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/avroArray"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/avroArray"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/avroMap"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/avroMap"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/avroFixed"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/avroFixed"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/avroUnion"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/avroUnion"
                         }
                     ]
                 },
@@ -1583,7 +1583,7 @@
                     "type": "object",
                     "properties": {
                         "type": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/primitiveType"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/primitiveType"
                         }
                     },
                     "required": [
@@ -1594,7 +1594,7 @@
                     "title": "Custom Type",
                     "description": "Reference to a ComplexType",
                     "not": {
-                        "$ref": "#/definitions/json-schema-draft-07-schema/definitions/primitiveType"
+                        "$ref": "#/definitions/avroSchema_v1/definitions/primitiveType"
                     },
                     "type": "string",
                     "pattern": "^[A-Za-z_][A-Za-z0-9_]*(\\.[A-Za-z_][A-Za-z0-9_]*)*$"
@@ -1604,7 +1604,7 @@
                     "description": "A Union of types",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/json-schema-draft-07-schema/definitions/avroSchema"
+                        "$ref": "#/definitions/avroSchema_v1/definitions/avroSchema"
                     },
                     "minItems": 1
                 },
@@ -1614,10 +1614,10 @@
                     "type": "object",
                     "properties": {
                         "name": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/name"
                         },
                         "type": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/types"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/types"
                         },
                         "doc": {
                             "type": "string"
@@ -1633,7 +1633,7 @@
                         "aliases": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                                "$ref": "#/definitions/avroSchema_v1/definitions/name"
                             }
                         }
                     },
@@ -1652,10 +1652,10 @@
                             "const": "record"
                         },
                         "name": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/name"
                         },
                         "namespace": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/namespace"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/namespace"
                         },
                         "doc": {
                             "type": "string"
@@ -1663,13 +1663,13 @@
                         "aliases": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                                "$ref": "#/definitions/avroSchema_v1/definitions/name"
                             }
                         },
                         "fields": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/avroField"
+                                "$ref": "#/definitions/avroSchema_v1/definitions/avroField"
                             }
                         }
                     },
@@ -1689,10 +1689,10 @@
                             "const": "enum"
                         },
                         "name": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/name"
                         },
                         "namespace": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/namespace"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/namespace"
                         },
                         "doc": {
                             "type": "string"
@@ -1700,13 +1700,13 @@
                         "aliases": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                                "$ref": "#/definitions/avroSchema_v1/definitions/name"
                             }
                         },
                         "symbols": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                                "$ref": "#/definitions/avroSchema_v1/definitions/name"
                             }
                         }
                     },
@@ -1726,10 +1726,10 @@
                             "const": "array"
                         },
                         "name": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/name"
                         },
                         "namespace": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/namespace"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/namespace"
                         },
                         "doc": {
                             "type": "string"
@@ -1737,11 +1737,11 @@
                         "aliases": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                                "$ref": "#/definitions/avroSchema_v1/definitions/name"
                             }
                         },
                         "items": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/types"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/types"
                         }
                     },
                     "required": [
@@ -1759,10 +1759,10 @@
                             "const": "map"
                         },
                         "name": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/name"
                         },
                         "namespace": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/namespace"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/namespace"
                         },
                         "doc": {
                             "type": "string"
@@ -1770,11 +1770,11 @@
                         "aliases": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                                "$ref": "#/definitions/avroSchema_v1/definitions/name"
                             }
                         },
                         "values": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/types"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/types"
                         }
                     },
                     "required": [
@@ -1792,10 +1792,10 @@
                             "const": "fixed"
                         },
                         "name": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/name"
                         },
                         "namespace": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/namespace"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/namespace"
                         },
                         "doc": {
                             "type": "string"
@@ -1803,7 +1803,7 @@
                         "aliases": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                                "$ref": "#/definitions/avroSchema_v1/definitions/name"
                             }
                         },
                         "size": {
@@ -1828,7 +1828,7 @@
             "description": "Json-Schema definition for Avro AVSC files.",
             "oneOf": [
                 {
-                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/avroSchema"
+                    "$ref": "#/definitions/avroSchema_v1/definitions/avroSchema"
                 }
             ],
             "title": "Avro Schema Definition"

--- a/schemas/2.5.0-without-$id.json
+++ b/schemas/2.5.0-without-$id.json
@@ -1410,10 +1410,10 @@
                 "not": {
                     "oneOf": [
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema"
+                            "$ref": "#/definitions/openapiSchema_3_0"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/Reference"
+                            "$ref": "#/definitions/openapiSchema_3_0/definitions/Reference"
                         }
                     ]
                 },
@@ -1422,10 +1422,10 @@
                     "items": {
                         "oneOf": [
                             {
-                                "$ref": "#/definitions/json-schema-draft-07-schema"
+                                "$ref": "#/definitions/openapiSchema_3_0"
                             },
                             {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/Reference"
+                                "$ref": "#/definitions/openapiSchema_3_0/definitions/Reference"
                             }
                         ]
                     }
@@ -1435,10 +1435,10 @@
                     "items": {
                         "oneOf": [
                             {
-                                "$ref": "#/definitions/json-schema-draft-07-schema"
+                                "$ref": "#/definitions/openapiSchema_3_0"
                             },
                             {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/Reference"
+                                "$ref": "#/definitions/openapiSchema_3_0/definitions/Reference"
                             }
                         ]
                     }
@@ -1448,10 +1448,10 @@
                     "items": {
                         "oneOf": [
                             {
-                                "$ref": "#/definitions/json-schema-draft-07-schema"
+                                "$ref": "#/definitions/openapiSchema_3_0"
                             },
                             {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/Reference"
+                                "$ref": "#/definitions/openapiSchema_3_0/definitions/Reference"
                             }
                         ]
                     }
@@ -1459,10 +1459,10 @@
                 "items": {
                     "oneOf": [
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema"
+                            "$ref": "#/definitions/openapiSchema_3_0"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/Reference"
+                            "$ref": "#/definitions/openapiSchema_3_0/definitions/Reference"
                         }
                     ]
                 },
@@ -1471,10 +1471,10 @@
                     "additionalProperties": {
                         "oneOf": [
                             {
-                                "$ref": "#/definitions/json-schema-draft-07-schema"
+                                "$ref": "#/definitions/openapiSchema_3_0"
                             },
                             {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/Reference"
+                                "$ref": "#/definitions/openapiSchema_3_0/definitions/Reference"
                             }
                         ]
                     }
@@ -1482,10 +1482,10 @@
                 "additionalProperties": {
                     "oneOf": [
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema"
+                            "$ref": "#/definitions/openapiSchema_3_0"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/Reference"
+                            "$ref": "#/definitions/openapiSchema_3_0/definitions/Reference"
                         },
                         {
                             "type": "boolean"
@@ -1505,7 +1505,7 @@
                     "default": false
                 },
                 "discriminator": {
-                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/Discriminator"
+                    "$ref": "#/definitions/openapiSchema_3_0/definitions/Discriminator"
                 },
                 "readOnly": {
                     "type": "boolean",
@@ -1517,14 +1517,14 @@
                 },
                 "example": true,
                 "externalDocs": {
-                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/ExternalDocumentation"
+                    "$ref": "#/definitions/openapiSchema_3_0/definitions/ExternalDocumentation"
                 },
                 "deprecated": {
                     "type": "boolean",
                     "default": false
                 },
                 "xml": {
-                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/XML"
+                    "$ref": "#/definitions/openapiSchema_3_0/definitions/XML"
                 }
             },
             "patternProperties": {
@@ -1539,7 +1539,7 @@
                     "description": "Root Schema",
                     "oneOf": [
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/types"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/types"
                         }
                     ]
                 },
@@ -1548,31 +1548,31 @@
                     "description": "Allowed Avro types",
                     "oneOf": [
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/primitiveType"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/primitiveType"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/primitiveTypeWithMetadata"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/primitiveTypeWithMetadata"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/customTypeReference"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/customTypeReference"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/avroRecord"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/avroRecord"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/avroEnum"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/avroEnum"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/avroArray"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/avroArray"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/avroMap"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/avroMap"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/avroFixed"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/avroFixed"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/avroUnion"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/avroUnion"
                         }
                     ]
                 },
@@ -1597,7 +1597,7 @@
                     "type": "object",
                     "properties": {
                         "type": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/primitiveType"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/primitiveType"
                         }
                     },
                     "required": [
@@ -1608,7 +1608,7 @@
                     "title": "Custom Type",
                     "description": "Reference to a ComplexType",
                     "not": {
-                        "$ref": "#/definitions/json-schema-draft-07-schema/definitions/primitiveType"
+                        "$ref": "#/definitions/avroSchema_v1/definitions/primitiveType"
                     },
                     "type": "string",
                     "pattern": "^[A-Za-z_][A-Za-z0-9_]*(\\.[A-Za-z_][A-Za-z0-9_]*)*$"
@@ -1618,7 +1618,7 @@
                     "description": "A Union of types",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/json-schema-draft-07-schema/definitions/avroSchema"
+                        "$ref": "#/definitions/avroSchema_v1/definitions/avroSchema"
                     },
                     "minItems": 1
                 },
@@ -1628,10 +1628,10 @@
                     "type": "object",
                     "properties": {
                         "name": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/name"
                         },
                         "type": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/types"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/types"
                         },
                         "doc": {
                             "type": "string"
@@ -1647,7 +1647,7 @@
                         "aliases": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                                "$ref": "#/definitions/avroSchema_v1/definitions/name"
                             }
                         }
                     },
@@ -1666,10 +1666,10 @@
                             "const": "record"
                         },
                         "name": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/name"
                         },
                         "namespace": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/namespace"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/namespace"
                         },
                         "doc": {
                             "type": "string"
@@ -1677,13 +1677,13 @@
                         "aliases": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                                "$ref": "#/definitions/avroSchema_v1/definitions/name"
                             }
                         },
                         "fields": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/avroField"
+                                "$ref": "#/definitions/avroSchema_v1/definitions/avroField"
                             }
                         }
                     },
@@ -1703,10 +1703,10 @@
                             "const": "enum"
                         },
                         "name": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/name"
                         },
                         "namespace": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/namespace"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/namespace"
                         },
                         "doc": {
                             "type": "string"
@@ -1714,13 +1714,13 @@
                         "aliases": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                                "$ref": "#/definitions/avroSchema_v1/definitions/name"
                             }
                         },
                         "symbols": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                                "$ref": "#/definitions/avroSchema_v1/definitions/name"
                             }
                         }
                     },
@@ -1740,10 +1740,10 @@
                             "const": "array"
                         },
                         "name": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/name"
                         },
                         "namespace": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/namespace"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/namespace"
                         },
                         "doc": {
                             "type": "string"
@@ -1751,11 +1751,11 @@
                         "aliases": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                                "$ref": "#/definitions/avroSchema_v1/definitions/name"
                             }
                         },
                         "items": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/types"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/types"
                         }
                     },
                     "required": [
@@ -1773,10 +1773,10 @@
                             "const": "map"
                         },
                         "name": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/name"
                         },
                         "namespace": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/namespace"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/namespace"
                         },
                         "doc": {
                             "type": "string"
@@ -1784,11 +1784,11 @@
                         "aliases": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                                "$ref": "#/definitions/avroSchema_v1/definitions/name"
                             }
                         },
                         "values": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/types"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/types"
                         }
                     },
                     "required": [
@@ -1806,10 +1806,10 @@
                             "const": "fixed"
                         },
                         "name": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/name"
                         },
                         "namespace": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/namespace"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/namespace"
                         },
                         "doc": {
                             "type": "string"
@@ -1817,7 +1817,7 @@
                         "aliases": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                                "$ref": "#/definitions/avroSchema_v1/definitions/name"
                             }
                         },
                         "size": {
@@ -1842,7 +1842,7 @@
             "description": "Json-Schema definition for Avro AVSC files.",
             "oneOf": [
                 {
-                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/avroSchema"
+                    "$ref": "#/definitions/avroSchema_v1/definitions/avroSchema"
                 }
             ],
             "title": "Avro Schema Definition"

--- a/schemas/2.6.0-without-$id.json
+++ b/schemas/2.6.0-without-$id.json
@@ -1415,10 +1415,10 @@
                 "not": {
                     "oneOf": [
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema"
+                            "$ref": "#/definitions/openapiSchema_3_0"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/Reference"
+                            "$ref": "#/definitions/openapiSchema_3_0/definitions/Reference"
                         }
                     ]
                 },
@@ -1427,10 +1427,10 @@
                     "items": {
                         "oneOf": [
                             {
-                                "$ref": "#/definitions/json-schema-draft-07-schema"
+                                "$ref": "#/definitions/openapiSchema_3_0"
                             },
                             {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/Reference"
+                                "$ref": "#/definitions/openapiSchema_3_0/definitions/Reference"
                             }
                         ]
                     }
@@ -1440,10 +1440,10 @@
                     "items": {
                         "oneOf": [
                             {
-                                "$ref": "#/definitions/json-schema-draft-07-schema"
+                                "$ref": "#/definitions/openapiSchema_3_0"
                             },
                             {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/Reference"
+                                "$ref": "#/definitions/openapiSchema_3_0/definitions/Reference"
                             }
                         ]
                     }
@@ -1453,10 +1453,10 @@
                     "items": {
                         "oneOf": [
                             {
-                                "$ref": "#/definitions/json-schema-draft-07-schema"
+                                "$ref": "#/definitions/openapiSchema_3_0"
                             },
                             {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/Reference"
+                                "$ref": "#/definitions/openapiSchema_3_0/definitions/Reference"
                             }
                         ]
                     }
@@ -1464,10 +1464,10 @@
                 "items": {
                     "oneOf": [
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema"
+                            "$ref": "#/definitions/openapiSchema_3_0"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/Reference"
+                            "$ref": "#/definitions/openapiSchema_3_0/definitions/Reference"
                         }
                     ]
                 },
@@ -1476,10 +1476,10 @@
                     "additionalProperties": {
                         "oneOf": [
                             {
-                                "$ref": "#/definitions/json-schema-draft-07-schema"
+                                "$ref": "#/definitions/openapiSchema_3_0"
                             },
                             {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/Reference"
+                                "$ref": "#/definitions/openapiSchema_3_0/definitions/Reference"
                             }
                         ]
                     }
@@ -1487,10 +1487,10 @@
                 "additionalProperties": {
                     "oneOf": [
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema"
+                            "$ref": "#/definitions/openapiSchema_3_0"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/Reference"
+                            "$ref": "#/definitions/openapiSchema_3_0/definitions/Reference"
                         },
                         {
                             "type": "boolean"
@@ -1510,7 +1510,7 @@
                     "default": false
                 },
                 "discriminator": {
-                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/Discriminator"
+                    "$ref": "#/definitions/openapiSchema_3_0/definitions/Discriminator"
                 },
                 "readOnly": {
                     "type": "boolean",
@@ -1522,14 +1522,14 @@
                 },
                 "example": true,
                 "externalDocs": {
-                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/ExternalDocumentation"
+                    "$ref": "#/definitions/openapiSchema_3_0/definitions/ExternalDocumentation"
                 },
                 "deprecated": {
                     "type": "boolean",
                     "default": false
                 },
                 "xml": {
-                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/XML"
+                    "$ref": "#/definitions/openapiSchema_3_0/definitions/XML"
                 }
             },
             "patternProperties": {
@@ -1544,7 +1544,7 @@
                     "description": "Root Schema",
                     "oneOf": [
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/types"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/types"
                         }
                     ]
                 },
@@ -1553,31 +1553,31 @@
                     "description": "Allowed Avro types",
                     "oneOf": [
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/primitiveType"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/primitiveType"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/primitiveTypeWithMetadata"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/primitiveTypeWithMetadata"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/customTypeReference"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/customTypeReference"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/avroRecord"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/avroRecord"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/avroEnum"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/avroEnum"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/avroArray"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/avroArray"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/avroMap"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/avroMap"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/avroFixed"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/avroFixed"
                         },
                         {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/avroUnion"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/avroUnion"
                         }
                     ]
                 },
@@ -1602,7 +1602,7 @@
                     "type": "object",
                     "properties": {
                         "type": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/primitiveType"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/primitiveType"
                         }
                     },
                     "required": [
@@ -1613,7 +1613,7 @@
                     "title": "Custom Type",
                     "description": "Reference to a ComplexType",
                     "not": {
-                        "$ref": "#/definitions/json-schema-draft-07-schema/definitions/primitiveType"
+                        "$ref": "#/definitions/avroSchema_v1/definitions/primitiveType"
                     },
                     "type": "string",
                     "pattern": "^[A-Za-z_][A-Za-z0-9_]*(\\.[A-Za-z_][A-Za-z0-9_]*)*$"
@@ -1623,7 +1623,7 @@
                     "description": "A Union of types",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/json-schema-draft-07-schema/definitions/avroSchema"
+                        "$ref": "#/definitions/avroSchema_v1/definitions/avroSchema"
                     },
                     "minItems": 1
                 },
@@ -1633,10 +1633,10 @@
                     "type": "object",
                     "properties": {
                         "name": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/name"
                         },
                         "type": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/types"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/types"
                         },
                         "doc": {
                             "type": "string"
@@ -1652,7 +1652,7 @@
                         "aliases": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                                "$ref": "#/definitions/avroSchema_v1/definitions/name"
                             }
                         }
                     },
@@ -1671,10 +1671,10 @@
                             "const": "record"
                         },
                         "name": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/name"
                         },
                         "namespace": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/namespace"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/namespace"
                         },
                         "doc": {
                             "type": "string"
@@ -1682,13 +1682,13 @@
                         "aliases": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                                "$ref": "#/definitions/avroSchema_v1/definitions/name"
                             }
                         },
                         "fields": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/avroField"
+                                "$ref": "#/definitions/avroSchema_v1/definitions/avroField"
                             }
                         }
                     },
@@ -1708,10 +1708,10 @@
                             "const": "enum"
                         },
                         "name": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/name"
                         },
                         "namespace": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/namespace"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/namespace"
                         },
                         "doc": {
                             "type": "string"
@@ -1719,13 +1719,13 @@
                         "aliases": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                                "$ref": "#/definitions/avroSchema_v1/definitions/name"
                             }
                         },
                         "symbols": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                                "$ref": "#/definitions/avroSchema_v1/definitions/name"
                             }
                         }
                     },
@@ -1745,10 +1745,10 @@
                             "const": "array"
                         },
                         "name": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/name"
                         },
                         "namespace": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/namespace"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/namespace"
                         },
                         "doc": {
                             "type": "string"
@@ -1756,11 +1756,11 @@
                         "aliases": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                                "$ref": "#/definitions/avroSchema_v1/definitions/name"
                             }
                         },
                         "items": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/types"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/types"
                         }
                     },
                     "required": [
@@ -1778,10 +1778,10 @@
                             "const": "map"
                         },
                         "name": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/name"
                         },
                         "namespace": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/namespace"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/namespace"
                         },
                         "doc": {
                             "type": "string"
@@ -1789,11 +1789,11 @@
                         "aliases": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                                "$ref": "#/definitions/avroSchema_v1/definitions/name"
                             }
                         },
                         "values": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/types"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/types"
                         }
                     },
                     "required": [
@@ -1811,10 +1811,10 @@
                             "const": "fixed"
                         },
                         "name": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/name"
                         },
                         "namespace": {
-                            "$ref": "#/definitions/json-schema-draft-07-schema/definitions/namespace"
+                            "$ref": "#/definitions/avroSchema_v1/definitions/namespace"
                         },
                         "doc": {
                             "type": "string"
@@ -1822,7 +1822,7 @@
                         "aliases": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/json-schema-draft-07-schema/definitions/name"
+                                "$ref": "#/definitions/avroSchema_v1/definitions/name"
                             }
                         },
                         "size": {
@@ -1847,7 +1847,7 @@
             "description": "Json-Schema definition for Avro AVSC files.",
             "oneOf": [
                 {
-                    "$ref": "#/definitions/json-schema-draft-07-schema/definitions/avroSchema"
+                    "$ref": "#/definitions/avroSchema_v1/definitions/avroSchema"
                 }
             ],
             "title": "Avro Schema Definition"

--- a/test/fixtures/asyncapi.yml
+++ b/test/fixtures/asyncapi.yml
@@ -1,0 +1,42 @@
+# yaml-language-server: $schema=/Users/wookiee/sources/asyncapi-node/schemas/2.6.0-without-$id.json
+asyncapi: 2.6.0
+
+info:
+  
+  title: test.mosquitto.org
+  version: This service is in charge of processing all the events related to comments.
+
+servers:
+  dev:
+    url: test.mosquitto.org
+    protocol: mqtt
+
+channels:
+  comment/liked:
+    
+    description: Updates the likes count in the database when new like is noticed.
+    publish:
+      operationId: commentLiked
+      message:
+        description: Message that is being sent when a comment has been liked by someone.
+        payload:
+          $ref: '#/components/schemas/commentId'
+
+  comment/unliked:
+    description: Updates the likes count in the database when comment is unliked.
+    publish: 
+      operationId: commentUnliked
+      message:
+        description: Message that is being sent when a comment has been unliked by someone.
+        messageId: ddd
+        payload:
+          $ref: '#/components/schemas/commentId'
+
+components:
+  schemas:
+    commentId:
+      type: object
+      additionalProperties: false
+      properties:
+        commentId: 
+          type: string

--- a/test/fixtures/asyncapi.yml
+++ b/test/fixtures/asyncapi.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=/Users/wookiee/sources/asyncapi-node/schemas/2.6.0-without-$id.json
+# yaml-language-server: $schema=YOUR-PROJECTS-DIRECTORY/spec-json-schemas/schemas/2.6.0-without-$id.json
 asyncapi: 2.6.0
 
 info:

--- a/tools/bundler/index.js
+++ b/tools/bundler/index.js
@@ -55,7 +55,6 @@ console.log(`Using the following output directory: ${outputDirectory}`);
   console.log('done');
 })();
 
-
 /**
  * we first update definitions from URL to normal names
  * than update refs to point to new definitions, always inline never remote
@@ -72,6 +71,8 @@ function modifyRefsAndDefinitions(bundledSchema) {
   }
 
   traverse(bundledSchema, replaceRef);
+  traverse(bundledSchema.definitions.avroSchema_v1, updateAvro);
+  traverse(bundledSchema.definitions.openapiSchema_3_0, updateOpenAPI);
 
   return bundledSchema
 }
@@ -109,4 +110,32 @@ function replaceRef(schema) {
   } else {
     schema.$ref = `#/definitions/${getDefinitionName(schema.$ref)}`;
   }
+}
+
+/**
+ * this is a callback used when traversing through json schema
+ * to fix avro schema definitions to point to right direction
+ */
+function updateAvro(schema){
+  //traversing shoudl take place only in case of schemas with refs
+  if (schema.$ref === undefined) return;
+
+  schema.$ref = schema.$ref.replace(
+    "json-schema-draft-07-schema",
+    "avroSchema_v1"
+  );
+}
+
+/**
+ * this is a callback used when traversing through json schema
+ * to fix open api schema definitions to point to right direction
+ */
+function updateOpenAPI(schema){
+  //traversing shoudl take place only in case of schemas with refs
+  if (schema.$ref === undefined) return;
+
+  schema.$ref = schema.$ref.replace(
+    "json-schema-draft-07-schema",
+    "openapiSchema_3_0"
+  );
 }

--- a/tools/bundler/index.js
+++ b/tools/bundler/index.js
@@ -72,7 +72,8 @@ function modifyRefsAndDefinitions(bundledSchema) {
 
   traverse(bundledSchema, replaceRef);
   traverse(bundledSchema.definitions.avroSchema_v1, updateAvro);
-  traverse(bundledSchema.definitions.openapiSchema_3_0, updateOpenAPI);
+  traverse(bundledSchema.definitions.openapiSchema_3_0, updateOpenApi);
+  traverse(bundledSchema.definitions['json-schema-draft-07-schema'], updateJsonSchema);
 
   return bundledSchema
 }
@@ -100,16 +101,8 @@ function replaceRef(schema) {
   //traversing shoudl take place only in case of schemas with refs
   if (schema.$ref === undefined ) return;
 
-  // '#/definitions' refs are always those related to JSON Schema draft, so we just need to update them to point to json schema draft that is inlined inside schema
-  if (schema.$ref.startsWith('#/definitions')) {
-    schema.$ref = schema.$ref.replace('#/definitions/', `#/definitions/${JSON_SCHEMA_PROP_NAME}/definitions/`);
-  // '#' refs need to be updated to point to the root of inlined json schema draft
-  } else if (schema.$ref === '#') {
-    schema.$ref = `#/definitions/${JSON_SCHEMA_PROP_NAME}`;
-  // the rest of refs are those related to remote URL refst that need to be update and point to inlined versions
-  } else {
-    schema.$ref = `#/definitions/${getDefinitionName(schema.$ref)}`;
-  }
+  // updating refs that are related to remote URL refs that need to be update and point to inlined versions
+  if (!schema.$ref.startsWith('#')) schema.$ref = `#/definitions/${getDefinitionName(schema.$ref)}`;
 }
 
 /**
@@ -121,8 +114,8 @@ function updateAvro(schema){
   if (schema.$ref === undefined) return;
 
   schema.$ref = schema.$ref.replace(
-    "json-schema-draft-07-schema",
-    "avroSchema_v1"
+    '#/definitions/',
+    '#/definitions/avroSchema_v1/definitions/'
   );
 }
 
@@ -130,12 +123,35 @@ function updateAvro(schema){
  * this is a callback used when traversing through json schema
  * to fix open api schema definitions to point to right direction
  */
-function updateOpenAPI(schema){
+function updateOpenApi(schema){
+  //traversing shoudl take place only in case of schemas with refs
+  if (schema.$ref === undefined) return;
+  const openApiPropName = 'openapiSchema_3_0';
+
+  schema.$ref = schema.$ref.replace(
+    '#/definitions/',
+    `#/definitions/${openApiPropName}/definitions/`
+  );
+
+  if (schema.$ref === '#') {
+    schema.$ref = `#/definitions/${openApiPropName}`;
+  }
+}
+
+/**
+ * this is a callback used when traversing through json schema
+ * to fix open api schema definitions to point to right direction
+ */
+function updateJsonSchema(schema){
   //traversing shoudl take place only in case of schemas with refs
   if (schema.$ref === undefined) return;
 
   schema.$ref = schema.$ref.replace(
-    "json-schema-draft-07-schema",
-    "openapiSchema_3_0"
+    '#/definitions/',
+    `#/definitions/${JSON_SCHEMA_PROP_NAME}/definitions/`
   );
+
+  if (schema.$ref === '#') {
+    schema.$ref = `#/definitions/${JSON_SCHEMA_PROP_NAME}`;
+  }
 }


### PR DESCRIPTION
autocompletion in IDEs is affected

![Screenshot 2023-05-24 at 09 19 10](https://github.com/asyncapi/spec-json-schemas/assets/6995927/7319f8a0-06bc-46bf-b82c-809421e58237)

some more rewriting in refs in the dedicated JSON Schema was needed

- `schemas` content is generated, you can skip review of this one
- added `test/fixtures/asyncapi.yml` to make it easier long term to test schemas on local, readme also updated
- main magic changes in `index.js`