### PR TITLE
feat: adapt Kafka bindings to v3

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -45,7 +45,7 @@ jobs:
         env:
           GITHUB_TOKEN: "${{ secrets.GH_TOKEN }}"
           GITHUB_LOGIN: asyncapi-bot
-          MERGE_LABELS: ""
+          MERGE_LABELS: "!do-not-merge"
           MERGE_METHOD: "squash"
           MERGE_COMMIT_MESSAGE: "{pullRequest.title} (#{pullRequest.number})"
           MERGE_RETRIES: "20"

--- a/.npmignore
+++ b/.npmignore
@@ -3,3 +3,4 @@ test
 go.mod
 go.sum
 *.go
+tools/bundler

--- a/bindings/kafka/v2-0.4.0/channel.json
+++ b/bindings/kafka/v2-0.4.0/channel.json
@@ -1,0 +1,81 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://asyncapi.com/bindings/kafka/v2-0.4.0/channel.json",
+    "title": "Channel Schema",
+    "description": "This object contains information about the channel representation in Kafka.",
+    "type": "object",
+    "additionalProperties": false,
+    "patternProperties": {
+      "^x-[\\w\\d\\.\\-\\_]+$": {
+        "$ref": "https://raw.githubusercontent.com/asyncapi/spec-json-schemas/v2.14.0/schemas/2.4.0.json#/definitions/specificationExtension"
+      }
+    },
+    "properties": {
+      "topic": {
+        "type": "string",
+        "description": "Kafka topic name if different from channel name."
+      },
+      "partitions": {
+        "type": "integer",
+        "minimum": 1,
+        "description": "Number of partitions configured on this topic."
+      },
+      "replicas": {
+        "type": "integer",
+        "minimum": 1,
+        "description": "Number of replicas configured on this topic."
+      },
+      "topicConfiguration" : {
+        "description": "Topic configuration properties that are relevant for the API.",
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "cleanup.policy": {
+            "description": "The [`cleanup.policy`](https://kafka.apache.org/documentation/#topicconfigs_cleanup.policy) configuration option.",
+            "type": "array",
+            "items":{
+              "type": "string",
+              "enum": ["compact", "delete"]
+            }
+          },
+          "retention.ms": {
+            "description": "The [`retention.ms`](https://kafka.apache.org/documentation/#topicconfigs_retention.ms) configuration option.",
+            "type": "integer",
+            "minimum": -1            
+          },
+          "retention.bytes": {
+            "description": "The [`retention.bytes`](https://kafka.apache.org/documentation/#topicconfigs_retention.bytes) configuration option.",
+            "type": "integer",
+            "minimum": -1
+          },
+          "delete.retention.ms": {
+            "description": "The [`delete.retention.ms`](https://kafka.apache.org/documentation/#topicconfigs_delete.retention.ms) configuration option.",
+            "type": "integer",
+            "minimum": 0
+          },
+          "max.message.bytes": {
+            "description": "The [`max.message.bytes`](https://kafka.apache.org/documentation/#topicconfigs_max.message.bytes) configuration option.",
+            "type": "integer",
+            "minimum": 0
+          }
+        }
+      },
+      "bindingVersion": {
+        "type": "string",
+        "enum": [
+          "v2-0.4.0"
+        ],
+        "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+      }
+  
+    },
+    "examples": [
+      {
+        "topic": "my-specific-topic",
+        "partitions": 20,
+        "replicas": 3,
+        "bindingVersion": "v2-0.4.0"
+      }
+    ]
+  }
+  

