### PR TITLE
fix: fix type of payload in MessageExample

### DIFF
--- a/definitions/3.0.0/messageExampleObject.json
+++ b/definitions/3.0.0/messageExampleObject.json
@@ -24,7 +24,7 @@
     },
     "headers": {
       "type": "object",
-      "description": "Example of the application headers. MUST be a map of key-value pairs."
+      "description": "Example of the application headers. It MUST be a map of key-value pairs."
     },
     "payload": {
       "type": ["number", "string", "boolean", "object", "array", "null"],

--- a/definitions/3.0.0/messageExampleObject.json
+++ b/definitions/3.0.0/messageExampleObject.json
@@ -24,7 +24,7 @@
     },
     "headers": {
       "type": "object",
-      "description": "Example of the application headers. It can be of any type."
+      "description": "Example of the application headers. MUST be a map of key-value pairs."
     },
     "payload": {
       "type": ["number", "string", "boolean", "object", "array", "null"],

--- a/definitions/3.0.0/messageExampleObject.json
+++ b/definitions/3.0.0/messageExampleObject.json
@@ -23,7 +23,7 @@
       "description": "A brief summary of the message example."
     },
     "headers": {
-      "type": ["number", "string", "boolean", "object", "array", "null"],
+      "type": "object",
       "description": "Example of the application headers. It can be of any type."
     },
     "payload": {

--- a/definitions/3.0.0/messageExampleObject.json
+++ b/definitions/3.0.0/messageExampleObject.json
@@ -23,10 +23,11 @@
       "description": "A brief summary of the message example."
     },
     "headers": {
-      "type": "object",
+      "type": ["number", "string", "boolean", "object", "array", "null"],
       "description": "Example of the application headers. It can be of any type."
     },
     "payload": {
+      "type": ["number", "string", "boolean", "object", "array", "null"],
       "description": "Example of the message payload. It can be of any type."
     }
   },


### PR DESCRIPTION
Define `payload` as `any` type

Fixes #560 