### PR TITLE
feat!: remove messageId from Message and MessageTrait objects

### DIFF
--- a/definitions/3.0.0/messageObject.json
+++ b/definitions/3.0.0/messageObject.json
@@ -13,9 +13,6 @@
     "headers": {
       "$ref": "http://asyncapi.com/definitions/3.0.0/anySchema.json"
     },
-    "messageId": {
-      "type": "string"
-    },
     "payload": {
       "$ref": "http://asyncapi.com/definitions/3.0.0/anySchema.json"
     },

--- a/definitions/3.0.0/messageTrait.json
+++ b/definitions/3.0.0/messageTrait.json
@@ -13,9 +13,6 @@
     "headers": {
       "$ref": "http://asyncapi.com/definitions/3.0.0/anySchema.json"
     },
-    "messageId": {
-      "type": "string"
-    },
     "correlationId": {
       "oneOf": [
         {

--- a/schemas/3.0.0-without-$id.json
+++ b/schemas/3.0.0-without-$id.json
@@ -1994,9 +1994,6 @@
                 "headers": {
                     "$ref": "#/definitions/anySchema"
                 },
-                "messageId": {
-                    "type": "string"
-                },
                 "payload": {
                     "$ref": "#/definitions/anySchema"
                 },
@@ -3767,9 +3764,6 @@
                 },
                 "headers": {
                     "$ref": "#/definitions/anySchema"
-                },
-                "messageId": {
-                    "type": "string"
                 },
                 "correlationId": {
                     "oneOf": [

--- a/schemas/3.0.0.json
+++ b/schemas/3.0.0.json
@@ -2041,9 +2041,6 @@
                 "headers": {
                     "$ref": "http://asyncapi.com/definitions/3.0.0/anySchema.json"
                 },
-                "messageId": {
-                    "type": "string"
-                },
                 "payload": {
                     "$ref": "http://asyncapi.com/definitions/3.0.0/anySchema.json"
                 },
@@ -3830,9 +3827,6 @@
                 },
                 "headers": {
                     "$ref": "http://asyncapi.com/definitions/3.0.0/anySchema.json"
-                },
-                "messageId": {
-                    "type": "string"
                 },
                 "correlationId": {
                     "oneOf": [


### PR DESCRIPTION
**Description**

Removes the `messageId` property from the Message and MessageTrait objects.

**Related issue(s)**
https://github.com/asyncapi/spec/issues/978