--- a/bindings/kafka/v2-0.4.0/message.json
+++ b/bindings/kafka/v2-0.4.0/message.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/bindings/kafka/message.json",
+  "title": "Message Schema",
+  "type": "object",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^x-[\\w\\d\\.\\-\\_]+$": {
+      "$ref": "https://asyncapi.com/definitions/2.4.0/specificationExtension.json"
+    }
+  },
+  "properties": {
+    "key": {
+      "oneOf": [
+        {
+          "$ref": "https://asyncapi.com/definitions/2.4.0/schema.json"
+        },
+        {
+          "$ref": "https://asyncapi.com/definitions/2.4.0/Reference.json"
+        }
+      ],
+      "description": "The message key."
+    },
+    "schemaIdLocation": {
+      "type": "string",
+      "description": "If a Schema Registry is used when performing this operation, tells where the id of schema is stored.",
+      "enum": ["header", "payload"]
+    },
+    "schemaIdPayloadEncoding": {
+      "type": "string",
+      "description": "Number of bytes or vendor specific values when schema id is encoded in payload."
+    },
+    "schemaLookupStrategy": {
+      "type": "string",
+      "description": "Freeform string for any naming strategy class to use. Clients should default to the vendor default if not supplied."
+    },
+    "bindingVersion": {
+      "type": "string",
+      "enum": [
+        "0.4.0"
+      ],
+      "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+    }
+
+  },
+  "examples": [
+    {
+      "key": {
+        "type": "string",
+        "enum": [
+          "myKey"
+        ]
+      },
+      "schemaIdLocation": "payload",
+      "schemaIdPayloadEncoding": "apicurio-new",
+      "schemaLookupStrategy": "TopicIdStrategy",
+      "bindingVersion": "0.3.0"
+    },
+    {
+      "key": {
+        "$ref": "path/to/user-create.avsc#/UserCreate"
+      },
+      "schemaIdLocation": "payload",
+      "schemaIdPayloadEncoding": "4",
+      "bindingVersion": "0.3.0"
+    }
+  ]
+}

--- a/bindings/kafka/v2-0.4.0/operation.json
+++ b/bindings/kafka/v2-0.4.0/operation.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/bindings/kafka/operation.json",
+  "title": "Operation Schema",
+  "description": "This object contains information about the operation representation in Kafka.",
+  "type": "object",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^x-[\\w\\d\\.\\-\\_]+$": {
+      "$ref": "https://raw.githubusercontent.com/asyncapi/spec-json-schemas/v2.14.0/schemas/2.4.0.json#/definitions/specificationExtension"
+    }
+  },
+  "properties": {
+    "groupId": {
+      "$ref": "https://raw.githubusercontent.com/asyncapi/spec-json-schemas/v2.14.0/schemas/2.4.0.json#/definitions/schema",
+      "description": "Id of the consumer group."
+    },
+    "clientId": {
+      "$ref": "https://raw.githubusercontent.com/asyncapi/spec-json-schemas/v2.14.0/schemas/2.4.0.json#/definitions/schema",
+      "description": "Id of the consumer inside a consumer group."
+    },
+    "bindingVersion": {
+      "type": "string",
+      "enum": [
+        "0.4.0"
+      ],
+      "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+    }
+
+  },
+  "examples": [
+    {
+      "groupId": {
+        "type": "string",
+        "enum": [
+          "myGroupId"
+        ]
+      },
+      "clientId": {
+        "type": "string",
+        "enum": [
+          "myClientId"
+        ]
+      },
+      "bindingVersion": "0.3.0"
+    }
+  ]
+}

--- a/bindings/kafka/v2-0.4.0/server.json
+++ b/bindings/kafka/v2-0.4.0/server.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/bindings/kafka/server.json",
+  "title": "Server Schema",
+  "description": "This object contains server connection information to a Kafka broker. This object contains additional information not possible to represent within the core AsyncAPI specification.",
+  "type": "object",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^x-[\\w\\d\\.\\-\\_]+$": {
+      "$ref": "https://raw.githubusercontent.com/asyncapi/spec-json-schemas/v2.14.0/schemas/2.4.0.json#/definitions/specificationExtension"
+    }
+  },
+  "properties": {
+    "schemaRegistryUrl": {
+      "type": "string",
+      "description": "API URL for the Schema Registry used when producing Kafka messages (if a Schema Registry was used)."
+    },
+    "schemaRegistryVendor": {
+      "type": "string",
+      "description": "The vendor of the Schema Registry and Kafka serdes library that should be used."
+    },
+    "bindingVersion": {
+      "type": "string",
+      "enum": [
+        "0.4.0"
+      ],
+      "description": "The version of this binding."
+    }
+  },
+  "examples": [
+    {
+      "schemaRegistryUrl": "https://my-schema-registry.com",
+      "schemaRegistryVendor": "confluent",
+      "bindingVersion": "0.3.0"
+    }
+  ]
+}

