### PR TITLE
fix: make `key` in kafka msg binding validate as anyOf

### DIFF
--- a/bindings/kafka/0.4.0/message.json
+++ b/bindings/kafka/0.4.0/message.json
@@ -11,12 +11,15 @@
   },
   "properties": {
     "key": {
-      "oneOf": [
+      "anyOf": [
         {
           "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
         },
         {
           "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+        },
+        {
+          "$ref": "http://asyncapi.com/definitions/3.0.0/avroSchema_v1.json"
         }
       ],
       "description": "The message key."


### PR DESCRIPTION
Kafka binding for messages, in 0.4 version introduced Avro support for `key` - but JSON Schema is not properly modified

Kafka message binding -> https://github.com/asyncapi/bindings/tree/master/kafka#message-binding-object
![Screenshot 2023-12-11 at 11 01 52](https://github.com/asyncapi/spec-json-schemas/assets/6995927/318c387a-c652-4a4c-b898-e6d0441a02c7)

so things like below should be allowed:
```yaml
      bindings:
        kafka:
          key:
            $ref: "https://deploy-preview-921--asyncapi-website.netlify.app/resources/casestudies/adeo/CostingResponseKey.avsc"
```

Just go to https://studio.asyncapi.com/?url=https://raw.githubusercontent.com/asyncapi/spec/d78dcea70c9b094a3df72f9a4e811828cec778cc/examples/adeo-kafka-request-reply-asyncapi.yml and try to remove lines 242-245 all all suddenly validation stops failing

#### Where issue is coming from

This is what json schema for message binding says: https://github.com/asyncapi/spec-json-schemas/blob/master/bindings/kafka/0.4.0/message.json#L13-L21

current JSON Schema validates agains `oneOf` listed schemas, but problem is that these are reference object + json schema. JSON schema defines `$ref` property as well, so when in `key` you put `$ref`, it is then valid against both schemas listed under `oneOf` and yeah, it is an error.

I don't think there is a better solution than just using `anyOf` instead of `oneOf` 🤔 

Also, such validation combination like the one I fix, is used in many other bindings, so also not sure but maybe I should propagate the fix everywhere?

#### This PR fixes

- enables people to put Avro as key inline
- changes validation keyword from `oneOf` to `anyOf`



