### PR TITLE
fix: add separate messsage example object

### DIFF
--- a/definitions/3.0.0/messageExampleObject.json
+++ b/definitions/3.0.0/messageExampleObject.json
@@ -1,0 +1,35 @@
+{
+  "type": "object",
+  "additionalProperties": false,
+  "anyOf": [
+    {
+      "required": [
+        "payload"
+      ]
+    },
+    {
+      "required": [
+        "headers"
+      ]
+    }
+  ],
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Machine readable name of the message example."
+    },
+    "summary": {
+      "type": "string",
+      "description": "A brief summary of the message example."
+    },
+    "headers": {
+      "type": "object",
+      "description": "Example of the application headers. It can be of any type."
+    },
+    "payload": {
+      "description": "Example of the message payload. It can be of any type."
+    }
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/definitions/3.0.0/messageExampleObject.json"
+}

--- a/definitions/3.0.0/messageObject.json
+++ b/definitions/3.0.0/messageObject.json
@@ -76,37 +76,7 @@
       "type": "array",
       "description": "List of examples.",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "anyOf": [
-          {
-            "required": [
-              "payload"
-            ]
-          },
-          {
-            "required": [
-              "headers"
-            ]
-          }
-        ],
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "Machine readable name of the message example."
-          },
-          "summary": {
-            "type": "string",
-            "description": "A brief summary of the message example."
-          },
-          "headers": {
-            "type": "object",
-            "description": "Example of the application headers. It can be of any type."
-          },
-          "payload": {
-            "description": "Example of the message payload. It can be of any type."
-          }
-        }
+        "$ref": "http://asyncapi.com/definitions/3.0.0/messageExampleObject.json"
       }
     },
     "bindings": {

--- a/definitions/3.0.0/messageTrait.json
+++ b/definitions/3.0.0/messageTrait.json
@@ -73,7 +73,7 @@
       "type": "array",
       "description": "List of examples.",
       "items": {
-        "type": "object"
+        "$ref": "http://asyncapi.com/definitions/3.0.0/messageExampleObject.json"
       }
     },
     "bindings": {

--- a/schemas/3.0.0-without-$id.json
+++ b/schemas/3.0.0-without-$id.json
@@ -2572,37 +2572,7 @@
                     "type": "array",
                     "description": "List of examples.",
                     "items": {
-                        "type": "object",
-                        "additionalProperties": false,
-                        "anyOf": [
-                            {
-                                "required": [
-                                    "payload"
-                                ]
-                            },
-                            {
-                                "required": [
-                                    "headers"
-                                ]
-                            }
-                        ],
-                        "properties": {
-                            "name": {
-                                "type": "string",
-                                "description": "Machine readable name of the message example."
-                            },
-                            "summary": {
-                                "type": "string",
-                                "description": "A brief summary of the message example."
-                            },
-                            "headers": {
-                                "type": "object",
-                                "description": "Example of the application headers. It can be of any type."
-                            },
-                            "payload": {
-                                "description": "Example of the message payload. It can be of any type."
-                            }
-                        }
+                        "$ref": "#/definitions/messageExampleObject"
                     }
                 },
                 "bindings": {
@@ -3563,6 +3533,39 @@
                     "location": "$message.header#/correlationId"
                 }
             ]
+        },
+        "messageExampleObject": {
+            "type": "object",
+            "additionalProperties": false,
+            "anyOf": [
+                {
+                    "required": [
+                        "payload"
+                    ]
+                },
+                {
+                    "required": [
+                        "headers"
+                    ]
+                }
+            ],
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Machine readable name of the message example."
+                },
+                "summary": {
+                    "type": "string",
+                    "description": "A brief summary of the message example."
+                },
+                "headers": {
+                    "type": "object",
+                    "description": "Example of the application headers. It can be of any type."
+                },
+                "payload": {
+                    "description": "Example of the message payload. It can be of any type."
+                }
+            }
         },
         "messageBindingsObject": {
             "type": "object",
@@ -4678,7 +4681,7 @@
                     "type": "array",
                     "description": "List of examples.",
                     "items": {
-                        "type": "object"
+                        "$ref": "#/definitions/messageExampleObject"
                     }
                 },
                 "bindings": {

--- a/schemas/3.0.0.json
+++ b/schemas/3.0.0.json
@@ -2624,37 +2624,7 @@
                     "type": "array",
                     "description": "List of examples.",
                     "items": {
-                        "type": "object",
-                        "additionalProperties": false,
-                        "anyOf": [
-                            {
-                                "required": [
-                                    "payload"
-                                ]
-                            },
-                            {
-                                "required": [
-                                    "headers"
-                                ]
-                            }
-                        ],
-                        "properties": {
-                            "name": {
-                                "type": "string",
-                                "description": "Machine readable name of the message example."
-                            },
-                            "summary": {
-                                "type": "string",
-                                "description": "A brief summary of the message example."
-                            },
-                            "headers": {
-                                "type": "object",
-                                "description": "Example of the application headers. It can be of any type."
-                            },
-                            "payload": {
-                                "description": "Example of the message payload. It can be of any type."
-                            }
-                        }
+                        "$ref": "http://asyncapi.com/definitions/3.0.0/messageExampleObject.json"
                     }
                 },
                 "bindings": {
@@ -3620,6 +3590,40 @@
                     "location": "$message.header#/correlationId"
                 }
             ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/messageExampleObject.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/messageExampleObject.json",
+            "type": "object",
+            "additionalProperties": false,
+            "anyOf": [
+                {
+                    "required": [
+                        "payload"
+                    ]
+                },
+                {
+                    "required": [
+                        "headers"
+                    ]
+                }
+            ],
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Machine readable name of the message example."
+                },
+                "summary": {
+                    "type": "string",
+                    "description": "A brief summary of the message example."
+                },
+                "headers": {
+                    "type": "object",
+                    "description": "Example of the application headers. It can be of any type."
+                },
+                "payload": {
+                    "description": "Example of the message payload. It can be of any type."
+                }
+            }
         },
         "http://asyncapi.com/definitions/3.0.0/messageBindingsObject.json": {
             "$id": "http://asyncapi.com/definitions/3.0.0/messageBindingsObject.json",
@@ -4748,7 +4752,7 @@
                     "type": "array",
                     "description": "List of examples.",
                     "items": {
-                        "type": "object"
+                        "$ref": "http://asyncapi.com/definitions/3.0.0/messageExampleObject.json"
                     }
                 },
                 "bindings": {


### PR DESCRIPTION
**Description**
This PR fixes that message trait examples are not validated correctly.

**Related issue(s)**
Fixes https://github.com/asyncapi/spec-json-schemas/issues/441