--- a/bindings/kafka/v3-0.4.0/channel.json
+++ b/bindings/kafka/v3-0.4.0/channel.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/bindings/kafka/v3-0.4.0/channel.json",
+  "title": "Channel Schema",
+  "description": "This object contains information about the channel representation in Kafka.",
+  "type": "object",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^x-[\\w\\d\\.\\x2d_]+$": {
+      "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+    }
+  },
+  "properties": {
+    "topic": {
+      "type": "string",
+      "description": "Kafka topic name if different from channel name."
+    },
+    "partitions": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Number of partitions configured on this topic."
+    },
+    "replicas": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Number of replicas configured on this topic."
+    },
+    "topicConfiguration" : {
+      "description": "Topic configuration properties that are relevant for the API.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "cleanup.policy": {
+          "description": "The [`cleanup.policy`](https://kafka.apache.org/documentation/#topicconfigs_cleanup.policy) configuration option.",
+          "type": "array",
+          "items":{
+            "type": "string",
+            "enum": ["compact", "delete"]
+          }
+        },
+        "retention.ms": {
+          "description": "The [`retention.ms`](https://kafka.apache.org/documentation/#topicconfigs_retention.ms) configuration option.",
+          "type": "integer",
+          "minimum": -1            
+        },
+        "retention.bytes": {
+          "description": "The [`retention.bytes`](https://kafka.apache.org/documentation/#topicconfigs_retention.bytes) configuration option.",
+          "type": "integer",
+          "minimum": -1
+        },
+        "delete.retention.ms": {
+          "description": "The [`delete.retention.ms`](https://kafka.apache.org/documentation/#topicconfigs_delete.retention.ms) configuration option.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "max.message.bytes": {
+          "description": "The [`max.message.bytes`](https://kafka.apache.org/documentation/#topicconfigs_max.message.bytes) configuration option.",
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "bindingVersion": {
+      "type": "string",
+      "enum": [
+        "v3-0.4.0"
+      ],
+      "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+    }
+
+  },
+  "examples": [
+    {
+      "topic": "my-specific-topic",
+      "partitions": 20,
+      "replicas": 3,
+      "bindingVersion": "v3-0.4.0"
+    }
+  ]
+}

