### PR TITLE
fix: allow Reference objects in MultiFormat schema fields

### DIFF
--- a/definitions/3.0.0/multiFormatSchema.json
+++ b/definitions/3.0.0/multiFormatSchema.json
@@ -33,7 +33,14 @@
         "then": {
           "properties": {
             "schema": {
-              "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+              "oneOf": [
+                {
+                  "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                },
+                {
+                  "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                }
+              ]
             }
           }
         }
@@ -77,7 +84,14 @@
         "then": {
           "properties": {
             "schema": {
-              "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+              "oneOf": [
+                {
+                  "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                },
+                {
+                  "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                }
+              ]
             }
           }
         }
@@ -99,7 +113,14 @@
         "then": {
           "properties": {
             "schema": {
-              "$ref": "http://json-schema.org/draft-07/schema"
+              "oneOf": [
+                {
+                  "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                },
+                {
+                  "$ref": "http://json-schema.org/draft-07/schema"
+                }
+              ]
             }
           }
         }
@@ -122,7 +143,14 @@
         "then": {
           "properties": {
             "schema": {
-              "$ref": "http://asyncapi.com/definitions/3.0.0/openapiSchema_3_0.json"
+              "oneOf": [
+                {
+                  "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                },
+                {
+                  "$ref": "http://asyncapi.com/definitions/3.0.0/openapiSchema_3_0.json"
+                }
+              ]
             }
           }
         }
@@ -145,7 +173,14 @@
         "then": {
           "properties": {
             "schema": {
-              "$ref": "http://asyncapi.com/definitions/3.0.0/avroSchema_v1.json"
+              "oneOf": [
+                {
+                  "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                },
+                {
+                  "$ref": "http://asyncapi.com/definitions/3.0.0/avroSchema_v1.json"
+                }
+              ]
             }
           }
         }

--- a/schemas/3.0.0-without-$id.json
+++ b/schemas/3.0.0-without-$id.json
@@ -2177,7 +2177,14 @@
                         "then": {
                             "properties": {
                                 "schema": {
-                                    "$ref": "#/definitions/schema"
+                                    "oneOf": [
+                                        {
+                                            "$ref": "#/definitions/Reference"
+                                        },
+                                        {
+                                            "$ref": "#/definitions/schema"
+                                        }
+                                    ]
                                 }
                             }
                         }
@@ -2221,7 +2228,14 @@
                         "then": {
                             "properties": {
                                 "schema": {
-                                    "$ref": "#/definitions/schema"
+                                    "oneOf": [
+                                        {
+                                            "$ref": "#/definitions/Reference"
+                                        },
+                                        {
+                                            "$ref": "#/definitions/schema"
+                                        }
+                                    ]
                                 }
                             }
                         }
@@ -2243,7 +2257,14 @@
                         "then": {
                             "properties": {
                                 "schema": {
-                                    "$ref": "#/definitions/json-schema-draft-07-schema"
+                                    "oneOf": [
+                                        {
+                                            "$ref": "#/definitions/Reference"
+                                        },
+                                        {
+                                            "$ref": "#/definitions/json-schema-draft-07-schema"
+                                        }
+                                    ]
                                 }
                             }
                         }
@@ -2266,7 +2287,14 @@
                         "then": {
                             "properties": {
                                 "schema": {
-                                    "$ref": "#/definitions/openapiSchema_3_0"
+                                    "oneOf": [
+                                        {
+                                            "$ref": "#/definitions/Reference"
+                                        },
+                                        {
+                                            "$ref": "#/definitions/openapiSchema_3_0"
+                                        }
+                                    ]
                                 }
                             }
                         }
@@ -2289,7 +2317,14 @@
                         "then": {
                             "properties": {
                                 "schema": {
-                                    "$ref": "#/definitions/avroSchema_v1"
+                                    "oneOf": [
+                                        {
+                                            "$ref": "#/definitions/Reference"
+                                        },
+                                        {
+                                            "$ref": "#/definitions/avroSchema_v1"
+                                        }
+                                    ]
                                 }
                             }
                         }

--- a/schemas/3.0.0.json
+++ b/schemas/3.0.0.json
@@ -2226,7 +2226,14 @@
                         "then": {
                             "properties": {
                                 "schema": {
-                                    "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                                    "oneOf": [
+                                        {
+                                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                                        },
+                                        {
+                                            "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                                        }
+                                    ]
                                 }
                             }
                         }
@@ -2270,7 +2277,14 @@
                         "then": {
                             "properties": {
                                 "schema": {
-                                    "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                                    "oneOf": [
+                                        {
+                                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                                        },
+                                        {
+                                            "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                                        }
+                                    ]
                                 }
                             }
                         }
@@ -2292,7 +2306,14 @@
                         "then": {
                             "properties": {
                                 "schema": {
-                                    "$ref": "http://json-schema.org/draft-07/schema"
+                                    "oneOf": [
+                                        {
+                                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                                        },
+                                        {
+                                            "$ref": "http://json-schema.org/draft-07/schema"
+                                        }
+                                    ]
                                 }
                             }
                         }
@@ -2315,7 +2336,14 @@
                         "then": {
                             "properties": {
                                 "schema": {
-                                    "$ref": "http://asyncapi.com/definitions/3.0.0/openapiSchema_3_0.json"
+                                    "oneOf": [
+                                        {
+                                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                                        },
+                                        {
+                                            "$ref": "http://asyncapi.com/definitions/3.0.0/openapiSchema_3_0.json"
+                                        }
+                                    ]
                                 }
                             }
                         }
@@ -2338,7 +2366,14 @@
                         "then": {
                             "properties": {
                                 "schema": {
-                                    "$ref": "http://asyncapi.com/definitions/3.0.0/avroSchema_v1.json"
+                                    "oneOf": [
+                                        {
+                                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                                        },
+                                        {
+                                            "$ref": "http://asyncapi.com/definitions/3.0.0/avroSchema_v1.json"
+                                        }
+                                    ]
                                 }
                             }
                         }

--- a/test/docs/3.0.0/streetlights-all.json
+++ b/test/docs/3.0.0/streetlights-all.json
@@ -74,6 +74,11 @@
                         }
                     }
                 }
+            },
+            "UserSignedUpV2": {
+                "payload": {
+                    "$ref": "external-schema.json"
+                }
             }
         }
     }

