### PR TITLE
fix: http message bindings not using latest version

### DIFF
--- a/definitions/3.0.0/messageBindingsObject.json
+++ b/definitions/3.0.0/messageBindingsObject.json
@@ -25,7 +25,7 @@
             }
           },
           "then": {
-            "$ref": "http://asyncapi.com/bindings/http/0.2.0/message.json"
+            "$ref": "http://asyncapi.com/bindings/http/0.3.0/message.json"
           }
         },
         {


### PR DESCRIPTION
**Description**
Newest version of the http message bindings is `0.3.0`