--- a/bindings/kafka/v3-0.4.0/message.json
+++ b/bindings/kafka/v3-0.4.0/message.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/bindings/kafka/0.4.0/message.json",
+  "title": "Message Schema",
+  "type": "object",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^x-[\\w\\d\\.\\x2d_]+$": {
+      "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+    }
+  },
+  "properties": {
+    "key": {
+      "oneOf": [
+        {
+          "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+        },
+        {
+          "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+        }
+      ],
+      "description": "The message key."
+    },
+    "schemaIdLocation": {
+      "type": "string",
+      "description": "If a Schema Registry is used when performing this operation, tells where the id of schema is stored.",
+      "enum": ["header", "payload"]
+    },
+    "schemaIdPayloadEncoding": {
+      "type": "string",
+      "description": "Number of bytes or vendor specific values when schema id is encoded in payload."
+    },
+    "schemaLookupStrategy": {
+      "type": "string",
+      "description": "Freeform string for any naming strategy class to use. Clients should default to the vendor default if not supplied."
+    },
+    "bindingVersion": {
+      "type": "string",
+      "enum": [
+        "0.4.0"
+      ],
+      "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+    }
+
+  },
+  "examples": [
+    {
+      "key": {
+        "type": "string",
+        "enum": [
+          "myKey"
+        ]
+      },
+      "schemaIdLocation": "payload",
+      "schemaIdPayloadEncoding": "apicurio-new",
+      "schemaLookupStrategy": "TopicIdStrategy",
+      "bindingVersion": "0.4.0"
+    },
+    {
+      "key": {
+        "$ref": "path/to/user-create.avsc#/UserCreate"
+      },
+      "schemaIdLocation": "payload",
+      "schemaIdPayloadEncoding": "4",
+      "bindingVersion": "0.4.0"
+    }
+  ]
+}

--- a/bindings/kafka/v3-0.4.0/operation.json
+++ b/bindings/kafka/v3-0.4.0/operation.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/bindings/kafka/0.4.0/operation.json",
+  "title": "Operation Schema",
+  "description": "This object contains information about the operation representation in Kafka.",
+  "type": "object",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^x-[\\w\\d\\.\\x2d_]+$": {
+      "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+    }
+  },
+  "properties": {
+    "groupId": {
+      "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json",
+      "description": "Id of the consumer group."
+    },
+    "clientId": {
+      "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json",
+      "description": "Id of the consumer inside a consumer group."
+    },
+    "bindingVersion": {
+      "type": "string",
+      "enum": [
+        "0.4.0"
+      ],
+      "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+    }
+  },
+  "examples": [
+    {
+      "groupId": {
+        "type": "string",
+        "enum": [
+          "myGroupId"
+        ]
+      },
+      "clientId": {
+        "type": "string",
+        "enum": [
+          "myClientId"
+        ]
+      },
+      "bindingVersion": "0.4.0"
+    }
+  ]
+}

--- a/bindings/kafka/v3-0.4.0/server.json
+++ b/bindings/kafka/v3-0.4.0/server.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/bindings/kafka/0.4.0/server.json",
+  "title": "Server Schema",
+  "description": "This object contains server connection information to a Kafka broker. This object contains additional information not possible to represent within the core AsyncAPI specification.",
+  "type": "object",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^x-[\\w\\d\\.\\x2d_]+$": {
+      "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+    }
+  },
+  "properties": {
+    "schemaRegistryUrl": {
+      "type": "string",
+      "description": "API URL for the Schema Registry used when producing Kafka messages (if a Schema Registry was used)."
+    },
+    "schemaRegistryVendor": {
+      "type": "string",
+      "description": "The vendor of the Schema Registry and Kafka serdes library that should be used."
+    },
+    "bindingVersion": {
+      "type": "string",
+      "enum": [
+        "0.4.0"
+      ],
+      "description": "The version of this binding."
+    }
+  },
+  "examples": [
+    {
+      "schemaRegistryUrl": "https://my-schema-registry.com",
+      "schemaRegistryVendor": "confluent",
+      "bindingVersion": "0.4.0"
+    }
+  ]
+}

