### PR TITLE
fix: kafka key can be reference

### DIFF
--- a/bindings/kafka/0.4.0/message.json
+++ b/bindings/kafka/0.4.0/message.json
@@ -11,7 +11,14 @@
   },
   "properties": {
     "key": {
-      "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json",
+      "oneOf": [
+        {
+          "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+        },
+        {
+          "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json",
+        }
+      ]
       "description": "The message key."
     },
     "schemaIdLocation": {


### PR DESCRIPTION
**Description**
This PR fixes that the message.binding.kafka.key can be a reference.