### PR TITLE
fix: examples of messages should not follow json schema

### DIFF
--- a/definitions/3.0.0/messageObject.json
+++ b/definitions/3.0.0/messageObject.json
@@ -100,10 +100,11 @@
             "description": "A brief summary of the message example."
           },
           "headers": {
-            "$ref": "http://asyncapi.com/definitions/3.0.0/anySchema.json"
+            "type": "object",
+            "description": "Schema definition of the application headers."
           },
           "payload": {
-            "$ref": "http://asyncapi.com/definitions/3.0.0/anySchema.json"
+            "description": "Definition of the message payload. It can be of any type"
           }
         }
       }

--- a/definitions/3.0.0/messageObject.json
+++ b/definitions/3.0.0/messageObject.json
@@ -101,10 +101,10 @@
           },
           "headers": {
             "type": "object",
-            "description": "Schema definition of the application headers."
+            "description": "Example of the application headers. It can be of any type."
           },
           "payload": {
-            "description": "Definition of the message payload. It can be of any type"
+            "description": "Example of the message payload. It can be of any type."
           }
         }
       }


### PR DESCRIPTION
https://github.com/asyncapi/spec-json-schemas/pull/370 introduced bug in Message Object JSON schema

`examples` `headers` and `payload` should not follow json schema spec

just like in [previous versions](https://github.com/asyncapi/spec-json-schemas/blob/next-major-spec/definitions/2.6.0/message.json#L118-L124) these fields need to be flexible as `payload` or `headers` are no necessarily json, could be avro for example

noticed with https://github.com/asyncapi/spec/blob/next-major-spec/examples/websocket-gemini.yml
![Screenshot 2023-10-10 at 17 52 12](https://github.com/asyncapi/spec-json-schemas/assets/6995927/625cea09-5226-4758-8705-2271855a5ea7)

I checked the change locally and works like a charm