--- a/definitions/3.0.0/channelBindingsObject.json
+++ b/definitions/3.0.0/channelBindingsObject.json
@@ -84,7 +84,7 @@
     "kafka": {
       "properties": {
         "bindingVersion": {
-          "enum": ["0.4.0", "0.3.0"]
+          "enum": ["v3-0.4.0", "0.4.0", "0.3.0"]
         }
       },
       "allOf": [
@@ -98,7 +98,20 @@
             }
           },
           "then": {
-            "$ref": "http://asyncapi.com/bindings/kafka/0.4.0/channel.json"
+            "$ref": "http://asyncapi.com/bindings/kafka/v3-0.4.0/channel.json"
+          }
+        },
+        {
+          "if": {
+            "required": [ "bindingVersion" ],
+            "properties": {
+              "bindingVersion": {
+                "const": "v3-0.4.0"
+              }
+            }
+          }, 
+          "then": {
+            "$ref": "http://asyncapi.com/bindings/kafka/v3-0.4.0/channel.json"
           }
         },
         {

--- a/definitions/3.0.0/messageBindingsObject.json
+++ b/definitions/3.0.0/messageBindingsObject.json
@@ -118,7 +118,7 @@
     "kafka": {
       "properties": {
         "bindingVersion": {
-          "enum": ["0.4.0", "0.3.0", "0.1.0"]
+          "enum": ["v3-0.4.0", "0.4.0", "0.3.0"]
         }
       },
       "allOf": [
@@ -132,7 +132,20 @@
             }
           },
           "then": {
-            "$ref": "http://asyncapi.com/bindings/kafka/0.4.0/message.json"
+            "$ref": "http://asyncapi.com/bindings/kafka/v3-0.4.0/message.json"
+          }
+        },
+        {
+          "if": {
+            "required": [ "bindingVersion" ],
+            "properties": {
+              "bindingVersion": {
+                "const": "v3-0.4.0"
+              }
+            }
+          }, 
+          "then": {
+            "$ref": "http://asyncapi.com/bindings/kafka/v3-0.4.0/message.json"
           }
         },
         {
@@ -159,19 +172,6 @@
           }, 
           "then": {
             "$ref": "http://asyncapi.com/bindings/kafka/0.3.0/message.json"
-          }
-        },
-        {
-          "if": {
-            "required": [ "bindingVersion" ],
-            "properties": {
-              "bindingVersion": {
-                "const": "0.1.0"
-              }
-            }
-          }, 
-          "then": {
-            "$ref": "http://asyncapi.com/bindings/kafka/0.1.0/message.json"
           }
         }
       ]

--- a/definitions/3.0.0/operationBindingsObject.json
+++ b/definitions/3.0.0/operationBindingsObject.json
@@ -118,7 +118,7 @@
     "kafka": {
       "properties": {
         "bindingVersion": {
-          "enum": ["0.4.0", "0.3.0", "0.1.0"]
+          "enum": ["v3-0.4.0", "0.4.0", "0.3.0"]
         }
       },
       "allOf": [
@@ -132,7 +132,20 @@
             }
           },
           "then": {
-            "$ref": "http://asyncapi.com/bindings/kafka/0.4.0/operation.json"
+            "$ref": "http://asyncapi.com/bindings/kafka/v3-0.4.0/operation.json"
+          }
+        },
+        {
+          "if": {
+            "required": [ "bindingVersion" ],
+            "properties": {
+              "bindingVersion": {
+                "const": "v3-0.4.0"
+              }
+            }
+          }, 
+          "then": {
+            "$ref": "http://asyncapi.com/bindings/kafka/v3-0.4.0/operation.json"
           }
         },
         {
@@ -159,19 +172,6 @@
           }, 
           "then": {
             "$ref": "http://asyncapi.com/bindings/kafka/0.3.0/operation.json"
-          }
-        },
-        {
-          "if": {
-            "required": [ "bindingVersion" ],
-            "properties": {
-              "bindingVersion": {
-                "const": "0.1.0"
-              }
-            }
-          }, 
-          "then": {
-            "$ref": "http://asyncapi.com/bindings/kafka/0.1.0/operation.json"
           }
         }
       ]

