### PR TITLE
chore: exclude tools/bundler/node_modules from final package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,3 +3,4 @@ test
 go.mod
 go.sum
 *.go
+tools/bundler/node_modules

--- a/.npmignore
+++ b/.npmignore
@@ -3,4 +3,4 @@ test
 go.mod
 go.sum
 *.go
-tools/bundler/node_modules
+tools/bundler


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

On a fresh install of the package `node_modules` in the `tools/bundler` are included while it's only useful when publishing the package.

This will allow to save some space / bandwith when installing this package.

<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->