--- a/test/docs/3.0.0/streetlights-avro.json
+++ b/test/docs/3.0.0/streetlights-avro.json
@@ -76,6 +76,12 @@
           "namespace": "com.example.avro",
           "type": "record"
         }
+      },
+      "ReferencedSchema" : {
+        "schemaFormat": "application/vnd.apache.avro;version=1.9.0",
+        "schema": {
+          "$ref": "reference-to-some-avro-file.avsc"
+        }
       }
     },
     "messages": {

--- a/test/docs/3.0.0/streetlights-openapi.json
+++ b/test/docs/3.0.0/streetlights-openapi.json
@@ -58,6 +58,14 @@
     }
   },
   "components": {
+    "schemas": {
+      "ReferencedSchema" : {
+        "schemaFormat": "application/vnd.oai.openapi;version=3.0.0",
+        "schema": {
+          "$ref": "reference-to-some-openapi-file.json"
+        }
+      }
+    },
     "messages": {
       "UserSignedUp": {
         "payload": {


### PR DESCRIPTION
**Description**

There was a bug where a multi-format schema wasn't supporting references to external documents. For example, the following schema was invalid:

```json
"ReferencedSchema" : {
    "schemaFormat": "application/vnd.apache.avro;version=1.9.0",
    "schema": {
      "$ref": "reference-to-some-avro-file.avsc"
    }
  }
```

This PR fixes that by changing `schema` field to become `oneOf` either reference object or the schema (asyncapi, avro, etc).

**Related issue(s)**
https://asyncapi.slack.com/archives/C0230UAM6R3/p1689875953351089