--- a/definitions/3.0.0/serverBindingsObject.json
+++ b/definitions/3.0.0/serverBindingsObject.json
@@ -84,7 +84,7 @@
     "kafka": {
       "properties": {
         "bindingVersion": {
-          "enum": ["0.4.0", "0.3.0"]
+          "enum": ["v3-0.4.0", "0.4.0", "0.3.0"]
         }
       },
       "allOf": [
@@ -98,7 +98,20 @@
             }
           },
           "then": {
-            "$ref": "http://asyncapi.com/bindings/kafka/0.4.0/server.json"
+            "$ref": "http://asyncapi.com/bindings/kafka/v3-0.4.0/server.json"
+          }
+        },
+        {
+          "if": {
+            "required": [ "bindingVersion" ],
+            "properties": {
+              "bindingVersion": {
+                "const": "v3-0.4.0"
+              }
+            }
+          }, 
+          "then": {
+            "$ref": "http://asyncapi.com/bindings/kafka/v3-0.4.0/server.json"
           }
         },
         {

--- a/go.mod
+++ b/go.mod
@@ -7,5 +7,5 @@ require github.com/stretchr/testify v1.7.0
 require (
 	github.com/davecgh/go-spew v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
+	gopkg.in/yaml.v3 v3.0.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -7,5 +7,6 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.0 h1:hjy8E9ON/egN1tAYqKb61G10WtihqetD4sz2H+8nIeA=
+gopkg.in/yaml.v3 v3.0.0/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/package-lock.json
+++ b/package-lock.json
@@ -2654,6 +2654,16 @@
     }
   },
   "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.22.13",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
+      "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.22.13",
+        "chalk": "^2.4.2"
+      }
+    },
     "@babel/core": {
       "version": "7.12.13",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.12.13.tgz",
@@ -2730,24 +2740,38 @@
         }
       }
     },
-    "@babel/helper-function-name": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
-      "integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-get-function-arity": "^7.12.13",
-        "@babel/template": "^7.12.13",
-        "@babel/types": "^7.12.13"
-      }
+    "@babel/helper-environment-visitor": {
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
+      "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
+      "dev": true
     },
-    "@babel/helper-get-function-arity": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
-      "integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
+    "@babel/helper-hoist-variables": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
+      "integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.12.13"
+        "@babel/types": "^7.22.5"
+      },
+      "dependencies": {
+        "@babel/helper-validator-identifier": {
+          "version": "7.22.20",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+          "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
+          "dev": true
+        },
+        "@babel/types": {
+          "version": "7.23.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
+          "integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-string-parser": "^7.22.5",
+            "@babel/helper-validator-identifier": "^7.22.20",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "@babel/helper-member-expression-to-functions": {
@@ -2824,6 +2848,12 @@
         "@babel/types": "^7.12.13"
       }
     },
+    "@babel/helper-string-parser": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
+      "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
+      "dev": true
+    },
     "@babel/helper-validator-identifier": {
       "version": "7.12.11",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
@@ -2839,6 +2869,25 @@
         "@babel/template": "^7.12.13",
         "@babel/traverse": "^7.12.13",
         "@babel/types": "^7.12.13"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.20.tgz",
+      "integrity": "sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.22.20",
+        "chalk": "^2.4.2",
+        "js-tokens": "^4.0.0"
+      },
+      "dependencies": {
+        "@babel/helper-validator-identifier": {
+          "version": "7.22.20",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+          "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
+          "dev": true
+        }
       }
     },
     "@babel/parser": {
@@ -2881,40 +2930,86 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.13.tgz",
-      "integrity": "sha512-3Zb4w7eE/OslI0fTp8c7b286/cQps3+vdLW3UcwC8VSJC6GbKn55aeVVu2QJNuCDoeKyptLOFrPq8WqZZBodyA==",
+      "version": "7.23.2",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
+      "integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.12.13",
-        "@babel/generator": "^7.12.13",
-        "@babel/helper-function-name": "^7.12.13",
-        "@babel/helper-split-export-declaration": "^7.12.13",
-        "@babel/parser": "^7.12.13",
-        "@babel/types": "^7.12.13",
+        "@babel/code-frame": "^7.22.13",
+        "@babel/generator": "^7.23.0",
+        "@babel/helper-environment-visitor": "^7.22.20",
+        "@babel/helper-function-name": "^7.23.0",
+        "@babel/helper-hoist-variables": "^7.22.5",
+        "@babel/helper-split-export-declaration": "^7.22.6",
+        "@babel/parser": "^7.23.0",
+        "@babel/types": "^7.23.0",
         "debug": "^4.1.0",
-        "globals": "^11.1.0",
-        "lodash": "^4.17.19"
+        "globals": "^11.1.0"
       },
       "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
