### PR TITLE
fix: maximum value for SQS `deliveryDelay` is 15 minutes, not 15 seconds

### DIFF
--- a/bindings/sqs/0.2.0/channel.json
+++ b/bindings/sqs/0.2.0/channel.json
@@ -67,7 +67,7 @@
           "type": "integer",
           "description": "The number of seconds to delay before a message sent to the queue can be received. used to create a delay queue.",
           "minimum": 0,
-          "maximum": 15,
+          "maximum": 900,
           "default": 0
         },
         "visibilityTimeout": {

--- a/bindings/sqs/0.2.0/operation.json
+++ b/bindings/sqs/0.2.0/operation.json
@@ -70,7 +70,7 @@
           "type": "integer",
           "description": "The number of seconds to delay before a message sent to the queue can be received. Used to create a delay queue.",
           "minimum": 0,
-          "maximum": 15,
+          "maximum": 900,
           "default": 0
         },
         "visibilityTimeout": {

--- a/bindings/sqs/0.3.0/channel.json
+++ b/bindings/sqs/0.3.0/channel.json
@@ -68,7 +68,7 @@
           "type": "integer",
           "description": "The number of seconds to delay before a message sent to the queue can be received. used to create a delay queue.",
           "minimum": 0,
-          "maximum": 15,
+          "maximum": 900,
           "default": 0
         },
         "visibilityTimeout": {

--- a/bindings/sqs/0.3.0/operation.json
+++ b/bindings/sqs/0.3.0/operation.json
@@ -77,7 +77,7 @@
           "type": "integer",
           "description": "The number of seconds to delay before a message sent to the queue can be received. Used to create a delay queue.",
           "minimum": 0,
-          "maximum": 15,
+          "maximum": 900,
           "default": 0
         },
         "visibilityTimeout": {


### PR DESCRIPTION
**Description**

According to [AWS documentation](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-delay-queues.html) the maximum amount of delay is 15 minutes and the property is set in seconds, therefore the maximum in the binding needs to be updated accordingly.

