### PR TITLE
fix: go module version now supports v6. This does not affect the NPM …

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/asyncapi/spec-json-schemas/v4
+module github.com/asyncapi/spec-json-schemas/v6
 
 go 1.17
 


### PR DESCRIPTION
**Description**

Caused by https://github.com/asyncapi/spec-json-schemas/issues/376

Go package module name was never updated, and it should be done every time a major version is released.
It is not ideal, but at this time there is no other choice. We will investigate further in https://github.com/asyncapi/spec-json-schemas/issues/376.

**Related issue(s)**
https://github.com/asyncapi/spec-json-schemas/issues/376