-          "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+        "@babel/generator": {
+          "version": "7.23.0",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.0.tgz",
+          "integrity": "sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==",
           "dev": true,
           "requires": {
-            "@babel/highlight": "^7.12.13"
+            "@babel/types": "^7.23.0",
+            "@jridgewell/gen-mapping": "^0.3.2",
+            "@jridgewell/trace-mapping": "^0.3.17",
+            "jsesc": "^2.5.1"
           }
         },
-        "@babel/highlight": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.12.13.tgz",
-          "integrity": "sha512-kocDQvIbgMKlWxXe9fof3TQ+gkIPOUSEYhJjqUjvKMez3krV7vbzYCDq39Oj11UAVK7JqPVGQPlgE85dPNlQww==",
+        "@babel/helper-function-name": {
+          "version": "7.23.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
+          "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
           "dev": true,
           "requires": {
-            "@babel/helper-validator-identifier": "^7.12.11",
-            "chalk": "^2.0.0",
-            "js-tokens": "^4.0.0"
+            "@babel/template": "^7.22.15",
+            "@babel/types": "^7.23.0"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.22.6",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
+          "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.22.5"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.22.20",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+          "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
+          "dev": true
+        },
+        "@babel/parser": {
+          "version": "7.23.0",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
+          "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
+          "dev": true
+        },
+        "@babel/template": {
+          "version": "7.22.15",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
+          "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.22.13",
+            "@babel/parser": "^7.22.15",
+            "@babel/types": "^7.22.15"
+          }
+        },
+        "@babel/types": {
+          "version": "7.23.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
+          "integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-string-parser": "^7.22.5",
+            "@babel/helper-validator-identifier": "^7.22.20",
+            "to-fast-properties": "^2.0.0"
           }
         }
       }
@@ -2999,6 +3094,45 @@
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.2.tgz",
       "integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==",
       "dev": true
+    },
+    "@jridgewell/gen-mapping": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
+      "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
+    "@jridgewell/resolve-uri": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
+      "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
+      "dev": true
+    },
+    "@jridgewell/set-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+      "dev": true
+    },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+      "dev": true
+    },
+    "@jridgewell/trace-mapping": {
+      "version": "0.3.19",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.19.tgz",
+      "integrity": "sha512-kf37QtfW+Hwx/buWGMPcR60iF9ziHa6r/CZJIHbmcm4+0qrXiVdxegAH0F6yddEVQ7zdkjcGCgCzUu+BcbhQxw==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
     },
     "@types/json-schema": {
       "version": "7.0.11",


### PR DESCRIPTION
**Description**

This is the companion PR to https://github.com/asyncapi/bindings/pull/221.

As discussed and proposed [here](https://github.com/asyncapi/bindings/issues/182#issuecomment-1792837812) in issue #182, this PR: 
- Duplicates previous version `0.4.0` in `v2-0.4.0` and `v3-0.4.0` to keep track of bindings changes related to AsyncAPI v3 or v3
- Schemas related to v2 are referencing the v2 specification extensions schema (https://raw.githubusercontent.com/asyncapi/spec-json-schemas/v2.14.0/schemas/2.4.0.json#/definitions/specificationExtension)
- Schemas related to v3 are referencing the v3 specification extension schema (http://asyncapi.com/definitions/3.0.0/specificationExtension.json)


Another PR with specific schemas for v2 and v3 is on its way on `asyncapi/spec-json-schemas`.

**Related issue(s)**

Relates to https://github.com/asyncapi/bindings/issues/182