### PR TITLE
fix: enable `$ref` support for bindings

### DIFF
--- a/definitions/3.0.0/channel.json
+++ b/definitions/3.0.0/channel.json
@@ -62,7 +62,14 @@
       ]
     },
     "bindings": {
-      "$ref": "http://asyncapi.com/definitions/3.0.0/channelBindingsObject.json"
+      "oneOf": [
+        {
+          "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+        },
+        {
+          "$ref": "http://asyncapi.com/definitions/3.0.0/channelBindingsObject.json"
+        }
+      ]
     }
   },
   "$schema": "http://json-schema.org/draft-07/schema#",

--- a/definitions/3.0.0/messageObject.json
+++ b/definitions/3.0.0/messageObject.json
@@ -107,7 +107,14 @@
       }
     },
     "bindings": {
-      "$ref": "http://asyncapi.com/definitions/3.0.0/messageBindingsObject.json"
+      "oneOf": [
+        {
+          "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+        },
+        {
+          "$ref": "http://asyncapi.com/definitions/3.0.0/messageBindingsObject.json"
+        }
+      ]
     },
     "traits": {
       "type": "array",

--- a/definitions/3.0.0/messageTrait.json
+++ b/definitions/3.0.0/messageTrait.json
@@ -74,7 +74,14 @@
       }
     },
     "bindings": {
-      "$ref": "http://asyncapi.com/definitions/3.0.0/messageBindingsObject.json"
+      "oneOf": [
+        {
+          "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+        },
+        {
+          "$ref": "http://asyncapi.com/definitions/3.0.0/messageBindingsObject.json"
+        }
+      ]
     }
   },
   "$schema": "http://json-schema.org/draft-07/schema#",

--- a/definitions/3.0.0/operation.json
+++ b/definitions/3.0.0/operation.json
@@ -88,7 +88,14 @@
       ]
     },
     "bindings": {
-      "$ref": "http://asyncapi.com/definitions/3.0.0/operationBindingsObject.json"
+      "oneOf": [
+        {
+          "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+        },
+        {
+          "$ref": "http://asyncapi.com/definitions/3.0.0/operationBindingsObject.json"
+        }
+      ]
     }
   },
   "$schema": "http://json-schema.org/draft-07/schema#",

--- a/definitions/3.0.0/operationTrait.json
+++ b/definitions/3.0.0/operationTrait.json
@@ -26,7 +26,14 @@
       "$ref": "http://asyncapi.com/definitions/3.0.0/operation.json#/properties/externalDocs"
     },
     "bindings": {
-      "$ref": "http://asyncapi.com/definitions/3.0.0/operation.json#/properties/bindings"
+      "oneOf": [
+        {
+          "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+        },
+        {
+          "$ref": "http://asyncapi.com/definitions/3.0.0/operationBindingsObject.json"
+        }
+      ]
     }
   },
   "$schema": "http://json-schema.org/draft-07/schema#",

--- a/definitions/3.0.0/server.json
+++ b/definitions/3.0.0/server.json
@@ -70,7 +70,14 @@
       ]
     },
     "bindings": {
-      "$ref": "http://asyncapi.com/definitions/3.0.0/serverBindingsObject.json"
+      "oneOf": [
+        {
+          "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+        },
+        {
+          "$ref": "http://asyncapi.com/definitions/3.0.0/serverBindingsObject.json"
+        }
+      ]
     }
   },
   "$schema": "http://json-schema.org/draft-07/schema#",


### PR DESCRIPTION
fixes: https://github.com/asyncapi/spec-json-schemas/issues/438

tested locally following https://github.com/asyncapi/spec-json-schemas/#schemastore-compatibility-testing and works like a charm