### PR TITLE
fix: kafka bindings not using latest version

### DIFF
--- a/definitions/3.0.0/operationBindingsObject.json
+++ b/definitions/3.0.0/operationBindingsObject.json
@@ -131,7 +131,7 @@
     "kafka": {
       "properties": {
         "bindingVersion": {
-          "enum": ["0.4.0", "0.3.0"]
+          "enum": ["0.5.0", "0.4.0", "0.3.0"]
         }
       },
       "allOf": [

--- a/definitions/3.0.0/serverBindingsObject.json
+++ b/definitions/3.0.0/serverBindingsObject.json
@@ -50,7 +50,7 @@
     "kafka": {
       "properties": {
         "bindingVersion": {
-          "enum": ["0.4.0", "0.3.0"]
+          "enum": ["0.5.0", "0.4.0", "0.3.0"]
         }
       },
       "allOf": [


### PR DESCRIPTION
Added missing versions to https://github.com/asyncapi/spec-json-schemas/pull/501

Added fix as per https://github.com/asyncapi/spec-json-schemas/pull/501#issuecomment-2028640789