### PR TITLE
feat:  solace add per operation fields

### DIFF
--- a/bindings/solace/0.2.0/operation.json
+++ b/bindings/solace/0.2.0/operation.json
@@ -71,14 +71,14 @@
           }
         ]
       }
+    },
+    "bindingVersion": {
+      "type": "string",
+      "enum": [
+        "0.2.0"
+      ],
+      "description": "The version of this binding. If omitted, \"latest\" MUST be assumed."
     }
-  },
-  "bindingVersion": {
-    "type": "string",
-    "enum": [
-      "0.2.0"
-    ],
-    "description": "The version of this binding. If omitted, \"latest\" MUST be assumed."
   },
   "examples": [
     {

--- a/bindings/solace/0.3.0/operation.json
+++ b/bindings/solace/0.3.0/operation.json
@@ -79,14 +79,14 @@
           }
         ]
       }
+    },
+    "bindingVersion": {
+      "type": "string",
+      "enum": [
+        "0.3.0"
+      ],
+      "description": "The version of this binding. If omitted, \"latest\" MUST be assumed."
     }
-  },
-  "bindingVersion": {
-    "type": "string",
-    "enum": [
-      "0.3.0"
-    ],
-    "description": "The version of this binding. If omitted, \"latest\" MUST be assumed."
   },
   "examples": [
     {

--- a/bindings/solace/0.4.0/operation.json
+++ b/bindings/solace/0.4.0/operation.json
@@ -1,0 +1,128 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/bindings/solace/0.4.0/operation.json",
+  "title": "Solace operation bindings object",
+  "description": "This object contains information about the operation representation in Solace.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "bindingVersion": {
+      "type": "string",
+      "enum": [
+        "0.4.0"
+      ],
+      "description": "The version of this binding. If omitted, \"latest\" MUST be assumed."
+    },
+    "destinations": {
+      "description": "The list of Solace destinations referenced in the operation.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "deliveryMode": {
+            "type": "string",
+            "enum": [
+              "direct",
+              "persistent"
+            ]
+          }
+        },
+        "oneOf": [
+          {
+            "properties": {
+              "destinationType": {
+                "type": "string",
+                "const": "queue",
+                "description": "If the type is queue, then the subscriber can bind to the queue. The queue subscribes to the given topicSubscriptions. If no topicSubscriptions are provied, the queue will subscribe to the topic as represented by the channel name."
+              },
+              "queue": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "The name of the queue"
+                  },
+                  "topicSubscriptions": {
+                    "type": "array",
+                    "description": "The list of topics that the queue subscribes to.",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "accessType": {
+                    "type": "string",
+                    "enum": [
+                      "exclusive",
+                      "nonexclusive"
+                    ]
+                  },
+                  "maxTtl": {
+                    "type": "string",
+                    "description": "The maximum TTL to apply to messages to be spooled."
+                  },
+                  "maxMsgSpoolUsage": {
+                    "type": "string",
+                    "description": "The maximum amount of message spool that the given queue may use"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "properties": {
+              "destinationType": {
+                "type": "string",
+                "const": "topic",
+                "description": "If the type is topic, then the subscriber subscribes to the given topicSubscriptions. If no topicSubscriptions are provided, the client will subscribe to the topic as represented by the channel name."
+              },
+              "topicSubscriptions": {
+                "type": "array",
+                "description": "The list of topics that the client subscribes to.",
+                "items": {
+                  "type": "string"
+                }
+          }
+            }
+          }
+        ]
+      }
+    },
+    "timeToLive": {
+      "type": "integer",
+      "description": "Interval in milliseconds or a Schema Object containing the definition of the lifetime of the message."
+    },
+    "priority": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 255,
+      "description": "The valid priority value range is 0-255 with 0 as the lowest priority and 255 as the highest or a Schema Object containing the definition of the priority."
+    },
+    "dmqEligible": {
+      "type": "boolean",
+      "description": "Set the message to be eligible to be moved to a Dead Message Queue. The default value is false."
+    }
+  },
+  "examples": [
+    {
+      "bindingVersion": "0.4.0",
+      "destinations": [
+        {
+          "destinationType": "queue",
+          "queue": {
+            "name": "sampleQueue",
+            "topicSubscriptions": [
+              "samples/*"
+            ],
+            "accessType": "nonexclusive"
+          }
+        },
+        {
+          "destinationType": "topic",
+          "topicSubscriptions": [
+            "samples/*"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/bindings/solace/0.4.0/server.json
+++ b/bindings/solace/0.4.0/server.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/bindings/solace/0.4.0/server.json",
+  "title": "Solace server bindings object",
+  "description": "This object contains server connection information about the Solace broker. This object contains additional connectivity information not possible to represent within the core AsyncAPI specification.",
+  "type": "object",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^x-[\\w\\d\\.\\x2d_]+$": {
+      "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+    }
+  },
+  "properties": {
+    "msgVpn": {
+      "type": "string",
+      "description": "The name of the Virtual Private Network to connect to on the Solace broker."
+    },
+    "clientName": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 160,
+      "description": "A unique client name to use to register to the appliance. If specified, it must be a valid Topic name, and a maximum of 160 bytes in length when encoded as UTF-8."
+    },
+    "bindingVersion": {
+      "type": "string",
+      "enum": [
+        "0.4.0"
+      ],
+      "description": "The version of this binding."
+    }
+  },
+  "examples": [
+    {
+      "msgVpn": "ProdVPN",
+      "bindingVersion": "0.4.0"
+    }
+  ]
+}

--- a/definitions/3.0.0/operationBindingsObject.json
+++ b/definitions/3.0.0/operationBindingsObject.json
@@ -289,7 +289,7 @@
     "solace": {
       "properties": {
         "bindingVersion": {
-          "enum": ["0.3.0", "0.2.0"]
+          "enum": ["0.4.0", "0.3.0", "0.2.0"]
         }
       },
       "allOf": [
@@ -303,7 +303,20 @@
             }
           },
           "then": {
-            "$ref": "http://asyncapi.com/bindings/solace/0.3.0/operation.json"
+            "$ref": "http://asyncapi.com/bindings/solace/0.4.0/operation.json"
+          }
+        },
+        {
+          "if": {
+            "required": [ "bindingVersion" ],
+            "properties": {
+              "bindingVersion": {
+                "const": "0.4.0"
+              }
+            }
+          }, 
+          "then": {
+            "$ref": "http://asyncapi.com/bindings/solace/0.4.0/operation.json"
           }
         },
         {

--- a/definitions/3.0.0/serverBindingsObject.json
+++ b/definitions/3.0.0/serverBindingsObject.json
@@ -174,7 +174,7 @@
     "solace": {
       "properties": {
         "bindingVersion": {
-          "enum": ["0.3.0", "0.2.0"]
+          "enum": ["0.4.0", "0.3.0", "0.2.0"]
         }
       },
       "allOf": [
@@ -188,7 +188,20 @@
             }
           },
           "then": {
-            "$ref": "http://asyncapi.com/bindings/solace/0.3.0/server.json"
+            "$ref": "http://asyncapi.com/bindings/solace/0.4.0/server.json"
+          }
+        },
+        {
+          "if": {
+            "required": [ "bindingVersion" ],
+            "properties": {
+              "bindingVersion": {
+                "const": "0.4.0"
+              }
+            }
+          }, 
+          "then": {
+            "$ref": "http://asyncapi.com/bindings/solace/0.4.0/server.json"
           }
         },
         {


### PR DESCRIPTION
**Description**

- fix up solace bindings having a invalid schema
- feat: add per operation fields from: https://github.com/asyncapi/bindings/pull/237


**fix up solace bindings having a invalid schema**
To reproduce the bug, use this schema:
```yaml
components:
  schemas:
    Person:
      type: string        
  messages:
    PersonEvent:
      payload:
        $ref: '#/components/schemas/Person'
      schemaFormat: application/vnd.aai.asyncapi+json;version=2.0.0
      contentType: application/json
operations:
  addPerson:
    action: send
    channel:
      $ref: '#/channels/address'
    messages:
      - $ref: '#/channels/address/messages/personEvent'
    bindings:
      solace:
        bindingVersion: 0.3.0
        destinations:
          - destinationType: queue
            queue:
              name: CreatedHREvents
              topicSubscriptions:
                - person/*/created
          - destinationType: queue
            queue:
              name: UpdatedHREvents
              topicSubscriptions:
                - person/*/updated
channels:
  person:
    address: person/{personId}/{eventType}
    parameters:
      personId:
        schema:
          type: string
      eventType:
        schema:
          type: string
    messages:
      personEvent:
        $ref: '#/components/messages/PersonEvent'
asyncapi: 3.0.0
info:
  title: HRApp
  version: 0.0.1
```

with: https://studio.asyncapi.com/

